### PR TITLE
fix(observability): bound private messaging telemetry

### DIFF
--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -1073,6 +1073,13 @@ impl AdapterRouter {
                     }
 
                     conn.prompt_done().await;
+                    let turn_duration_ms =
+                        u64::try_from(prompt_start.elapsed().as_millis()).unwrap_or(u64::MAX);
+                    emit_turn_completed(
+                        turn_duration_ms,
+                        response_error.as_deref(),
+                        &turn_result,
+                    );
                     // Stop the cosmetic edit loop before the finalize write path
                     // issues its authoritative edit. Dropping buf_tx closes the watch
                     // channel so the loop breaks on its next check, but it may be
@@ -1118,13 +1125,23 @@ impl AdapterRouter {
                         display_for(platform_is_acp, &tool_lines, &text_buf, false, tool_display);
                     let final_content = if final_content.is_empty() {
                         if turn_result.is_silent_failure() {
-                            warn!(
-                                stop_reason = ?turn_result.stop_reason,
-                                input_tokens = ?turn_result.input_tokens,
-                                output_tokens = ?turn_result.output_tokens,
-                                total_tokens = ?turn_result.total_tokens,
-                                "agent returned empty turn (0 output tokens) — likely provider/model/auth failure"
-                            );
+                            if crate::redact::safe_observability_enabled() {
+                                warn!(
+                                    stop_reason = bounded_stop_reason(&turn_result),
+                                    input_tokens = ?turn_result.input_tokens,
+                                    output_tokens = ?turn_result.output_tokens,
+                                    total_tokens = ?turn_result.total_tokens,
+                                    "agent returned empty turn (0 output tokens) — likely provider/model/auth failure"
+                                );
+                            } else {
+                                warn!(
+                                    stop_reason = ?turn_result.stop_reason,
+                                    input_tokens = ?turn_result.input_tokens,
+                                    output_tokens = ?turn_result.output_tokens,
+                                    total_tokens = ?turn_result.total_tokens,
+                                    "agent returned empty turn (0 output tokens) — likely provider/model/auth failure"
+                                );
+                            }
                         }
                         classify_empty_turn(response_error.as_deref(), &turn_result)
                     } else if let Some(err) = response_error {
@@ -1501,6 +1518,77 @@ pub(crate) fn classify_empty_turn(
     } else {
         "_(no response)_".to_string()
     }
+}
+
+/// Classify a terminal agent turn for the bounded operational telemetry event.
+///
+/// The classification intentionally depends only on protocol status and token
+/// counts. Message content, session ids, and platform identities never enter
+/// the telemetry event.
+pub(crate) fn classify_turn_outcome(
+    response_error: Option<&str>,
+    turn_result: &TurnResult,
+) -> &'static str {
+    if response_error.is_some() {
+        "error"
+    } else if turn_result.is_silent_failure() {
+        "silent_failure"
+    } else {
+        "completed"
+    }
+}
+
+/// Keep the protocol stop reason useful for aggregation without trusting an
+/// arbitrary agent-provided string as log-safe text.
+pub(crate) fn bounded_stop_reason(turn_result: &TurnResult) -> &'static str {
+    match turn_result.stop_reason.as_deref() {
+        Some("end_turn") => "end_turn",
+        Some("max_tokens") => "max_tokens",
+        Some("max_turn_requests") => "max_turn_requests",
+        Some("refusal") => "refusal",
+        Some("cancelled") => "cancelled",
+        Some(_) => "other",
+        None => "unknown",
+    }
+}
+
+fn emit_turn_completed(
+    duration_ms: u64,
+    response_error: Option<&str>,
+    turn_result: &TurnResult,
+) {
+    emit_turn_completed_with_mode(
+        duration_ms,
+        response_error,
+        turn_result,
+        crate::redact::safe_observability_enabled(),
+    );
+}
+
+fn emit_turn_completed_with_mode(
+    duration_ms: u64,
+    response_error: Option<&str>,
+    turn_result: &TurnResult,
+    safe_observability: bool,
+) {
+    if !safe_observability {
+        return;
+    }
+
+    let token_usage_reported = turn_result.input_tokens.is_some()
+        && turn_result.output_tokens.is_some()
+        && turn_result.total_tokens.is_some();
+    tracing::info!(
+        event_type = "agent.turn_completed",
+        outcome = classify_turn_outcome(response_error, turn_result),
+        duration_ms,
+        stop_reason = bounded_stop_reason(turn_result),
+        input_tokens = turn_result.input_tokens.unwrap_or_default(),
+        output_tokens = turn_result.output_tokens.unwrap_or_default(),
+        total_tokens = turn_result.total_tokens.unwrap_or_default(),
+        token_usage_reported,
+        "agent turn completed"
+    );
 }
 
 /// Content to stream/deliver for a reply. ACP gets the raw append-only answer `text`
@@ -2332,7 +2420,10 @@ mod tests {
 #[cfg(test)]
 mod directive_tests {
     use super::parse_output_directives;
-    use super::{classify_empty_turn, SILENT_FAILURE_MSG};
+    use super::{
+        bounded_stop_reason, classify_empty_turn, classify_turn_outcome,
+        emit_turn_completed_with_mode, SILENT_FAILURE_MSG,
+    };
     use crate::acp::TurnResult;
 
     #[test]
@@ -2553,5 +2644,106 @@ mod directive_tests {
         };
         let result = classify_empty_turn(None, &tr);
         assert_eq!(result, "_(no response)_");
+    }
+
+    #[test]
+    fn turn_outcome_reports_completed_error_and_silent_failure_without_content() {
+        let completed = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            input_tokens: Some(10),
+            output_tokens: Some(5),
+            total_tokens: Some(15),
+        };
+        assert_eq!(classify_turn_outcome(None, &completed), "completed");
+
+        assert_eq!(
+            classify_turn_outcome(Some("provider unavailable"), &completed),
+            "error"
+        );
+
+        let silent = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            input_tokens: Some(10),
+            output_tokens: Some(0),
+            total_tokens: Some(10),
+        };
+        assert_eq!(classify_turn_outcome(None, &silent), "silent_failure");
+        assert_eq!(
+            classify_turn_outcome(Some("provider unavailable"), &silent),
+            "error",
+            "explicit protocol errors take precedence over silent-failure inference"
+        );
+    }
+
+    #[test]
+    fn stop_reason_is_bounded_before_logging() {
+        for reason in [
+            "end_turn",
+            "max_tokens",
+            "max_turn_requests",
+            "refusal",
+            "cancelled",
+        ] {
+            let turn = TurnResult {
+                stop_reason: Some(reason.into()),
+                ..TurnResult::default()
+            };
+            assert_eq!(bounded_stop_reason(&turn), reason);
+        }
+
+        let untrusted = TurnResult {
+            stop_reason: Some("user content must not reach logs".into()),
+            ..TurnResult::default()
+        };
+        assert_eq!(bounded_stop_reason(&untrusted), "other");
+        assert_eq!(bounded_stop_reason(&TurnResult::default()), "unknown");
+    }
+
+    #[test]
+    fn turn_completion_json_has_numeric_token_fields() {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone)]
+        struct Capture(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for Capture {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let capture = Capture(Arc::clone(&bytes));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_writer(move || capture.clone())
+            .finish();
+        let turn = TurnResult {
+            stop_reason: Some("end_turn".into()),
+            input_tokens: Some(10),
+            output_tokens: Some(5),
+            total_tokens: Some(15),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            emit_turn_completed_with_mode(41, None, &turn, false);
+            emit_turn_completed_with_mode(42, None, &turn, true);
+        });
+
+        let output = String::from_utf8(bytes.lock().unwrap().clone()).unwrap();
+        let event: serde_json::Value = serde_json::from_str(output.trim()).unwrap();
+        let fields = &event["fields"];
+        assert_eq!(fields["event_type"], "agent.turn_completed");
+        assert_eq!(fields["input_tokens"], 10);
+        assert_eq!(fields["output_tokens"], 5);
+        assert_eq!(fields["total_tokens"], 15);
+        assert_eq!(fields["token_usage_reported"], true);
+        assert_eq!(output.lines().count(), 1, "disabled mode must emit no event");
     }
 }

--- a/crates/openab-core/src/dispatch.rs
+++ b/crates/openab-core/src/dispatch.rs
@@ -101,6 +101,7 @@ struct ThreadHandle {
     generation: u64,
     channel_id: String,
     adapter_kind: String,
+    channel_platform: String,
 }
 
 impl ThreadHandle {
@@ -370,6 +371,7 @@ impl Dispatcher {
                     generation: next_g,
                     channel_id: thread_channel.channel_id.clone(),
                     adapter_kind: adapter.platform().to_string(),
+                    channel_platform: thread_channel.platform.clone(),
                 }
             });
             (entry.tx.clone(), entry.generation)
@@ -414,6 +416,7 @@ impl Dispatcher {
                         generation: retry_g,
                         channel_id: thread_channel.channel_id.clone(),
                         adapter_kind: adapter.platform().to_string(),
+                        channel_platform: thread_channel.platform.clone(),
                     }
                 });
                 (entry.tx.clone(), entry.generation)
@@ -518,8 +521,11 @@ impl Dispatcher {
             let pending = handle.pending_count();
             if pending > 0 {
                 warn!(
-                    thread_id = %thread_id,
-                    channel   = %handle.channel_id,
+                    thread_id = %crate::redact::redact_session_ids_if_safe(thread_id),
+                    channel   = %crate::redact::redact_platform_identity_if_safe(
+                        &handle.channel_platform,
+                        &handle.channel_id,
+                    ),
                     adapter   = %handle.adapter_kind,
                     buffered_lost = pending,
                     "shutdown dropped pending messages without dispatch",
@@ -566,8 +572,11 @@ async fn consumer_loop(
                 }
                 Err(_elapsed) => {
                     debug!(
-                        thread_key = %thread_key,
-                        channel = %thread_channel.channel_id,
+                        thread_key = %crate::redact::redact_session_ids_if_safe(&thread_key),
+                        channel = %crate::redact::redact_platform_identity_if_safe(
+                            &thread_channel.platform,
+                            &thread_channel.channel_id,
+                        ),
                         "consumer idle timeout, exiting"
                     );
                     break;
@@ -642,7 +651,15 @@ async fn dispatch_batch(
         .iter()
         .map(|m| m.arrived_at.elapsed().as_millis())
         .collect();
-    let senders: Vec<String> = batch.iter().map(|m| m.sender_name.clone()).collect();
+    let sender_tags: Vec<String> = batch
+        .iter()
+        .map(|message| {
+            crate::redact::redact_platform_identity_if_safe(
+                &thread_channel.platform,
+                &message.sender_name,
+            )
+        })
+        .collect();
 
     // Native-streaming recipient is bound to the turn (captured per-message). A
     // batch attributes to the most recent sender; None for non-Slack/bot turns.
@@ -729,7 +746,11 @@ async fn dispatch_batch(
                     let _ = adapter
                         .send_message(&dispatch_channel, &format!("⚠️ {e}"))
                         .await;
-                    error!(session_key, error = %e, "workspace directive rejected");
+                    error!(
+                        session_key = %crate::redact::redact_session_ids_if_safe(&session_key),
+                        error = %e,
+                        "workspace directive rejected"
+                    );
                     return;
                 }
 
@@ -742,7 +763,11 @@ async fn dispatch_batch(
                 if let Some(ref title) = title_to_apply {
                     if !title.is_empty() {
                         if let Err(e) = adapter.rename_thread(&dispatch_channel, title).await {
-                            warn!(session_key, error = %e, "failed to apply title directive");
+                            warn!(
+                                session_key = %crate::redact::redact_session_ids_if_safe(&session_key),
+                                error = %e,
+                                "failed to apply title directive"
+                            );
                         }
                     }
                 }
@@ -810,18 +835,21 @@ async fn dispatch_batch(
     let agent_dispatch_ms = dispatch_start.elapsed().as_millis();
     let span = info_span!(
         "dispatch",
-        channel = %thread_channel.channel_id,
+        channel = %crate::redact::redact_platform_identity_if_safe(
+            &thread_channel.platform,
+            &thread_channel.channel_id,
+        ),
         adapter = adapter.platform(),
     );
     let _enter = span.enter();
     info!(
-        thread_key         = %thread_key,
+        thread_key         = %crate::redact::redact_session_ids_if_safe(thread_key),
         events_per_dispatch = batch_size,
         packed_block_count  = packed_block_count,
         agent_dispatch_ms   = agent_dispatch_ms,
         tokens_per_event    = ?tokens_per_event,
         wait_ms             = ?wait_ms,
-        senders             = ?senders,
+        senders             = ?sender_tags,
         "batch dispatched",
     );
 }
@@ -1152,6 +1180,7 @@ mod tests {
             generation,
             channel_id: "C".into(),
             adapter_kind: "discord".into(),
+            channel_platform: "discord".into(),
         }
     }
 
@@ -1241,6 +1270,7 @@ mod tests {
             generation: 0,
             channel_id: "c".into(),
             adapter_kind: "discord".into(),
+            channel_platform: "discord".into(),
         };
         d.per_thread.lock().unwrap().insert(key.to_string(), handle);
     }
@@ -1296,6 +1326,7 @@ mod tests {
             generation: 0,
             channel_id: "c".into(),
             adapter_kind: "discord".into(),
+            channel_platform: "discord".into(),
         }
     }
 
@@ -1708,6 +1739,7 @@ mod tests {
                 generation: 999,
                 channel_id: "T".into(),
                 adapter_kind: "mock".into(),
+                channel_platform: "mock".into(),
             };
             d.per_thread.lock().unwrap().insert(key.clone(), handle);
             abort

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -81,17 +81,26 @@ struct EventFilterParams<'a> {
 fn should_skip_event(event: &GatewayEvent, filter: &EventFilterParams) -> bool {
     // Bot filter
     if event.sender.is_bot && !filter.allow_bot_messages && !filter.trusted_bot_ids.contains(&event.sender.id) {
-        tracing::info!(sender = %event.sender.id, "gateway: bot not in trusted_bot_ids, skipping");
+        tracing::info!(
+            sender = %redact_channel(&event.platform, &event.sender.id),
+            "gateway: bot not in trusted_bot_ids, skipping"
+        );
         return true;
     }
     // Channel allowlist
     if !filter.allow_all_channels && !filter.allowed_channels.contains(&event.channel.id) {
-        tracing::info!(channel = %redact_channel(&event.channel.id), "gateway: channel not in allowed_channels, skipping");
+        tracing::info!(
+            channel = %redact_channel(&event.platform, &event.channel.id),
+            "gateway: channel not in allowed_channels, skipping"
+        );
         return true;
     }
     // User allowlist
     if !filter.allow_all_users && !filter.allowed_users.contains(&event.sender.id) {
-        tracing::info!(sender = %event.sender.id, "gateway: user not in allowed_users, skipping");
+        tracing::info!(
+            sender = %redact_channel(&event.platform, &event.sender.id),
+            "gateway: user not in allowed_users, skipping"
+        );
         return true;
     }
     // @mention gating: in groups, only respond if bot is mentioned
@@ -912,8 +921,8 @@ pub async fn run_gateway_adapter(
 
                                     info!(
                                         platform = %event.platform,
-                                        sender = %event.sender.name,
-                                        channel = %redact_channel(&event.channel.id),
+                                        sender = %redact_channel(&event.platform, &event.sender.name),
+                                        channel = %redact_channel(&event.platform, &event.channel.id),
                                         "gateway event received"
                                     );
 
@@ -1314,8 +1323,8 @@ fn gate_gateway_event(router: &crate::adapter::AdapterRouter, event: &GatewayEve
             // (should_skip_event handles bot admission; L3 is human-only).
             tracing::info!(
                 platform = %event.platform,
-                sender = %event.sender.id,
-                channel = %redact_channel(&event.channel.id),
+                sender = %redact_channel(&event.platform, &event.sender.id),
+                channel = %redact_channel(&event.platform, &event.channel.id),
                 "gateway event denied (identity); echoing request-access"
             );
             let throttle_key = format!("{}:{}", event.platform, event.sender.id);
@@ -1342,8 +1351,8 @@ fn gate_gateway_event(router: &crate::adapter::AdapterRouter, event: &GatewayEve
         _ => {
             tracing::info!(
                 platform = %event.platform,
-                sender = %event.sender.id,
-                channel = %redact_channel(&event.channel.id),
+                sender = %redact_channel(&event.platform, &event.sender.id),
+                channel = %redact_channel(&event.platform, &event.channel.id),
                 ?decision,
                 "gateway event denied (scope); silent"
             );
@@ -1392,8 +1401,8 @@ pub async fn process_gateway_event(
 
     tracing::info!(
         platform = %event.platform,
-        sender = %event.sender.name,
-        channel = %redact_channel(&event.channel.id),
+        sender = %redact_channel(&event.platform, &event.sender.name),
+        channel = %redact_channel(&event.platform, &event.channel.id),
         "gateway event received (unified)"
     );
 
@@ -1877,7 +1886,7 @@ mod tests {
     }
 }
 
-/// Render a channel id for logs, hashing it when it is an ACP channel or session id.
+/// Render a gateway identity for logs using the platform-aware core policy.
 ///
 /// An ACP `channel_id` is `acp_<uuid>` and the session id is `sess_<same uuid>`, so the two are
 /// mutually derivable: either form printed in full IS a resume credential. Anyone reading operator
@@ -1891,24 +1900,15 @@ mod tests {
 /// redacting would, and it has already read as zero overlap between two logs describing the same
 /// session.
 ///
-/// Only ACP ids are hashed. A Discord or Slack channel id is a public identifier that operators
-/// legitimately grep for, and redacting it would cost real debuggability to protect nothing.
+/// With safe observability enabled, LINE and Telegram identities are also pseudonymized because
+/// they identify private messaging users or conversations. Discord and Slack channel ids keep
+/// their existing operator semantics.
 ///
 /// Copies of this function live in `openab-gateway` and `openab-mcp` because those crates
 /// deliberately do not depend on this one. Each is pinned to the same vector; where a crate has a
 /// redactor of its own, its test compares against that rather than against a copied literal.
-fn redact_channel(id: &str) -> String {
-    let Some(uuid) = id
-        .strip_prefix("acp_")
-        .or_else(|| id.strip_prefix("sess_"))
-        .filter(|uuid| !uuid.is_empty())
-    else {
-        return id.to_string();
-    };
-    use sha2::{Digest as _, Sha256};
-    let digest = Sha256::digest(uuid.as_bytes());
-    let short: String = digest.iter().take(4).map(|b| format!("{b:02x}")).collect();
-    format!("#{short}")
+fn redact_channel(platform: &str, id: &str) -> String {
+    crate::redact::redact_platform_identity(platform, id)
 }
 
 #[cfg(test)]
@@ -1929,34 +1929,50 @@ mod redact_channel_tests {
     #[test]
     fn an_acp_id_hashes_its_uuid_to_the_shared_vector_and_others_pass_through() {
         assert_eq!(
-            super::redact_channel(CHANNEL),
+            super::redact_channel("acp", CHANNEL),
             "#12b9377c",
             "ACP channel ids must hash to the tag the other crates produce for the same session"
         );
         assert_eq!(
-            super::redact_channel(SESSION),
+            super::redact_channel("acp", SESSION),
             "#12b9377c",
             "both forms of one session must share a tag — hashing the prefix is what split them"
         );
         assert_eq!(
-            super::redact_channel(CHANNEL),
+            super::redact_channel("acp", CHANNEL),
             crate::redact::redact_session_ids(CHANNEL),
             "this crate's two redactors must agree without relying on a copied literal"
         );
         assert_eq!(
-            super::redact_channel(SESSION),
+            super::redact_channel("acp", SESSION),
             crate::redact::redact_session_ids(SESSION),
             "including on the session form, which used to pass through here unredacted"
         );
         assert_eq!(
-            super::redact_channel("1234567890"),
+            super::redact_channel("discord", "1234567890"),
             "1234567890",
             "a non-ACP channel id is a public identifier and must stay greppable"
         );
         assert_eq!(
-            super::redact_channel("-"),
+            super::redact_channel("discord", "-"),
             "-",
             "the no-session sentinel must not be hashed into something that looks like a session"
+        );
+        assert!(
+            !crate::redact::redact_platform_identity_with_mode(
+                "telegram",
+                "1234567890",
+                true,
+            )
+            .contains("1234567890")
+        );
+        assert!(
+            !crate::redact::redact_platform_identity_with_mode(
+                "line",
+                "U1234567890abcdef",
+                true,
+            )
+            .contains("U1234567890abcdef")
         );
     }
 }

--- a/crates/openab-core/src/redact.rs
+++ b/crates/openab-core/src/redact.rs
@@ -9,12 +9,20 @@
 //! named `channel` misses it entirely. Redaction here matches on the VALUE's shape, which is why
 //! it can be applied to a composite without the caller taking it apart.
 //!
-//! Applying this to a non-ACP identifier is a no-op, deliberately. A Discord or Slack channel id
-//! is public and operators grep for it, and because the function leaves it untouched, a caller
-//! that cannot tell whether a given id will ever be ACP does not have to find out — applying it
-//! is free and removes the question. That is cheaper than an investigation and safer than a guess.
+//! LINE and Telegram identifiers are private messaging identities and are pseudonymized whenever
+//! safe observability is explicitly enabled. Other non-ACP identifiers remain unchanged
+//! deliberately: a Discord or Slack channel id is public and operators grep for it.
 
-/// Hash any `acp_`/`sess_` prefixed segment of `s`, leaving everything else exactly as it was.
+const SAFE_OBSERVABILITY_ENV: &str = "OPENAB_SAFE_OBSERVABILITY";
+
+/// Whether the opt-in bounded telemetry and private-platform log policy is enabled.
+pub fn safe_observability_enabled() -> bool {
+    std::env::var(SAFE_OBSERVABILITY_ENV)
+        .map(|value| matches!(value.as_str(), "1" | "true"))
+        .unwrap_or(false)
+}
+
+/// Hash any `acp_`/`sess_` segment and any LINE/Telegram composite identity in `s`.
 ///
 /// Segments are split on `:` so a `<platform>:<channel_id>` pool key redacts its id half and keeps
 /// the platform readable.
@@ -23,6 +31,30 @@
 /// across every log line that mentions it — that correlation is the only reason to keep an
 /// identifier in a log at all.
 pub fn redact_session_ids(s: &str) -> String {
+    redact_session_ids_with_mode(s, safe_observability_enabled())
+}
+
+/// Redact every session/platform identifier only after safe observability was
+/// enabled. Use this for newly protected log sites so the disabled default
+/// preserves their legacy output.
+pub fn redact_session_ids_if_safe(s: &str) -> String {
+    if safe_observability_enabled() {
+        redact_session_ids_with_mode(s, true)
+    } else {
+        s.to_string()
+    }
+}
+
+fn redact_session_ids_with_mode(s: &str, safe_observability: bool) -> String {
+    if let Some((platform, identities)) = s.split_once(':') {
+        if safe_observability && is_private_messaging_platform(platform) {
+            return std::iter::once(platform.to_string())
+                .chain(identities.split(':').map(hash_tag))
+                .collect::<Vec<_>>()
+                .join(":");
+        }
+    }
+
     s.split(':')
         .map(|seg| match seg.strip_prefix("acp_").or_else(|| seg.strip_prefix("sess_")) {
             Some(uuid) if !uuid.is_empty() => hash_tag(uuid),
@@ -30,6 +62,39 @@ pub fn redact_session_ids(s: &str) -> String {
         })
         .collect::<Vec<_>>()
         .join(":")
+}
+
+/// Render a platform identity for logs. With safe observability enabled, LINE
+/// and Telegram identifiers are reduced to a stable pseudonymous tag. Other
+/// platforms preserve today's operator-facing ids, while ACP resume
+/// credentials remain covered by [`redact_session_ids`] in either mode.
+pub fn redact_platform_identity(platform: &str, id: &str) -> String {
+    redact_platform_identity_with_mode(platform, id, safe_observability_enabled())
+}
+
+/// Platform-aware counterpart to [`redact_session_ids_if_safe`].
+pub fn redact_platform_identity_if_safe(platform: &str, id: &str) -> String {
+    if safe_observability_enabled() {
+        redact_platform_identity_with_mode(platform, id, true)
+    } else {
+        id.to_string()
+    }
+}
+
+pub(crate) fn redact_platform_identity_with_mode(
+    platform: &str,
+    id: &str,
+    safe_observability: bool,
+) -> String {
+    if safe_observability && is_private_messaging_platform(platform) {
+        hash_tag(id)
+    } else {
+        redact_session_ids_with_mode(id, safe_observability)
+    }
+}
+
+fn is_private_messaging_platform(platform: &str) -> bool {
+    matches!(platform, "line" | "telegram")
 }
 
 fn hash_tag(uuid: &str) -> String {
@@ -41,7 +106,9 @@ fn hash_tag(uuid: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::redact_session_ids;
+    use super::{
+        redact_platform_identity_with_mode, redact_session_ids, redact_session_ids_with_mode,
+    };
 
     /// A table, not a single vector — the branch structure is what needs pinning.
     ///
@@ -73,6 +140,45 @@ mod tests {
             redact_session_ids("discord:1234567890"),
             "discord:1234567890",
             "a non-ACP composite is untouched, which is why applying this blindly is safe"
+        );
+    }
+
+    #[test]
+    fn private_messaging_ids_and_composite_keys_are_pseudonymized() {
+        let telegram = redact_platform_identity_with_mode("telegram", "1234567890", true);
+        assert!(telegram.starts_with('#') && telegram.len() == 9);
+        assert!(!telegram.contains("1234567890"));
+        assert_eq!(
+            telegram,
+            redact_platform_identity_with_mode("telegram", "1234567890", true)
+        );
+
+        let line = redact_session_ids_with_mode("line:U1234567890abcdef", true);
+        assert!(line.starts_with("line:#"));
+        assert!(!line.contains("U1234567890abcdef"));
+
+        let telegram_composite =
+            redact_session_ids_with_mode("telegram:1234567890:9876543210", true);
+        assert_eq!(telegram_composite.matches('#').count(), 2);
+        assert!(!telegram_composite.contains("1234567890"));
+        assert!(!telegram_composite.contains("9876543210"));
+
+        assert_eq!(
+            redact_platform_identity_with_mode("discord", "1234567890", true),
+            "1234567890",
+            "public platform ids keep their existing operator semantics"
+        );
+    }
+
+    #[test]
+    fn private_messaging_redaction_is_explicitly_opt_in() {
+        assert_eq!(
+            redact_platform_identity_with_mode("telegram", "1234567890", false),
+            "1234567890"
+        );
+        assert_eq!(
+            redact_session_ids_with_mode("line:U1234567890abcdef", false),
+            "line:U1234567890abcdef"
         );
     }
 }

--- a/crates/openab-gateway/src/adapters/line.rs
+++ b/crates/openab-gateway/src/adapters/line.rs
@@ -189,7 +189,11 @@ async fn process_line_webhook_events(
         }
 
         let json = serde_json::to_string(&gateway_event).unwrap();
-        info!(channel = %gateway_event.channel.id, sender = %gateway_event.sender.id, "line → gateway");
+        info!(
+            channel = %crate::redact_platform_identity(&gateway_event.channel.id),
+            sender = %crate::redact_platform_identity(&gateway_event.sender.id),
+            "line → gateway"
+        );
         let _ = state.event_tx.send(json);
     }
 }
@@ -371,7 +375,7 @@ async fn build_gateway_event_from_line_event(
     let is_group = channel_type == "group" || channel_type == "room";
     if is_group && !mentionees.iter().any(|m| m.is_self) {
         info!(
-            channel = %channel_id,
+            channel = %crate::redact_platform_identity(&channel_id),
             "line group message dropped (@mention gating: bot not mentioned)"
         );
         return None;
@@ -692,7 +696,10 @@ pub async fn dispatch_line_reply(
     // Try Reply API first (free, no quota consumed)
     let mut used_reply = false;
     if let Some(reply_token) = cached_token {
-        info!(to = %reply.channel.id, "gateway → line (reply API)");
+        info!(
+            to = %crate::redact_platform_identity(&reply.channel.id),
+            "gateway → line (reply API)"
+        );
         let resp = client
             .post(format!("{}/v2/bot/message/reply", api_base))
             .bearer_auth(access_token)
@@ -714,14 +721,25 @@ pub async fn dispatch_line_reply(
                     && ((body_lower.contains("invalid") && body_lower.contains("reply token"))
                         || body_lower.contains("expired"));
                 if token_unusable {
-                    warn!(status = %status, body = %body, "LINE reply token unusable, falling back to Push");
+                    warn!(
+                        status = %status,
+                        body = %crate::upstream_error_for_log(&body, "reply_token_unusable"),
+                        "LINE reply token unusable, falling back to Push"
+                    );
                 } else {
-                    error!(status = %status, body = %body, "LINE Reply API error, NOT falling back to Push (possible duplicate risk)");
+                    error!(
+                        status = %status,
+                        body = %crate::upstream_error_for_log(&body, "api_error"),
+                        "LINE Reply API error, NOT falling back to Push (possible duplicate risk)"
+                    );
                     used_reply = true;
                 }
             }
             Err(e) => {
-                error!(err = %e, "LINE Reply API network error, NOT falling back to Push (possible duplicate risk)");
+                error!(
+                    err = %crate::request_error_for_log(&e),
+                    "LINE Reply API network error, NOT falling back to Push (possible duplicate risk)"
+                );
                 used_reply = true;
             }
         }
@@ -729,7 +747,10 @@ pub async fn dispatch_line_reply(
 
     // Fallback to Push API
     if !used_reply {
-        info!(to = %reply.channel.id, "gateway → line (push API)");
+        info!(
+            to = %crate::redact_platform_identity(&reply.channel.id),
+            "gateway → line (push API)"
+        );
         let _ = client
             .post(format!("{}/v2/bot/message/push", api_base))
             .bearer_auth(access_token)
@@ -739,7 +760,9 @@ pub async fn dispatch_line_reply(
             }))
             .send()
             .await
-            .map_err(|e| error!("line push error: {e}"));
+            .map_err(|e| {
+                error!("line push error: {}", crate::request_error_for_log(&e))
+            });
     }
 
     used_reply

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -228,7 +228,12 @@ pub async fn webhook(
     }
 
     let json = serde_json::to_string(&event).unwrap();
-    info!(chat_id = %msg.chat.id, sender = %sender_name, "telegram → gateway");
+    let sender_id = from.map(|user| user.id.to_string()).unwrap_or_default();
+    info!(
+        chat_id = %crate::redact_platform_identity(&msg.chat.id.to_string()),
+        sender = %crate::private_identity_or_legacy(&sender_id, sender_name),
+        "telegram → gateway"
+    );
     let _ = state.event_tx.send(json);
     axum::http::StatusCode::OK
 }
@@ -291,6 +296,38 @@ fn is_markdown_parse_error(description: &str) -> bool {
     desc_lower.contains("can't find end")
         || desc_lower.contains("can't parse")
         || desc_lower.contains("parse entities")
+}
+
+fn telegram_api_error_class(description: &str) -> &'static str {
+    let description = description.to_lowercase();
+    if is_markdown_parse_error(&description) {
+        "markdown_parse"
+    } else if description.contains("unauthorized") {
+        "unauthorized"
+    } else if description.contains("forbidden") {
+        "forbidden"
+    } else if description.contains("not found") {
+        "not_found"
+    } else if description.contains("too many requests") {
+        "rate_limited"
+    } else {
+        "api_error"
+    }
+}
+
+fn telegram_api_error_for_log(description: &str) -> String {
+    telegram_api_error_for_log_with_mode(description, crate::safe_observability_enabled())
+}
+
+fn telegram_api_error_for_log_with_mode(
+    description: &str,
+    safe_observability: bool,
+) -> String {
+    crate::upstream_error_for_log_with_mode(
+        description,
+        telegram_api_error_class(description),
+        safe_observability,
+    )
 }
 
 /// Returns true if the content is complex enough to benefit from sendRichMessage.
@@ -360,12 +397,22 @@ async fn send_rich_message(
         "message_thread_id": thread_id,
         "rich_message": { "markdown": text },
     });
-    let resp = client.post(&url).json(&body).send().await.map_err(|e| e.to_string())?;
-    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| crate::request_error_for_log(&error))?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|error| crate::request_error_for_log(&error))?;
     if json["ok"].as_bool() == Some(true) {
         Ok(json)
     } else {
-        Err(json["description"].as_str().unwrap_or("unknown error").to_string())
+        Err(telegram_api_error_for_log(
+            json["description"].as_str().unwrap_or("unknown error"),
+        ))
     }
 }
 
@@ -391,12 +438,22 @@ async fn send_rich_message_draft(
         "draft_id": draft_id,
         "rich_message": if text.contains("<tg-") { serde_json::json!({ "html": text }) } else { serde_json::json!({ "markdown": text }) },
     });
-    let resp = client.post(&url).json(&body).send().await.map_err(|e| e.to_string())?;
-    let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| crate::request_error_for_log(&error))?;
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|error| crate::request_error_for_log(&error))?;
     if json["ok"].as_bool() == Some(true) {
         Ok(())
     } else {
-        Err(json["description"].as_str().unwrap_or("unknown error").to_string())
+        Err(telegram_api_error_for_log(
+            json["description"].as_str().unwrap_or("unknown error"),
+        ))
     }
 }
 
@@ -413,7 +470,10 @@ pub async fn handle_reply(
     // Handle create_topic command
     if reply.command.as_deref() == Some("create_topic") {
         let req_id = reply.request_id.clone().unwrap_or_default();
-        info!(chat_id = %reply.channel.id, "creating forum topic");
+        info!(
+            chat_id = %crate::redact_platform_identity(&reply.channel.id),
+            "creating forum topic"
+        );
         let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/createForumTopic");
         let resp = client
             .post(&url)
@@ -427,7 +487,10 @@ pub async fn handle_reply(
                     let tid = body["result"]["message_thread_id"]
                         .as_i64()
                         .map(|id| id.to_string());
-                    info!(thread_id = ?tid, "forum topic created");
+                    let thread_tag = tid
+                        .as_deref()
+                        .map(crate::redact_platform_identity);
+                    info!(thread_id = ?thread_tag, "forum topic created");
                     GatewayResponse {
                         schema: "openab.gateway.response.v1".into(),
                         request_id: req_id,
@@ -441,24 +504,27 @@ pub async fn handle_reply(
                         .as_str()
                         .unwrap_or("unknown error")
                         .to_string();
-                    warn!(err = %err, "createForumTopic failed");
+                    warn!(
+                        err = %telegram_api_error_for_log(&err),
+                        "createForumTopic failed"
+                    );
                     GatewayResponse {
                         schema: "openab.gateway.response.v1".into(),
                         request_id: req_id,
                         success: false,
                         thread_id: None,
                         message_id: None,
-                        error: Some(err),
+                        error: Some(telegram_api_error_for_log(&err)),
                     }
                 }
             }
-            Err(e) => GatewayResponse {
+            Err(error) => GatewayResponse {
                 schema: "openab.gateway.response.v1".into(),
                 request_id: req_id,
                 success: false,
                 thread_id: None,
                 message_id: None,
-                error: Some(e.to_string()),
+                error: Some(crate::request_error_for_log(&error)),
             },
         };
         let json = serde_json::to_string(&gw_resp).unwrap();
@@ -543,8 +609,13 @@ pub async fn handle_reply(
         let url = format!("{TELEGRAM_API_BASE}/bot{bot_token}/setMessageReaction");
         let msg_id: i64 = match reply.reply_to.parse() {
             Ok(id) => id,
-            Err(e) => {
-                warn!(reply_to = %reply.reply_to, chat_id = %reply.channel.id, error = %e, "invalid message_id for reaction, skipping");
+            Err(error) => {
+                warn!(
+                    reply_to = %crate::redact_platform_identity(&reply.reply_to),
+                    chat_id = %crate::redact_platform_identity(&reply.channel.id),
+                    error = %error,
+                    "invalid message_id for reaction, skipping"
+                );
                 return;
             }
         };
@@ -554,7 +625,7 @@ pub async fn handle_reply(
             "reaction": current,
         });
         debug!(
-            chat_id = %reply.channel.id,
+            chat_id = %crate::redact_platform_identity(&reply.channel.id),
             message_id = msg_id,
             emoji = %tg_emoji,
             is_add,
@@ -564,19 +635,31 @@ pub async fn handle_reply(
             Ok(resp) => {
                 let status = resp.status();
                 if !status.is_success() {
-                    let text = resp.text().await.unwrap_or_default();
-                    warn!(status = %status, body = %text, "setMessageReaction failed");
+                    let body = resp.text().await.unwrap_or_default();
+                    warn!(
+                        status = %status,
+                        body = %crate::upstream_error_for_log(&body, "api_error"),
+                        "setMessageReaction failed"
+                    );
                 }
             }
-            Err(e) => error!("telegram reaction error: {e}"),
+            Err(error) => error!(
+                "telegram reaction error: {}",
+                crate::request_error_for_log(&error)
+            ),
         }
         return;
     }
 
     // Normal send_message
+    let thread_tag = reply
+        .channel
+        .thread_id
+        .as_deref()
+        .map(crate::redact_platform_identity);
     info!(
-        chat_id = %reply.channel.id,
-        thread_id = ?reply.channel.thread_id,
+        chat_id = %crate::redact_platform_identity(&reply.channel.id),
+        thread_id = ?thread_tag,
         "gateway → telegram"
     );
 
@@ -594,7 +677,9 @@ pub async fn handle_reply(
         };
         match send_rich_message(client, bot_token, &reply.channel.id, &reply.channel.thread_id, &rich_text).await {
             Ok(_) => return,
-            Err(e) => warn!("sendRichMessage failed ({e}), falling back to sendMessage"),
+            Err(error) => warn!(
+                "sendRichMessage failed ({error}), falling back to sendMessage"
+            ),
         }
     }
 
@@ -619,7 +704,10 @@ pub async fn handle_reply(
                 if body["ok"].as_bool() != Some(true) {
                     let desc = body["description"].as_str().unwrap_or("unknown error");
                     if is_markdown_parse_error(desc) {
-                        warn!("Markdown send failed: {desc}, retrying as plain text");
+                        warn!(
+                            "Markdown send failed: {}, retrying as plain text",
+                            telegram_api_error_for_log(desc)
+                        );
                         match client
                             .post(&url)
                             .json(&serde_json::json!({
@@ -636,20 +724,28 @@ pub async fn handle_reply(
                                 if retry_body["ok"].as_bool() != Some(true) {
                                     error!(
                                         "telegram plain-text retry failed: {}",
-                                        retry_body["description"]
-                                            .as_str()
-                                            .unwrap_or("unknown error")
+                                        telegram_api_error_for_log(
+                                            retry_body["description"]
+                                                .as_str()
+                                                .unwrap_or("unknown error")
+                                        )
                                     );
                                 }
                             }
-                            Err(e) => error!("telegram plain-text send error: {e}"),
+                            Err(error) => error!(
+                                "telegram plain-text send error: {}",
+                                crate::request_error_for_log(&error)
+                            ),
                         }
                     } else {
-                        error!("telegram send failed: {desc}");
+                        error!("telegram send failed: {}", telegram_api_error_for_log(desc));
                     }
                 }
             }
-            Err(e) => error!("telegram send error: {e}"),
+            Err(error) => error!(
+                "telegram send error: {}",
+                crate::request_error_for_log(&error)
+            ),
         }
     }
 }
@@ -682,15 +778,25 @@ async fn download_telegram_media(
     let get_file_url = format!("{TELEGRAM_API_BASE}/bot{}/getFile", bot_token);
     let resp = match client.get(&get_file_url).query(&[("file_id", file_id)]).send().await {
         Ok(r) => r,
-        Err(e) => {
-            warn!(file_id, error = %e, kind = ?kind, "Telegram getFile request failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                kind = ?kind,
+                "Telegram getFile request failed"
+            );
             return Attachment::rejected(att_type, fallback_filename, default_mime, 0, "download failed: network error");
         }
     };
     let body: serde_json::Value = match resp.json().await {
         Ok(v) => v,
-        Err(e) => {
-            warn!(file_id, error = %e, kind = ?kind, "Telegram getFile JSON parse failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                kind = ?kind,
+                "Telegram getFile JSON parse failed"
+            );
             return Attachment::rejected(att_type, fallback_filename, default_mime, 0, "download failed: invalid API response");
         }
     };
@@ -705,8 +811,13 @@ async fn download_telegram_media(
     let download_url = format!("{TELEGRAM_API_BASE}/file/bot{}/{}", bot_token, file_path);
     let resp = match client.get(&download_url).send().await {
         Ok(r) => r,
-        Err(e) => {
-            warn!(file_id, error = %e, kind = ?kind, "Telegram media download request failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                kind = ?kind,
+                "Telegram media download request failed"
+            );
             return Attachment::rejected(att_type, fallback_filename, default_mime, 0, "download failed: network error");
         }
     };
@@ -747,8 +858,13 @@ async fn download_telegram_media(
 
     let bytes = match resp.bytes().await {
         Ok(b) => b,
-        Err(e) => {
-            warn!(file_id, error = %e, kind = ?kind, "Telegram media body read failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                kind = ?kind,
+                "Telegram media body read failed"
+            );
             return Attachment::rejected(att_type, fallback_filename, default_mime, 0, "download failed: body read error");
         }
     };
@@ -821,15 +937,23 @@ async fn download_telegram_document(
     let get_file_url = format!("{TELEGRAM_API_BASE}/bot{}/getFile", bot_token);
     let resp = match client.get(&get_file_url).query(&[("file_id", file_id)]).send().await {
         Ok(r) => r,
-        Err(e) => {
-            warn!(file_id, error = %e, "Telegram document getFile request failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                "Telegram document getFile request failed"
+            );
             return Attachment::rejected("text_file", file_name.to_string(), mime_type, 0, "download failed: network error");
         }
     };
     let body: serde_json::Value = match resp.json().await {
         Ok(v) => v,
-        Err(e) => {
-            warn!(file_id, error = %e, "Telegram document getFile JSON parse failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                "Telegram document getFile JSON parse failed"
+            );
             return Attachment::rejected("text_file", file_name.to_string(), mime_type, 0, "download failed: invalid API response");
         }
     };
@@ -844,8 +968,12 @@ async fn download_telegram_document(
     let download_url = format!("{TELEGRAM_API_BASE}/file/bot{}/{}", bot_token, file_path);
     let resp = match client.get(&download_url).send().await {
         Ok(r) => r,
-        Err(e) => {
-            warn!(file_id, err = %e, "Telegram document network error");
+        Err(error) => {
+            warn!(
+                file_id,
+                err = %crate::request_error_for_log(&error),
+                "Telegram document network error"
+            );
             return Attachment::rejected("text_file", file_name.to_string(), mime_type, 0, "download failed: network error");
         }
     };
@@ -878,8 +1006,12 @@ async fn download_telegram_document(
 
     let bytes = match resp.bytes().await {
         Ok(b) => b,
-        Err(e) => {
-            warn!(file_id, error = %e, "Telegram document body read failed");
+        Err(error) => {
+            warn!(
+                file_id,
+                error = %crate::request_error_for_log(&error),
+                "Telegram document body read failed"
+            );
             return Attachment::rejected("text_file", file_name.to_string(), mime_type, 0, "download failed: body read error");
         }
     };
@@ -954,6 +1086,26 @@ mod tests {
         assert!(is_markdown_parse_error("can't parse entities in message text"));
         assert!(!is_markdown_parse_error("Unauthorized"));
         assert!(!is_markdown_parse_error("Bad Request: chat not found"));
+    }
+
+    #[test]
+    fn api_errors_are_reduced_to_bounded_classes() {
+        let sensitive = "Bad Request: chat not found for user 123456789";
+        assert_eq!(telegram_api_error_class(sensitive), "not_found");
+        assert!(!telegram_api_error_class(sensitive).contains("123456789"));
+        assert_eq!(telegram_api_error_for_log_with_mode(sensitive, false), sensitive);
+        assert_eq!(
+            telegram_api_error_for_log_with_mode(sensitive, true),
+            "not_found"
+        );
+        assert_eq!(
+            telegram_api_error_class("Too Many Requests: retry after 30"),
+            "rate_limited"
+        );
+        assert_eq!(
+            telegram_api_error_class("can't parse entities in message text"),
+            "markdown_parse"
+        );
     }
 
     #[test]

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -987,7 +987,10 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                     Ok(reply) => {
                         info!(
                             platform = %reply.platform,
-                            channel = %redact_channel(&reply.channel.id),
+                            channel = %redact_channel_for_platform(
+                                &reply.platform,
+                                &reply.channel.id,
+                            ),
                             command = ?reply.command.as_deref(),
                             "OAB → gateway reply"
                         );
@@ -1327,10 +1330,107 @@ fn redact_channel(id: &str) -> String {
     else {
         return id.to_string();
     };
+    hash_tag(uuid)
+}
+
+fn redact_channel_for_platform(platform: &str, id: &str) -> String {
+    if matches!(platform, "line" | "telegram") {
+        redact_platform_identity(id)
+    } else {
+        redact_channel(id)
+    }
+}
+
+/// Render a messaging-platform identity for operator logs.
+///
+/// Unlike [`redact_channel`], which preserves public channel ids for existing
+/// operator workflows, this helper is for user and conversation identifiers
+/// received from private messaging platforms. Those identifiers are personal
+/// data. With safe observability explicitly enabled, keeping a short stable tag
+/// preserves the ability to correlate ingress and egress events without
+/// retaining the original identity verbatim. The disabled default preserves
+/// legacy operator behavior. This is log minimization, not cryptographic
+/// anonymization: low-entropy numeric ids may still be guessable.
+pub(crate) fn redact_platform_identity(id: &str) -> String {
+    redact_platform_identity_with_mode(id, safe_observability_enabled())
+}
+
+/// Keep a legacy operator label while disabled, but correlate by the stable
+/// private identity after safe observability is enabled.
+pub(crate) fn private_identity_or_legacy(id: &str, legacy: &str) -> String {
+    if safe_observability_enabled() {
+        redact_platform_identity_with_mode(id, true)
+    } else {
+        legacy.to_string()
+    }
+}
+
+fn redact_platform_identity_with_mode(id: &str, safe_observability: bool) -> String {
+    if !safe_observability {
+        return id.to_string();
+    }
+    hash_tag(id)
+}
+
+fn hash_tag(id: &str) -> String {
     use sha2::{Digest as _, Sha256};
-    let digest = Sha256::digest(uuid.as_bytes());
+    let digest = Sha256::digest(id.as_bytes());
     let short: String = digest.iter().take(4).map(|b| format!("{b:02x}")).collect();
     format!("#{short}")
+}
+
+pub(crate) fn safe_observability_enabled() -> bool {
+    std::env::var("OPENAB_SAFE_OBSERVABILITY")
+        .map(|value| matches!(value.as_str(), "1" | "true"))
+        .unwrap_or(false)
+}
+
+/// Reduce a request failure to a bounded class before writing it to logs.
+/// `reqwest::Error` display text can include the request URL; Telegram embeds
+/// the bot token in that URL, so logging the full error would expose a secret.
+pub(crate) fn request_error_class(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connect"
+    } else if error.is_decode() {
+        "decode"
+    } else if error.is_body() {
+        "body"
+    } else if error.is_request() {
+        "request"
+    } else {
+        "other"
+    }
+}
+
+/// Preserve legacy error detail by default. In safe observability mode, emit
+/// only the bounded class because a reqwest error may contain a credentialed
+/// request URL (Telegram embeds the bot token in its URL path).
+pub(crate) fn request_error_for_log(error: &reqwest::Error) -> String {
+    if safe_observability_enabled() {
+        request_error_class(error).to_string()
+    } else {
+        error.to_string()
+    }
+}
+
+/// Preserve the legacy upstream response text unless safe observability was
+/// explicitly enabled for this deployment.
+pub(crate) fn upstream_error_for_log(raw: &str, bounded_class: &str) -> String {
+    upstream_error_for_log_with_mode(raw, bounded_class, safe_observability_enabled())
+}
+
+pub(crate) fn upstream_error_for_log_with_mode(
+    raw: &str,
+    bounded_class: &str,
+    safe_observability: bool,
+) -> String {
+    if safe_observability {
+        bounded_class.to_string()
+    } else {
+        raw.to_string()
+    }
 }
 
 #[cfg(test)]
@@ -1381,5 +1481,35 @@ mod redact_channel_tests {
                 "redact_channel and redact_id must tag {id} identically"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod redact_platform_identity_tests {
+    use super::{redact_platform_identity_with_mode, upstream_error_for_log_with_mode};
+
+    #[test]
+    fn platform_identity_is_stable_distinct_and_does_not_contain_the_raw_id() {
+        let raw = "U1234567890abcdef";
+        let tag = redact_platform_identity_with_mode(raw, true);
+
+        assert_eq!(tag, redact_platform_identity_with_mode(raw, true));
+        assert_ne!(
+            tag,
+            redact_platform_identity_with_mode("Ufedcba0987654321", true)
+        );
+        assert!(!tag.contains(raw));
+        assert_eq!(tag.len(), 9, "# followed by eight lowercase hex digits");
+        assert_eq!(redact_platform_identity_with_mode(raw, false), raw);
+    }
+
+    #[test]
+    fn upstream_error_detail_is_bounded_only_after_opt_in() {
+        let raw = "Bad Request: chat not found for user 123456789";
+        assert_eq!(upstream_error_for_log_with_mode(raw, "not_found", false), raw);
+        assert_eq!(
+            upstream_error_for_log_with_mode(raw, "not_found", true),
+            "not_found"
+        );
     }
 }

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -24,6 +24,32 @@ openab run -c s3://my-bucket/path/to/config.toml
 
 Remote config is fetched via HTTP GET with a 10-second timeout and a 1 MiB response size limit. Environment variable expansion (`${VAR}`) works identically on both local and remote config content.
 
+### Safe observability (opt-in)
+
+Set `OPENAB_SAFE_OBSERVABILITY=true` on both the OpenAB process and a separately
+deployed `openab-gateway` process to enable bounded operational telemetry for
+private messaging deployments. It is disabled by default, so existing
+deployments keep their current logs and do not emit the new terminal-turn event.
+
+When enabled:
+
+- each terminal agent prompt emits one structured `agent.turn_completed` event
+  with outcome, bounded stop reason, duration, numeric token counters, and a
+  `token_usage_reported` flag;
+- LINE and Telegram user, conversation, thread, and composite dispatch
+  identifiers in the affected operator logs become stable short pseudonymous
+  tags; and
+- affected LINE and Telegram upstream failures log bounded error classes rather
+  than response bodies or credential-bearing request URLs.
+
+Migration note: dashboards and searches must use the pseudonymous tags instead
+of raw LINE or Telegram identifiers, and detailed upstream error text is no
+longer available from these logs. Disable the variable to restore legacy
+logging while diagnosing an incident, understanding that doing so can place
+private identifiers, upstream response text, or credential-bearing URLs in the
+log sink. The short tags are for correlation and log minimization, not
+cryptographic anonymization; low-entropy identifiers may still be guessable.
+
 > **Security best practice:** Never hardcode secrets in remote config files. Use environment variable references like `bot_token = "${DISCORD_BOT_TOKEN}"` and inject the actual values via local environment variables or Kubernetes Secrets. For centralized secret management with rotation and audit, use `[secrets.refs]` with AWS Secrets Manager or an exec provider — see [secrets-management.md](secrets-management.md). OpenAB expands `${VAR}` identically for both local and remote config.
 
 ### `s3://` config source


### PR DESCRIPTION
## What problem does this solve?

The Trusted Public POC needs enough usage telemetry to tell whether an agent turn completed and how many tokens it used, but its normal LINE and Telegram logs currently retain raw private-platform identities and can include upstream response detail. This adds an explicitly opt-in safe observability mode so the POC can be measured without changing existing deployments by default.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1530065146326683769

## Review Contract

### Goal

When `OPENAB_SAFE_OBSERVABILITY=true` is set on both OpenAB and `openab-gateway`, emit one bounded structured `agent.turn_completed` event per terminal prompt and minimize the affected LINE/Telegram operator logs by pseudonymizing private identities and replacing upstream error bodies or credential-bearing request errors with bounded classes. With the variable absent, preserve existing operator-visible behavior and do not emit the new turn event.

### Non-goals

- A metrics backend, dashboard, provider billing ledger, or per-tenant quota enforcement.
- Provider/model kind, cache-token, price, or cost attribution when ACP does not expose it.
- Redesigning user-visible agent/provider errors or debug-level raw ACP capture.
- Changing Discord, Slack, Feishu, Google Chat, or other public-channel logging semantics.
- Implementing the multitenant provider global hard cap or emergency-disable runbook.

### Accepted Residual Risks

- The eight-hex-character stable tags are pseudonyms, not anonymization. Low-entropy identifiers may be guessed and 32-bit tags can collide. They are used only for log correlation; tenant workloads/log access remain isolated. A keyed or wider tag is a follow-up if the POC demonstrates the need.
- Some ACP runtimes do not report usage. Those events contain numeric zero values with `token_usage_reported=false`, so queries must filter or group on that flag before interpreting token totals.
- The opt-in must reach both OpenAB and a separately deployed gateway. The configuration reference documents this; operators can verify the event and pseudonymous ingress/egress tags after rollout and roll back by removing the variable.
- The disabled default preserves legacy detailed logs, including their existing privacy/credential exposure risk. This is required for backward compatibility; private multitenant deployments should opt in.

### Acceptance Criteria

- [x] Disabled mode emits no `agent.turn_completed` event and preserves legacy LINE/Telegram identity and error detail behavior.
- [x] Enabled mode emits exactly one terminal `agent.turn_completed` event with bounded outcome and stop reason, duration, numeric input/output/total token fields, and `token_usage_reported`.
- [x] Enabled LINE/Telegram ingress, egress, dispatch, thread, and shutdown logs use stable pseudonymous identity tags derived using the actual message platform, including Unified adapter shutdown.
- [x] Enabled affected LINE/Telegram upstream response and request failures log bounded classes; `createForumTopic` does not forward a raw upstream description into core logs.
- [x] New behavior and opt-in defaults have regression tests; Core and Gateway tests, checks, clippy, and diff checks pass subject to the documented pre-existing Core test exception.
- [x] Configuration and migration behavior are documented.

### Follow-ups

- Add provider/model kind, cache-token, pricing, and cost fields when the selected ACP runtime exposes trustworthy values.
- Decide whether production deployments need keyed/wider pseudonymous tags and formal retention policy.
- Build the multitenant aggregation/dashboard and the separate provider hard-cap/emergency-disable control.
- Investigate and repair the pre-existing `secrets::tests::resolve_exec_nonzero_exit` environment-sensitive failure and repository-wide rustfmt drift separately.

## At a Glance

```
ACP terminal result
        |
        | OPENAB_SAFE_OBSERVABILITY=true
        v
agent.turn_completed
  outcome | duration_ms | bounded stop_reason
  numeric tokens | token_usage_reported

LINE / Telegram ingress <-> OpenAB dispatch <-> gateway egress
        raw private ids  --opt-in--> stable #<8hex> tags
        raw upstream errors --opt-in--> bounded error classes

flag absent: existing logs, no new terminal-turn event
```

## Prior Art & Industry Research

**OpenClaw:**

OpenClaw's OpenTelemetry integration records model-call usage as structured attributes when providers expose it, while content capture is separately controlled and disabled by default. Its gateway configuration also treats log redaction as a distinct operator policy. This PR follows the same separation between bounded usage signals and content/identity capture, but keeps the change opt-in to honor OpenAB's compatibility contract.

- https://github.com/openclaw/openclaw/blob/main/docs/gateway/opentelemetry.md
- https://github.com/openclaw/openclaw/blob/main/docs/gateway/configuration-reference.md

**Hermes Agent:**

Hermes stores session token counts as structured SQLite session metadata rather than relying on raw conversation logs. This PR similarly makes token counts numeric structured fields so operator queries do not have to parse prose or message bodies.

- https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/sessions.md
- https://github.com/NousResearch/hermes-agent/issues/20253

**Other references (optional):**

- POC acceptance source: OpenAB multitenant ADR 007 and the Trusted Public roadmap.

## Proposed Solution

- Add `OPENAB_SAFE_OBSERVABILITY`, disabled by default and documented for both processes.
- Emit a terminal turn event only in enabled mode. Outcome and stop reason are closed vocabularies; token fields are native JSON numbers, with an explicit completeness flag.
- Use one stable SHA-256-derived short tag policy for affected LINE/Telegram user, conversation, thread, and composite dispatch identifiers while retaining existing ACP credential redaction.
- Keep legacy values while disabled, including Telegram's legacy sender label, field names, and upstream error detail.
- In enabled mode, classify Telegram/LINE API descriptions and `reqwest` failures before they reach logs or a gateway response that core will log.
- Store the actual channel platform beside the Unified adapter kind so shutdown redaction cannot mistake private traffic for platform `unified`.

## Why this approach?

It supplies the minimum POC signal at the terminal turn boundary, where outcome and ACP usage are known, and applies minimization at the logging boundary before data reaches the sink. One explicit environment switch can be injected into the existing multitenant workload without introducing a metrics service or changing default OpenAB behavior. The trade-off is that the POC must consistently configure both processes and that short stable tags remain pseudonymous.

## Alternatives Considered

- **Always-on redaction and telemetry:** safer for new deployments, but violates this repository's backward-compatible-default rule and can break existing dashboards/searches.
- **Raw pass-through with sink-side redaction:** leaves secrets and private identifiers exposed before the sink filter and makes correctness depend on every downstream pipeline.
- **Hash every platform identifier:** reduces operator utility for public Discord/Slack channels without helping the private-platform POC.
- **Build a metrics/cost service now:** adds storage, attribution, and billing semantics before the POC has validated the basic signal.

## Validation

- [x] `cargo check -p openab-core -p openab-gateway`
- [x] `cargo test -p openab-gateway` — 314 unit tests + 2 conformance tests passed.
- [x] `cargo test -p openab-core --lib -- --skip secrets::tests::resolve_exec_nonzero_exit` — 682 passed, 0 failed, 1 filtered.
- [x] The skipped Core test fails identically on untouched `origin/main` in this environment because its expected non-zero exec error text differs; it is unrelated to these files.
- [x] `cargo clippy -p openab-core --lib -- -D warnings`
- [x] `cargo clippy -p openab-gateway --lib -- -D warnings`
- [x] `git diff --check`
- [x] Regression coverage verifies opt-in/default identity behavior, bounded upstream errors, closed stop reasons/outcomes, and numeric JSON token fields.
- [x] Manual source audit followed identity/error values through Telegram and LINE ingress, Unified dispatch/shutdown, gateway responses, and core logs.
- [ ] Deployment smoke test — intentionally deferred until this PR is reviewed, merged, and the multitenant deployment references the merged commit.

Repository-wide `cargo fmt --all -- --check` is not marked as passed: the current local rustfmt rewrites large untouched portions of `origin/main`. This PR avoids that unrelated mechanical churn; changed hunks pass `git diff --check`.
