### PR TITLE
fix(ctl): cfg-gate Unix-socket IPC for Windows build

### DIFF
--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -11,7 +11,9 @@ use openab_core::adapter::{ChannelRef, ChatAdapter};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
+#[cfg(unix)]
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 use tracing::{debug, error, info, warn};
 
@@ -68,6 +70,7 @@ pub fn spawn_server(
 }
 
 /// Start the control socket server at a specific path.
+#[cfg(unix)]
 pub fn spawn_server_at(
     path: PathBuf,
     handler: std::sync::Arc<dyn CtlHandler>,
@@ -108,6 +111,20 @@ pub fn spawn_server_at(
     })
 }
 
+/// Control socket IPC is Unix-only. On other platforms (e.g. Windows) the
+/// `openab set`/`get` commands and the in-process control server are not
+/// available; this returns a no-op task so the run path compiles unchanged.
+#[cfg(not(unix))]
+pub fn spawn_server_at(
+    path: PathBuf,
+    handler: std::sync::Arc<dyn CtlHandler>,
+) -> tokio::task::JoinHandle<()> {
+    let _ = (path, handler);
+    warn!("control socket (openab set/get) is only supported on Unix; skipping");
+    tokio::spawn(async {})
+}
+
+#[cfg(unix)]
 async fn handle_conn(
     stream: UnixStream,
     handler: &dyn CtlHandler,
@@ -312,6 +329,7 @@ pub async fn send_request(req: &Request) -> anyhow::Result<Response> {
 }
 
 /// Send a request to a specific socket path.
+#[cfg(unix)]
 pub async fn send_request_to(path: &PathBuf, req: &Request) -> anyhow::Result<Response> {
     let stream = UnixStream::connect(&path).await.map_err(|e| {
         anyhow::anyhow!(
@@ -335,6 +353,12 @@ pub async fn send_request_to(path: &PathBuf, req: &Request) -> anyhow::Result<Re
     Ok(resp)
 }
 
+/// Non-Unix platforms have no control socket; `openab set`/`get` are unavailable.
+#[cfg(not(unix))]
+pub async fn send_request_to(_path: &PathBuf, _req: &Request) -> anyhow::Result<Response> {
+    anyhow::bail!("`openab set`/`get` IPC is only supported on Unix platforms")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,6 +379,7 @@ mod tests {
         assert_eq!(parsed.thread_id.as_deref(), Some("123"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn server_client_roundtrip() {
         struct MockHandler;


### PR DESCRIPTION
## Summary

Fixes the long-standing **Build Binaries** failure on the windows-msvc targets (present since at least v0.9.0-beta.2). `src/ctl.rs` imported and used `tokio::net::UnixListener`/`UnixStream` unconditionally, so the `openab` binary failed to compile on Windows:

```
error[E0432]: unresolved imports `tokio::net::UnixListener`, `tokio::net::UnixStream`
error: could not compile `openab` (bin "openab") due to 1 previous error
```

## Fix

Per the cross-platform rule in AGENTS.md, gate the Unix-only code with `#[cfg(unix)]` and provide `#[cfg(not(unix))]` stubs so `main.rs`'s run/set/get paths compile unchanged:

- Unix-socket imports (`UnixListener`/`UnixStream`, tokio io traits) → `#[cfg(unix)]`
- `spawn_server_at` → unix impl + non-unix no-op task (logs a warning)
- `send_request_to` → unix impl + non-unix error (`openab set/get` is Unix-only)
- `handle_conn` → `#[cfg(unix)]`
- unix-socket roundtrip test → `#[cfg(unix)]`; the serialization test stays portable

The control socket (`openab set/get`) was already Unix-only in practice; this just makes the Windows build skip it cleanly instead of failing to compile.

## Verification

- `cargo check` on host (unix): clean
- Windows MSVC build verified by dispatching the Build Binaries workflow against this branch (build-only; the release-upload step is gated to `push` events)

The Linux CI (`ci.yml`, runs `clippy -- -D warnings`) stays clean because the gates are no-ops on unix.