### PR TITLE
feat(acp): kiro-cli v3 token refresh + auth callback wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1646,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1651,6 +1666,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2220,6 +2244,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2587,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rmcp",
  "rpassword",
+ "rusqlite",
  "rustls 0.22.4",
  "serde",
  "serde_json",
@@ -2833,6 +2869,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -3351,6 +3393,20 @@ checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4558,6 +4614,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/openab-core/Cargo.toml
+++ b/crates/openab-core/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 rpassword = "7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "multipart", "json", "blocking", "stream"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 bytes = "1"
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }

--- a/crates/openab-core/src/acp/connection.rs
+++ b/crates/openab-core/src/acp/connection.rs
@@ -92,6 +92,38 @@ pub enum ContentBlock {
     Image { media_type: String, data: String },
 }
 
+/// Merge consecutive Text blocks into a single Text block (joined with `\n\n`).
+/// Non-text blocks act as boundaries — text before and after an image remain separate.
+/// This is required because kiro v3 forwards the prompt array directly to Bedrock,
+/// which rejects multiple text content blocks in a single message.
+fn merge_text_blocks(blocks: &[ContentBlock]) -> Vec<ContentBlock> {
+    let mut merged: Vec<ContentBlock> = Vec::with_capacity(blocks.len());
+    let mut text_buf = String::new();
+
+    for block in blocks {
+        match block {
+            ContentBlock::Text { text } => {
+                if !text_buf.is_empty() {
+                    text_buf.push_str("\n\n");
+                }
+                text_buf.push_str(text);
+            }
+            other => {
+                if !text_buf.is_empty() {
+                    merged.push(ContentBlock::Text {
+                        text: std::mem::take(&mut text_buf),
+                    });
+                }
+                merged.push(other.clone());
+            }
+        }
+    }
+    if !text_buf.is_empty() {
+        merged.push(ContentBlock::Text { text: text_buf });
+    }
+    merged
+}
+
 impl ContentBlock {
     pub fn to_json(&self) -> Value {
         match self {
@@ -258,6 +290,46 @@ pub(crate) async fn run_reader_loop<R, W>(
         debug!(line = line.trim(), "acp_recv");
 
         // Auto-reply session/request_permission
+
+        // Auto-reply _kiro/auth/getAccessToken (v3 engine auth callback)
+        if msg.method.as_deref() == Some("_kiro/auth/getAccessToken") {
+            if let Some(id) = msg.id {
+                let result =
+                    match tokio::task::spawn_blocking(crate::acp::kiro_auth::build_auth_response)
+                        .await
+                    {
+                        Ok(Some(v)) => {
+                            info!("_kiro/auth/getAccessToken: providing token");
+                            v
+                        }
+                        Ok(None) => {
+                            tracing::warn!("_kiro/auth/getAccessToken: no token available");
+                            serde_json::json!({})
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "_kiro/auth/getAccessToken: failed to build response: {e}"
+                            );
+                            serde_json::json!({})
+                        }
+                    };
+                let reply = JsonRpcResponse::new(id, result);
+                if let Ok(data) = serde_json::to_string(&reply) {
+                    let mut w = writer.lock().await;
+                    let _ = w.write_all(format!("{data}\n").as_bytes()).await;
+                    let _ = w.flush().await;
+                }
+            }
+            continue;
+        }
+
+        // Detect auth errors in prompt responses and kill connection to force re-auth
+        if let Some(ref err) = msg.error {
+            if err.message.contains("Access denied") || err.message.contains("bearer token") {
+                tracing::warn!("auth error detected — connection will be dropped for re-auth");
+                break;
+            }
+        }
         if msg.method.as_deref() == Some("session/request_permission") {
             if let Some(id) = msg.id {
                 let title = msg
@@ -575,6 +647,19 @@ impl AcpConnection {
             load_session = self.supports_load_session,
             "initialized"
         );
+
+        // ACP protocol: notify agent that initialization is complete.
+        // Required by kiro-cli v3 engine before it accepts session requests.
+        let notif = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        });
+        self.send_raw(&serde_json::to_string(&notif)?).await?;
+        tracing::debug!("notifications/initialized sent");
+
+        // Small delay to allow v3 agent to process the notification
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
         Ok(())
     }
 
@@ -725,8 +810,11 @@ impl AcpConnection {
 
         let id = self.next_id();
 
-        // Convert content blocks to JSON
-        let prompt_json: Vec<Value> = content_blocks.iter().map(|b| b.to_json()).collect();
+        // Convert content blocks to JSON.
+        // Merge consecutive text blocks into one to satisfy v3 engine's stricter
+        // Bedrock validation (rejects multiple text blocks in prompt array).
+        let merged = merge_text_blocks(&content_blocks);
+        let prompt_json: Vec<Value> = merged.iter().map(|b| b.to_json()).collect();
 
         let req = JsonRpcRequest::new(
             id,

--- a/crates/openab-core/src/acp/connection.rs
+++ b/crates/openab-core/src/acp/connection.rs
@@ -257,6 +257,21 @@ fn build_agent_env(
     (result, inherited)
 }
 
+/// True only for errors that unambiguously indicate the agent's auth token is
+/// invalid or expired — cases where dropping the connection to force a fresh
+/// `_kiro/auth/getAccessToken` (with a refreshed token) is the correct
+/// recovery. Deliberately narrow: generic "Access denied" / "not authorized"
+/// messages are surfaced normally to the user instead of silently churning
+/// reconnects on unrelated permission/tool errors.
+fn is_auth_token_failure(err: &crate::acp::protocol::JsonRpcError) -> bool {
+    let m = err.message.to_ascii_lowercase();
+    m.contains("bearer token")
+        || m.contains("expired token")
+        || m.contains("token is expired")
+        || m.contains("security token included in the request is expired")
+        || m.contains("invalididentitytoken")
+}
+
 /// Reader loop body: reads JSON-RPC messages from `reader`, auto-replies
 /// `session/request_permission` via `writer`, resolves pending responses,
 /// and forwards notifications + stale id-bearing messages to the active
@@ -291,29 +306,37 @@ pub(crate) async fn run_reader_loop<R, W>(
 
         // Auto-reply session/request_permission
 
-        // Auto-reply _kiro/auth/getAccessToken (v3 engine auth callback)
+        // Auto-reply _kiro/auth/getAccessToken (v3 engine auth callback).
+        // On success reply with the refreshed token; on failure send a proper
+        // JSON-RPC *error* (never an empty success) so the engine knows auth
+        // is unavailable instead of retrying against a blank token that would
+        // 403 and trigger a reconnect storm.
         if msg.method.as_deref() == Some("_kiro/auth/getAccessToken") {
             if let Some(id) = msg.id {
-                let result =
-                    match tokio::task::spawn_blocking(crate::acp::kiro_auth::build_auth_response)
-                        .await
-                    {
-                        Ok(Some(v)) => {
-                            info!("_kiro/auth/getAccessToken: providing token");
-                            v
-                        }
-                        Ok(None) => {
-                            tracing::warn!("_kiro/auth/getAccessToken: no token available");
-                            serde_json::json!({})
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "_kiro/auth/getAccessToken: failed to build response: {e}"
-                            );
-                            serde_json::json!({})
-                        }
-                    };
-                let reply = JsonRpcResponse::new(id, result);
+                let reply = match tokio::task::spawn_blocking(
+                    crate::acp::kiro_auth::build_auth_response,
+                )
+                .await
+                {
+                    Ok(Some(result)) => {
+                        info!("_kiro/auth/getAccessToken: providing token");
+                        serde_json::json!({"jsonrpc":"2.0","id":id,"result":result})
+                    }
+                    Ok(None) => {
+                        tracing::warn!("_kiro/auth/getAccessToken: no token available");
+                        serde_json::json!({
+                            "jsonrpc":"2.0","id":id,
+                            "error":{"code":-32001,"message":"kiro auth unavailable: no valid token (run `kiro-cli login`)"}
+                        })
+                    }
+                    Err(e) => {
+                        tracing::error!("_kiro/auth/getAccessToken: failed to build response: {e}");
+                        serde_json::json!({
+                            "jsonrpc":"2.0","id":id,
+                            "error":{"code":-32603,"message":format!("kiro auth task failed: {e}")}
+                        })
+                    }
+                };
                 if let Ok(data) = serde_json::to_string(&reply) {
                     let mut w = writer.lock().await;
                     let _ = w.write_all(format!("{data}\n").as_bytes()).await;
@@ -323,10 +346,14 @@ pub(crate) async fn run_reader_loop<R, W>(
             continue;
         }
 
-        // Detect auth errors in prompt responses and kill connection to force re-auth
-        if let Some(ref err) = msg.error {
-            if err.message.contains("Access denied") || err.message.contains("bearer token") {
-                tracing::warn!("auth error detected — connection will be dropped for re-auth");
+        // Detect *token-level* auth failures in responses and drop the
+        // connection so the pool recreates it and the next prompt triggers a
+        // fresh `_kiro/auth/getAccessToken` with a refreshed token. Narrow by
+        // design (see `is_auth_token_failure`): generic "Access denied" errors
+        // surface to the user normally rather than silently churning reconnects.
+        if let Some(err) = &msg.error {
+            if is_auth_token_failure(err) {
+                tracing::warn!("auth-token failure detected — dropping connection for re-auth");
                 break;
             }
         }
@@ -1200,5 +1227,29 @@ mod reader_loop_tests {
         assert!(activity.in_flight());
         activity.set_in_flight(false);
         assert!(!activity.in_flight());
+    }
+    /// H2 regression guard: only unambiguous token-invalidity errors trigger a
+    /// reconnect; generic "Access denied" must NOT (it would cause spurious
+    /// disconnects on normal permission/tool errors).
+    #[test]
+    fn auth_token_failure_matcher_is_narrow() {
+        use crate::acp::protocol::JsonRpcError;
+        let hit = |msg: &str| {
+            is_auth_token_failure(&JsonRpcError {
+                code: -1,
+                message: msg.to_string(),
+                data: None,
+            })
+        };
+        // Genuine token failures → reconnect.
+        assert!(hit("Invalid bearer token"));
+        assert!(hit("The security token included in the request is expired"));
+        assert!(hit("InvalidIdentityToken: ..."));
+        assert!(hit("the token is expired"));
+        // Ambiguous / app-level errors → must NOT reconnect.
+        assert!(!hit("Access denied"));
+        assert!(!hit("Access denied to /etc/shadow"));
+        assert!(!hit("User is not authorized to perform this tool"));
+        assert!(!hit("permission denied"));
     }
 }

--- a/crates/openab-core/src/acp/kiro_auth.rs
+++ b/crates/openab-core/src/acp/kiro_auth.rs
@@ -1,0 +1,277 @@
+//! Kiro CLI token reader with auto-refresh via AWS SSO OIDC.
+//!
+//! Reads the cached access token from kiro-cli's sqlite database.
+//! If expired, uses the refresh_token + device registration to obtain
+//! a fresh token from AWS SSO OIDC and persists it back.
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, info};
+
+const DB_RELATIVE_PATH: &str = ".local/share/kiro-cli/data.sqlite3";
+const TOKEN_KEY: &str = "kirocli:odic:token";
+const REGISTRATION_KEY: &str = "kirocli:odic:device-registration";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TokenData {
+    access_token: String,
+    expires_at: String,
+    refresh_token: String,
+    #[serde(default)]
+    region: String,
+    #[serde(default)]
+    start_url: String,
+    #[serde(default)]
+    oauth_flow: String,
+    #[serde(default)]
+    scopes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Registration {
+    client_id: String,
+    client_secret: String,
+    #[serde(default)]
+    region: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default = "default_expires_in")]
+    expires_in: u64,
+}
+
+fn default_expires_in() -> u64 {
+    3600
+}
+
+fn db_path() -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    Some(format!("{}/{}", home, DB_RELATIVE_PATH))
+}
+
+fn parse_rfc3339(expires_at: &str) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+    // Prefer full RFC 3339 (including fractional seconds); fall back to
+    // truncating sub-second precision if the original cannot be parsed.
+    chrono::DateTime::parse_from_rfc3339(expires_at)
+        .ok()
+        .or_else(|| {
+            let clean = if let Some(dot_pos) = expires_at.find('.') {
+                format!("{}Z", &expires_at[..dot_pos])
+            } else {
+                expires_at.to_string()
+            };
+            chrono::DateTime::parse_from_rfc3339(&clean).ok()
+        })
+}
+
+fn is_expired(expires_at: &str) -> bool {
+    match parse_rfc3339(expires_at) {
+        Some(exp) => chrono::Utc::now() >= exp,
+        None => true, // If we can't parse, assume expired
+    }
+}
+
+fn expires_at_ms(expires_at: &str) -> Option<u64> {
+    parse_rfc3339(expires_at).map(|dt| dt.timestamp_millis() as u64)
+}
+
+fn read_token_data(conn: &rusqlite::Connection) -> Option<TokenData> {
+    let value: String = conn
+        .query_row(
+            "SELECT value FROM auth_kv WHERE key = ?1",
+            [TOKEN_KEY],
+            |row| row.get(0),
+        )
+        .ok()?;
+    serde_json::from_str(&value).ok()
+}
+
+fn read_registration(conn: &rusqlite::Connection) -> Option<Registration> {
+    let value: String = conn
+        .query_row(
+            "SELECT value FROM auth_kv WHERE key = ?1",
+            [REGISTRATION_KEY],
+            |row| row.get(0),
+        )
+        .ok()?;
+    serde_json::from_str(&value).ok()
+}
+
+fn refresh_token(token_data: &TokenData, reg: &Registration) -> Option<TokenData> {
+    let region = if reg.region.is_empty() {
+        "us-east-1"
+    } else {
+        &reg.region
+    };
+    let url = format!("https://oidc.{}.amazonaws.com/token", region);
+
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(&url)
+        .json(&serde_json::json!({
+            "grant_type": "refresh_token",
+            "client_id": reg.client_id,
+            "client_secret": reg.client_secret,
+            "refresh_token": token_data.refresh_token,
+        }))
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .ok()?;
+
+    if !resp.status().is_success() {
+        error!(status = %resp.status(), "SSO OIDC token refresh failed");
+        return None;
+    }
+
+    let refresh_resp: RefreshResponse = resp.json().ok()?;
+    let now = chrono::Utc::now();
+    let new_expires = now + chrono::Duration::seconds(refresh_resp.expires_in as i64);
+
+    Some(TokenData {
+        access_token: refresh_resp.access_token,
+        refresh_token: refresh_resp
+            .refresh_token
+            .unwrap_or_else(|| token_data.refresh_token.clone()),
+        expires_at: new_expires.to_rfc3339(),
+        region: token_data.region.clone(),
+        start_url: token_data.start_url.clone(),
+        oauth_flow: token_data.oauth_flow.clone(),
+        scopes: token_data.scopes.clone(),
+    })
+}
+
+fn save_token_data(conn: &rusqlite::Connection, token_data: &TokenData) {
+    if let Ok(json) = serde_json::to_string(token_data) {
+        let _ = conn.execute(
+            "UPDATE auth_kv SET value = ?1 WHERE key = ?2",
+            rusqlite::params![json, TOKEN_KEY],
+        );
+    }
+}
+
+/// Result of a successful token fetch, including profile ARN.
+#[derive(Debug, Clone)]
+pub struct KiroAuthResult {
+    pub access_token: String,
+    pub profile_arn: Option<String>,
+    pub expires_at: String,
+}
+
+/// Build the JSON-RPC result for `_kiro/auth/getAccessToken`.
+///
+/// Returns `None` if no valid token can be obtained.
+pub fn build_auth_response() -> Option<serde_json::Value> {
+    let auth = get_access_token()?;
+    let expires_at = expires_at_ms(&auth.expires_at).unwrap_or_else(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+            + 1_800_000
+    });
+    Some(serde_json::json!({
+        "accessToken": auth.access_token,
+        "expiresAt": expires_at,
+        "profileArn": auth.profile_arn,
+    }))
+}
+
+fn read_profile_arn(conn: &rusqlite::Connection) -> Option<String> {
+    let raw: String = conn
+        .query_row(
+            "SELECT value FROM state WHERE key = ?1",
+            ["api.codewhisperer.profile"],
+            |row| row.get::<_, String>(0),
+        )
+        .ok()?;
+    // Value may be a JSON string, a JSON object {"arn":"...", ...}, or a plain ARN.
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&raw) {
+        match value {
+            serde_json::Value::String(s) => return Some(s),
+            serde_json::Value::Object(obj) => {
+                if let Some(arn) = obj.get("arn").and_then(|v| v.as_str()) {
+                    return Some(arn.to_owned());
+                }
+            }
+            _ => {}
+        }
+    }
+    Some(raw)
+}
+
+/// Get a valid access token (and profile ARN), refreshing if necessary.
+///
+/// This function performs blocking I/O (sqlite + HTTP).
+/// Call from `tokio::task::spawn_blocking` in async contexts.
+pub fn get_access_token() -> Option<KiroAuthResult> {
+    let path = db_path()?;
+    let conn = rusqlite::Connection::open_with_flags(
+        &path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()?;
+
+    let mut token_data = read_token_data(&conn)?;
+
+    if is_expired(&token_data.expires_at) {
+        info!("kiro token expired, refreshing...");
+        let reg = read_registration(&conn);
+
+        let refreshed = reg.and_then(|r| refresh_token(&token_data, &r));
+
+        match refreshed {
+            Some(new_data) => {
+                token_data = new_data;
+                save_token_data(&conn, &token_data);
+                info!("kiro token refreshed via OIDC");
+            }
+            None => {
+                // OIDC refresh failed (token rotated or expired).
+                // Fallback: invoke kiro-cli whoami to trigger its internal refresh.
+                info!("OIDC refresh failed, falling back to kiro-cli whoami");
+                let profile_arn = read_profile_arn(&conn);
+                drop(conn);
+                let _ = std::process::Command::new("kiro-cli")
+                    .arg("whoami")
+                    .env(
+                        "PATH",
+                        format!(
+                            "{}/.local/bin:/usr/local/bin:/usr/bin:/bin",
+                            std::env::var("HOME").unwrap_or_default()
+                        ),
+                    )
+                    .output();
+                // Re-read the refreshed token from sqlite
+                let conn2 = rusqlite::Connection::open_with_flags(
+                    &path,
+                    rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                        | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+                )
+                .ok()?;
+                token_data = read_token_data(&conn2)?;
+                if is_expired(&token_data.expires_at) {
+                    error!("kiro-cli whoami fallback also failed");
+                    return None;
+                }
+                info!("kiro token refreshed via kiro-cli fallback");
+                return Some(KiroAuthResult {
+                    access_token: token_data.access_token,
+                    profile_arn: read_profile_arn(&conn2).or(profile_arn),
+                    expires_at: token_data.expires_at,
+                });
+            }
+        }
+    } else {
+        debug!("kiro token still valid");
+    }
+
+    let profile_arn = read_profile_arn(&conn);
+    Some(KiroAuthResult {
+        access_token: token_data.access_token,
+        profile_arn,
+        expires_at: token_data.expires_at,
+    })
+}

--- a/crates/openab-core/src/acp/kiro_auth.rs
+++ b/crates/openab-core/src/acp/kiro_auth.rs
@@ -5,11 +5,24 @@
 //! a fresh token from AWS SSO OIDC and persists it back.
 
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{debug, error, info};
 
 const DB_RELATIVE_PATH: &str = ".local/share/kiro-cli/data.sqlite3";
 const TOKEN_KEY: &str = "kirocli:odic:token";
 const REGISTRATION_KEY: &str = "kirocli:odic:device-registration";
+/// Cooldown after a failed refresh to avoid hammering AWS SSO OIDC and
+/// spawning `kiro-cli whoami` in a tight loop when the token is genuinely
+/// dead. Reset to 0 on a successful refresh.
+static LAST_REFRESH_FAIL_MS: AtomicU64 = AtomicU64::new(0);
+const REFRESH_FAIL_COOLDOWN_MS: u64 = 30_000;
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct TokenData {
@@ -217,6 +230,16 @@ pub fn get_access_token() -> Option<KiroAuthResult> {
     let mut token_data = read_token_data(&conn)?;
 
     if is_expired(&token_data.expires_at) {
+        // If a recent refresh attempt failed, skip the expensive OIDC HTTP
+        // call and `kiro-cli whoami` subprocess for the cooldown window so a
+        // dead token can't drive a retry storm.
+        let now = now_ms();
+        if now.saturating_sub(LAST_REFRESH_FAIL_MS.load(Ordering::Relaxed))
+            < REFRESH_FAIL_COOLDOWN_MS
+        {
+            debug!("kiro token expired but refresh in cooldown — skipping");
+            return None;
+        }
         info!("kiro token expired, refreshing...");
         let reg = read_registration(&conn);
 
@@ -226,6 +249,7 @@ pub fn get_access_token() -> Option<KiroAuthResult> {
             Some(new_data) => {
                 token_data = new_data;
                 save_token_data(&conn, &token_data);
+                LAST_REFRESH_FAIL_MS.store(0, Ordering::Relaxed);
                 info!("kiro token refreshed via OIDC");
             }
             None => {
@@ -253,9 +277,11 @@ pub fn get_access_token() -> Option<KiroAuthResult> {
                 .ok()?;
                 token_data = read_token_data(&conn2)?;
                 if is_expired(&token_data.expires_at) {
+                    LAST_REFRESH_FAIL_MS.store(now, Ordering::Relaxed);
                     error!("kiro-cli whoami fallback also failed");
                     return None;
                 }
+                LAST_REFRESH_FAIL_MS.store(0, Ordering::Relaxed);
                 info!("kiro token refreshed via kiro-cli fallback");
                 return Some(KiroAuthResult {
                     access_token: token_data.access_token,

--- a/crates/openab-core/src/acp/mod.rs
+++ b/crates/openab-core/src/acp/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "agentcore")]
 pub mod agentcore;
 pub mod connection;
+pub mod kiro_auth;
 pub mod pool;
 pub mod protocol;
 

--- a/crates/openab-core/src/cron.rs
+++ b/crates/openab-core/src/cron.rs
@@ -1250,7 +1250,7 @@ message = "hello"
 "#;
         let cfg: UsercronFile = toml::from_str(toml_str).unwrap();
         let job = &cfg.jobs[0];
-        assert_eq!(job.enabled, true);
+        assert!(job.enabled);
         assert_eq!(job.platform, "discord");
         assert_eq!(job.sender_name, "openab-cron");
         assert_eq!(job.timezone, "UTC");
@@ -1272,7 +1272,7 @@ channel = "123"
 message = "hello"
 "#;
         let cfg: UsercronFile = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.jobs[0].enabled, false);
+        assert!(!cfg.jobs[0].enabled);
     }
 
     #[test]

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -3589,14 +3589,14 @@ mod tests {
     fn image_attachment_block_includes_url_and_metadata() {
         // Simulates the format string used in the image attachment handler.
         let filename = "screenshot.png";
-        let content_type = Some("image/png");
+        let content_type = "image/png";
         let size: u32 = 142048;
         let url = "https://cdn.discordapp.com/attachments/123/456/screenshot.png";
 
         let text = format!(
             "[Image attachment]\nfilename: {}\ncontent_type: {}\nsize_bytes: {}\nurl: {} (expires ~24h)",
             filename,
-            content_type.unwrap_or("unknown"),
+            content_type,
             size,
             url,
         );
@@ -3611,11 +3611,10 @@ mod tests {
 
     #[test]
     fn image_attachment_block_missing_content_type_falls_back() {
-        let content_type: Option<&str> = None;
         let text = format!(
             "[Image attachment]\nfilename: {}\ncontent_type: {}\nsize_bytes: {}\nurl: {} (expires ~24h)",
             "photo.jpg",
-            content_type.unwrap_or("unknown"),
+            "unknown",
             99999,
             "https://cdn.discordapp.com/attachments/1/2/photo.jpg",
         );

--- a/crates/openab-core/src/format.rs
+++ b/crates/openab-core/src/format.rs
@@ -434,7 +434,7 @@ mod tests {
     #[test]
     fn fenced_hard_split_grapheme_safe() {
         // Emoji inside a code fence: grapheme-safe, all content preserved.
-        let content: String = std::iter::repeat("🎉❤️你").take(20).collect();
+        let content: String = std::iter::repeat_n("🎉❤️你", 20).collect();
         let text = format!("```\n{content}\n```");
         let chunks = split_message(&text, 20);
         assert_length_invariant(&chunks, 20);


### PR DESCRIPTION
## kiro-cli v3 token refresh + auth callback for ACP

The kiro-cli v3 engine requires a `_kiro/auth/getAccessToken` JSON-RPC callback from the host, stricter prompt content (single text block per message), and `notifications/initialized` before it accepts session requests. Without this wiring, kiro v3 sessions fail auth against Bedrock and cannot run.

**What this does**

- New `kiro_auth` module: reads the cached access token from kiro-cli's sqlite store, refreshes it via AWS SSO OIDC (refresh_token + device registration), persists it back; falls back to spawning `kiro-cli whoami` to trigger its internal refresh.
- ACP reader loop auto-replies `_kiro/auth/getAccessToken` with the refreshed token + profile ARN from the local store (replaces the previous hardcoded ARN).
- Merges consecutive text content blocks before sending prompts (Bedrock rejects multiple text blocks) and sends `notifications/initialized` after `initialize`.
- Auth-failure reconnect trigger narrowed to unambiguous token-invalidity errors only (`is_auth_token_failure`); generic "Access denied" surfaces normally instead of silently churning reconnects.
- Missing-token callback replies with a JSON-RPC **error** (-32001), never an empty success — prevents the v3 engine from retrying against a blank token → Bedrock 403 → reconnect storm.
- 30s refresh-failure cooldown so a genuinely dead token cannot hammer AWS SSO OIDC or spawn `kiro-cli whoami` in a loop.
- Regression test pinning the narrowed matcher; plus rust-1.96 clippy lint fixes in existing test code (`cron.rs`, `format.rs`, `discord.rs`) that were blocking `cargo clippy -- -D warnings`.

## Review Contract

### Goal

Make kiro-cli v3 agents usable through OpenAB: the ACP connection must supply a valid, auto-refreshed Bedrock access token on demand and stay within the v3 engine's stricter protocol expectations (single text block per prompt, `notifications/initialized`).

### Non-goals

- Replacing kiro-cli's own credential management; OpenAB only reads/refreshes what kiro-cli already cached and defers to `kiro-cli login` for initial auth.
- Supporting non-sqlite kiro-cli configurations or non-default `KIRO_HOME` paths.
- Fixing the pre-existing `secrets::tests::resolve_exec_nonzero_exit` test failure (environment-dependent, unrelated).
- The repo-wide `cargo fmt` drift (~1500 lines across 17 files, pre-existing).

### Accepted Residual Risks

- Token refresh uses `reqwest::blocking` inside `tokio::task::spawn_blocking` — correct today; a future refactor that calls it from an async context would panic. Mitigation: doc comment on `get_access_token` states the contract.
- `parse_rfc3339` fallback assumes UTC when sub-second parsing fails; only reachable for externally-written non-RFC3339 timestamps (the save path round-trips `to_rfc3339` cleanly).
- `save_token_data` is UPDATE-only (no INSERT fallback) — fine because the row always pre-exists (we just read it).
- Concurrent `_kiro/auth/getAccessToken` callbacks could race a refresh; window is tiny (callbacks are ~1/hour) and the worst case is a duplicate refresh, not corruption.
- Recovery: if auth is genuinely broken, the callback returns -32001 with "run `kiro-cli login`" guidance; the 30s cooldown bounds retry cost.

### Acceptance Criteria

- `cargo test -p openab-core --lib acp::connection::reader_loop_tests` passes, including `auth_token_failure_matcher_is_narrow` (generic "Access denied" must NOT reconnect; token-invalidity errors MUST).
- `cargo clippy -p openab-core --lib --tests -- -D warnings` is clean.
- Chosen-picked on latest `origin/main` (280db4db) with no conflicts; reader-loop behavior verified there.
- Manually verified (2026-08-11 review): missing-token path returns a JSON-RPC error object, not an empty success.

### Follow-ups

- Unit test for the `_kiro/auth/getAccessToken` reply shapes (success / -32001 / -32603) via a `run_reader_loop` duplex test — currently covered by inspection only.
- Repo-wide `cargo fmt` normalization PR.
- Consider a stable error-code boundary (mirrors what breadiary did) if more string-matching on agent errors accumulates.
