### PR TITLE
build: exclude standalone root crates from the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
 members = ["crates/openab-core", "crates/openab-gateway"]
+# Standalone crates at the repo root are NOT part of this workspace — each has
+# its own Cargo.lock and dedicated CI. Excluding them prevents cargo from
+# erroring ("current package believes it's in a workspace when it's not") when
+# tooling (e.g. `cargo fmt --check`) runs from inside their directories.
+exclude = ["agy-acp", "openab-agent", "openab-auth-proxy", "operator"]
 
 [package]
 name = "openab"


### PR DESCRIPTION
## Summary

Fixes the long-standing **CI openab-agent** failure (present since at least v0.9.0-beta.2). On the release-tag checkout, the job's first step `cargo fmt --check` (run from `openab-agent/`) dies in ~18s with:

```
`cargo metadata` exited with an error: error: current package believes it's in a workspace when it's not:
current:   .../openab-agent/Cargo.toml
workspace: .../Cargo.toml
```

The repo root has four standalone crates — `openab-agent`, `agy-acp`, `openab-auth-proxy`, `operator` — that are neither workspace `members` nor `exclude`d. cargo therefore refuses to operate inside them. (Regular PRs happened to pass, but the release-tag checkout reliably hits it.)

## Fix

Add the standalone root crates to `[workspace].exclude`. Each has its own `Cargo.lock` and dedicated CI, so they are intentionally not part of the root workspace. This is the cargo-recommended resolution and prevents the same latent failure for the sibling crates too.

## Verification

Reproduced before/after locally (replicating the CI step):

```
# BEFORE (no exclude): cd openab-agent && cargo fmt --check
`cargo metadata` exited with an error: current package believes it's in a workspace when it's not  → exit 1
# AFTER (with exclude):
cargo fmt --check  → exit 0
```

Root workspace still resolves: `cargo metadata --no-deps` OK. The crate itself is healthy (clippy/test pass on normal PRs).