### PR TITLE
docs(teams): propose commands and proactive delivery

### DIFF
--- a/docs/adr/custom-gateway.md
+++ b/docs/adr/custom-gateway.md
@@ -6,12 +6,14 @@
 - **Supersedes:** Sections of [ADR: LINE Adapter](./line-adapter.md) (v2 Target Architecture)
 - **Superseded by:** [ADR: Separate Binaries with Opt-In Unified Build](./unified-binary.md)
 
-> **⚠️ This ADR is partially superseded by the unified binary architecture.**
-> OpenAB now supports a single unified binary mode for simplified deployment
-> (see [ADR: Separate Binaries with Opt-In Unified Build](./unified-binary.md)).
-> While the unified binary is the recommended path for standard setups, the
-> standalone gateway architecture remains fully supported for deployments
-> requiring strict outbound-only network isolation for the OpenAB core.
+> **Standing: historical reference only.** This ADR records the original
+> standalone-gateway proposal and is not operative implementation instruction.
+> Unified mode is the standard deployment path; standalone Gateway remains
+> supported when Core must stay outbound-only. For operative protocol and delivery
+> requirements, use [Separate Binaries with Opt-In Unified Build](./unified-binary.md)
+> and [Gateway Capabilities and Delivery Semantics](gateway-capabilities-and-delivery-semantics.md).
+> Every requirement, rollout step, and compliance statement below describes this
+> superseded proposal unless a non-superseded ADR explicitly adopts it.
 
 ---
 
@@ -22,6 +24,7 @@ As an OpenAB operator, I want to connect webhook-based platforms (LINE, Telegram
 As a platform integrator, I want to write a plugin/adapter for my platform and register it with the gateway, so that any webhook source can drive an OAB agent session without upstream code changes.
 
 Requirements:
+
 - OAB core must remain outbound-only — no inbound ports, no TLS, no K8s Service
 - The gateway is a separate, independently deployable service
 - Adding a new webhook platform requires only a gateway plugin, zero OAB changes
@@ -101,7 +104,7 @@ Outbound (OAB → platform):
 
 ---
 
-## 3. Internal Event Schema
+## 3. Historical Internal Event Schema
 
 The contract between the gateway and OAB. All platform-specific details are normalized away before crossing this boundary.
 
@@ -136,6 +139,7 @@ The contract between the gateway and OAB. All platform-specific details are norm
 ```
 
 Key fields in the base schema:
+
 - **`channel.thread_id`**: thread identifier for platforms that support threads (Discord thread ID, Slack `thread_ts`). `null` for platforms without threads (LINE). OAB uses this for session key construction — without it, per-thread session isolation cannot work through the gateway.
 - **`mentions`**: array of mentioned entity IDs (users, bots). Required for @mention gating — the gateway adapter parses platform-specific mention formats and normalizes them here. Without it, OAB cannot determine whether the bot was mentioned, breaking the primary mitigation for LINE group chat noise and Discord/Slack trigger logic.
 
@@ -157,7 +161,10 @@ Key fields in the base schema:
 ```
 
 Key fields in the outbound reply:
-- **`reply_to`**: the `event_id` of the inbound `GatewayEvent` that triggered this reply. The gateway can use this for reply correlation — e.g., looking up a cached LINE reply token to prefer the free Reply API over the quota-consuming Push API. Empty string if the reply is not associated with a specific inbound event (e.g., cron-triggered messages).
+
+- **`reply_to`**: the `event_id` of the inbound `GatewayEvent` that triggered this reply. The gateway can use this for reply correlation — e.g., looking up a cached LINE reply token to prefer the free Reply API over the quota-consuming Push API. Empty string if the reply is not associated with a specific inbound event (e.g., cron-triggered messages). Legacy command peers may still overload it with a platform target.
+- **`quote_message_id`**: optional platform message selected for visual reply/quote behavior; it is distinct from origin correlation.
+- **`target_message_id`**: additive optional target for edit/delete/reaction commands. Core uses it only when the negotiated capability advertises support; otherwise it copies the target into legacy `reply_to`.
 
 ### Design Principles for the Schema
 
@@ -178,9 +185,11 @@ The following fields/concepts are known to be needed but are not fully defined i
 | `reply_context` | Reply token, quote target, original message reference — not all platforms only need `channel.id` to deliver a reply |
 | `tenant` / `gateway_instance` | Multi-tenancy routing if a shared gateway serves multiple OAB instances |
 
+The capability and delivery-result portion is resolved by [Gateway Capabilities and Delivery Semantics](gateway-capabilities-and-delivery-semantics.md). Teams process-local route and duplicate-suppression behavior is resolved by [Teams Ephemeral Ingress Route and Duplicate Suppression](teams-ephemeral-ingress-state.md), its event correlation plus real send ACK by [Teams Real Send Acknowledgement and Reply Correlation](teams-real-send-acknowledgement.md), and its explicit command target plus ownership enforcement by [Teams Bot-Owned Message Mutations](teams-owned-message-mutations.md). The other rows remain deferred.
+
 ---
 
-## 4. Gateway Adapter Interface
+## 4. Historical Gateway Adapter Interface
 
 Each platform adapter implements a common interface:
 
@@ -305,7 +314,7 @@ GitHub shows the gateway handling a non-chat event. The adapter maps repo → ch
 
 ---
 
-## 7. Open Design Questions
+## 7. Historical Open Design Questions
 
 | Question | Options | Impact |
 |---|---|---|
@@ -317,11 +326,11 @@ GitHub shows the gateway handling a non-chat event. The adapter maps repo → ch
 
 ---
 
-## 8. Rollout Plan
+## 8. Historical Rollout Plan
 
 | Phase | Scope | Deliverable |
 |---|---|---|
-| **v1 (now)** | LINE adapter inside OAB | PR #521 — unblocks LINE users |
+| **v1 (2026-04-22 baseline)** | LINE adapter inside OAB | PR #521 — unblocks LINE users |
 | **v2** | Standalone gateway + OAB generic gateway adapter + LINE migrated out | Gateway service, LINE adapter, internal event schema, OAB connects via WebSocket |
 | **v3** | Multi-platform gateway | Telegram, GitHub, custom adapters |
 | **v4** | Plugin / distribution model | Third-party adapters without forking gateway |
@@ -386,10 +395,13 @@ The gateway holding all platform credentials is the correct architectural choice
 
 ---
 
-## Compliance
+## Historical Compliance Proposal
+
+These clauses governed the superseded proposal; non-superseded ADRs named in the
+standing notice above take precedence.
 
 1. **OAB outbound-only**: after adoption of the custom gateway architecture, new platform integrations must not add inbound platform-traffic handling to OAB core unless explicitly approved by a superseding ADR.
-2. **Event schema stability**: the `openab.gateway.event.v1` schema is currently a draft envelope for v2 development. The protocol spec must finalize all required fields (including deferred concerns in Section 3) before the schema is declared stable. Once declared stable, breaking changes require a version bump (`v2`) and a migration path.
+2. **Event schema stability**: at ADR version 0.2 (2026-06-29), `openab.gateway.event.v1` was a draft envelope for v2 development. Current wire stability is defined by the implementation and [Gateway Capabilities and Delivery Semantics](gateway-capabilities-and-delivery-semantics.md); this historical clause has no independent authority.
 3. **Credential isolation**: platform credentials (tokens, secrets) must reside in the gateway, not in OAB. OAB must not hold or access platform-specific authentication material.
 4. **Adapter interface compliance**: all gateway adapters must implement `validate`, `parse`, `send`, and `health`. Adapters that skip signature validation must be explicitly flagged as insecure.
 5. **Webhook correctness**: all adapters must validate signatures against exact raw request body bytes, per the constraints defined in [ADR: LINE Adapter](./line-adapter.md) Compliance #1.

--- a/docs/adr/gateway-capabilities-and-delivery-semantics.md
+++ b/docs/adr/gateway-capabilities-and-delivery-semantics.md
@@ -1,0 +1,241 @@
+# ADR: Gateway Capabilities and Delivery Semantics
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Author:** @NeoHsu
+- **Related:**
+  - [Custom Gateway](custom-gateway.md)
+  - [Unified Binary](unified-binary.md)
+  - [Multi-Platform Adapters](multi-platform-adapters.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+  - [Teams message reactions preview](teams-message-reactions-preview.md)
+
+---
+
+## Context
+
+OpenAB has two paths for webhook-based chat platforms:
+
+1. **Unified:** platform adapters and Core run in one process.
+2. **Standalone:** Core connects to `openab-gateway` through `/ws`.
+
+Before this decision, Core inferred behavior from adapter-wide methods and platform-name allowlists. That caused three classes of error:
+
+- a shared Unified adapter could apply Telegram streaming settings to Teams;
+- Standalone Core could not know whether a Gateway acknowledged send, edit, or delete operations;
+- a transport timeout could not be distinguished from an explicit platform rejection.
+
+The Standalone event channel is a bounded in-process broadcast channel. It has no durable inbox, replay, shared deduplication store, or consumer-group semantics. Multiple Core consumers therefore receive duplicate events rather than distributed work.
+
+## Decision
+
+### 1. Proposed baseline product decisions
+
+The following decisions define this proposed single-process baseline:
+
+| ID | Decision |
+| --- | --- |
+| D1 | The baseline supports one process replica and one active Standalone Core consumer per platform. Ingress after local enqueue is best-effort; there is no crash replay or exactly-once claim. A second consumer is warned at high severity and reported as unsupported, but is not rejected in this backward-compatible release. |
+| D2 | Standalone uses an optional, client-initiated capability handshake. A peer that does not complete a supported handshake remains in legacy mode; missing ACKs are not delivery failures in legacy mode. |
+| D3 | `GatewayEvent.event_id` is correlation metadata, never a platform activity ID. New↔new create/send returns the real platform message ID. Teams client presentation is outside transport acknowledgement semantics. |
+| D4 | Teams supports Microsoft commercial public cloud only. Sovereign-cloud and custom-proxy endpoints require an explicit future cloud profile. |
+| D5 | User-visible status and content streaming are independent capabilities. Teams processing status must not reuse a streaming placeholder implicitly. |
+
+### 2. Platform-aware capability contract
+
+Each adapter exposes capabilities for the actual `ChannelRef.platform`:
+
+```rust
+struct AdapterCapabilities {
+    send_ack: bool,
+    edit_ack: bool,
+    delete_ack: bool,
+    supports_target_message_id: bool,
+    supports_reactions: bool,
+    can_edit: bool,
+    can_delete: bool,
+    streaming_mode: StreamingMode,
+    show_streaming_placeholder: bool,
+    message_limit: MessageLimit,
+    status_backend: StatusBackend,
+}
+```
+
+Capability defaults fail closed:
+
+- no required ACK;
+- no additive command-target field or native reaction support;
+- no edit or delete support;
+- streaming disabled;
+- status side effects disabled;
+- a conservative 4,096-character message limit.
+
+Direct adapters derive a backward-compatible capability view from their existing methods. Unified and Standalone shared adapters override it by platform.
+
+A valid negotiated hello is authoritative. If a platform is omitted from a valid hello, Core uses fail-closed defaults rather than optimistic legacy behavior. Legacy behavior is used only before a supported hello is accepted.
+
+### 3. Optional Standalone hello exchange
+
+Core sends this additive control frame immediately after connecting:
+
+```json
+{
+  "schema": "openab.gateway.client_hello.v1",
+  "protocol_version": 1,
+  "client_name": "openab-core/<version>",
+  "requested_platforms": ["teams"]
+}
+```
+
+A new Gateway responds:
+
+```json
+{
+  "schema": "openab.gateway.hello.v1",
+  "protocol_version": 1,
+  "capabilities": {
+    "teams": {
+      "send_ack": true,
+      "edit_ack": true,
+      "delete_ack": true,
+      "supports_target_message_id": true,
+      "supports_reactions": false,
+      "can_edit": true,
+      "can_delete": true,
+      "streaming_mode": "disabled",
+      "show_streaming_placeholder": true,
+      "message_limit": { "unit": "characters", "max": 4096 },
+      "status_backend": "none"
+    }
+  },
+  "topology": {
+    "active_consumers": 1,
+    "supported": true,
+    "delivery_mode": "best_effort_broadcast"
+  }
+}
+```
+
+Rules:
+
+- unknown JSON fields are additive and may be ignored;
+- an empty `requested_platforms` list requests all configured adapters; the stock Core uses this because one Standalone socket can carry events from several platforms;
+- protocol version mismatch, malformed hello, or no hello keeps Core in legacy mode;
+- Gateway continues to accept `openab.gateway.reply.v1` as the first frame, so an old Core works with a new Gateway;
+- a new Core may send `client_hello` to an old Gateway; the old Gateway may log it as an invalid reply but must keep the connection usable;
+- operations emitted before a valid hello is processed use legacy semantics;
+- control frames are prioritized over broadcast events once received.
+
+Recommended Standalone rollout order remains Gateway first, then Core, but either side may be upgraded first.
+
+### 4. Structured write outcome
+
+Gateway keeps the existing `openab.gateway.response.v1` fields and adds optional fields:
+
+- `outcome`: `delivered`, `rejected`, or `unknown`;
+- `error_code`;
+- `retry_after_ms`.
+
+The internal result is:
+
+```rust
+enum WriteOutcome {
+    Delivered { message_id: Option<String> },
+    Rejected {
+        code: String,
+        message: String,
+        retry_after_ms: Option<u64>,
+    },
+    Unknown { code: String, message: String },
+}
+```
+
+Semantics:
+
+- create/send delivery requires a non-empty real message ID when that operation advertises required ACK support;
+- edit/delete delivery does not require a message ID in its ACK;
+- explicit platform refusal is `Rejected`;
+- an ambiguous POST timeout or disconnect is `Unknown` and must not be retried blindly;
+- legacy responses without `outcome` map from the existing `success`, `message_id`, and `error` fields;
+- Core waits only for an operation whose capability advertises the corresponding ACK;
+- Teams advertises `send_ack = true` only after its event-route send path emits a terminal structured response with a non-empty Bot Framework activity ID on delivery;
+- Teams advertises edit/delete ACK and `supports_target_message_id` only after bot-owned mutation enforcement emits a terminal response on every command path;
+- Teams advertises `supports_reactions = true` and `status_backend = reactions` only under the explicit public-preview `reactions_enabled` opt-in; the default remains false/`none`;
+- `supports_reactions` is independent from the selected progress backend so permanent batch receipts can coexist with a processing message; new Core normalizes an old peer's `status_backend = reactions` to reaction support;
+- configured Teams processing messages are selected Core-side only after a valid hello advertises required send/edit/delete ACKs, additive command targets, and bot-owned edit/delete; no valid hello means no message status;
+- negotiated required ACK timeout defaults to 12 seconds and is configurable as `[gateway].gateway_ack_timeout_secs`;
+- configuration rejects zero, a budget at or above `pool.prompt_hard_timeout_secs`, and a Teams budget at or below the 10-second Connector timeout;
+- legacy response waits preserve their previous best-effort behavior.
+
+The 12-second Gateway budget must remain greater than the Teams Bot Connector request timeout (10 seconds) and less than the ACP turn hard timeout.
+
+### 5. Topology guardrail
+
+Each Gateway process counts active `/ws` Core consumers:
+
+- one consumer: `topology.supported = true`;
+- more than one: emit an error-level log and return `topology.supported = false` with `delivery_mode = "best_effort_broadcast"`;
+- disconnect decrements the count through a drop guard, including task cancellation paths.
+
+This detects unsupported fan-out inside one Gateway process. It cannot detect multiple independent Gateway replicas because the baseline deliberately has no shared state. The Helm deployments therefore remain fixed at `replicas: 1` with `Recreate` strategy. External deployments must follow the same constraint.
+
+Rejecting the second consumer would be a breaking change and is deferred.
+
+## Compatibility Matrix
+
+| Core | Gateway | Behavior |
+| --- | --- | --- |
+| old | old | Existing protocol and fire-and-forget behavior. |
+| old | new | Gateway accepts a reply without hello; additive response fields are ignored. |
+| new | old | Core sends optional hello, receives none, and stays in legacy mode; missing ACK is not failure. |
+| new | new | Valid hello enables platform-aware capabilities, operation-specific required ACKs, structured outcomes, and topology reporting. |
+
+## Security and Reliability Boundaries
+
+- Capability negotiation is not authentication or authorization. Existing WebSocket token, platform webhook authentication, tenant checks, L2 scope, and L3 identity gates remain authoritative.
+- Hello frames contain no platform credentials, service URLs, route records, or user identifiers.
+- Advertising a capability does not make an operation safe by itself; the adapter must emit the corresponding ACK on every terminal path before the flag is enabled.
+- `Unknown` preserves ambiguity instead of creating duplicates through automatic retry.
+- This baseline does not claim durable enqueue, replay, duplicate-safe multi-consumer operation, or exactly-once delivery.
+
+## Consequences
+
+### Positive
+
+- Teams no longer inherits generic Gateway or Telegram streaming/status behavior; reaction availability, processing-message selection, and progressive content each require their own explicit opt-in and capability gate.
+- Core no longer needs write-path platform allowlists such as `EDIT_RESPONSE_PLATFORMS`.
+- New platform features can be introduced additively without forcing a lockstep Core/Gateway deployment.
+- Operators and Core can identify unsupported multi-consumer topology.
+- Delivery uncertainty is represented explicitly and can be handled without unsafe retry.
+
+### Negative
+
+- Capability DTOs are mirrored in Core and Gateway and require wire-compatibility tests.
+- The first operation may use legacy behavior if it races ahead of hello processing.
+- Existing adapters that cannot return a stable message ID must advertise conservative send-once behavior until their delivery path is upgraded.
+- Cross-replica topology remains undetectable without a shared coordination system.
+
+## Alternatives Rejected
+
+1. **Platform-name allowlists in Core.** Rejected because they drift whenever an adapter changes behavior and cannot represent deployment-specific support.
+2. **Mandatory hello before accepting replies.** Rejected because it breaks old Core deployments during rolling upgrade.
+3. **Treat every timeout as rejection.** Rejected because the platform may have committed an ambiguous POST.
+4. **Retry ambiguous POST automatically.** Rejected because it can duplicate user-visible activities.
+5. **Reject the second consumer immediately.** Deferred because this is a breaking operational change.
+6. **Claim HA from multiple broadcast consumers.** Rejected because broadcast fan-out is not work distribution and has no shared idempotency state.
+
+## Verification
+
+Automated verification must cover:
+
+- capability DTO defaults and wire round trips;
+- all three structured outcomes plus legacy response decoding;
+- old Core→new Gateway reply without hello;
+- new Core→old Gateway legacy fallback;
+- new↔new capability selection;
+- requested-platform filtering;
+- second-consumer unsupported topology and disconnect decrement;
+- Unified Teams isolation from Telegram streaming settings;
+- additive reaction-support decoding and processing-message fail-closed capability selection;
+- Teams progressive-response selection only under explicit opt-in plus every required write primitive, in Standalone and Unified modes;
+- configurable 12-second ACK default.

--- a/docs/adr/teams-attachment-ingress.md
+++ b/docs/adr/teams-attachment-ingress.md
@@ -1,0 +1,305 @@
+# ADR: Teams Metadata-First Attachment Ingress
+
+- **Status:** Proposed
+- **Date:** 2026-08-09
+- **Author:** @NeoHsu
+- **Related:**
+  - [Inbound attachments](../inbound-attachments.md)
+  - [Custom Gateway](custom-gateway.md)
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Teams typed scope and mention routing](teams-typed-scope-and-mention-routing.md)
+  - [Microsoft: Send and receive files](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4)
+
+---
+
+## Context
+
+Teams message activities can carry inline images and, in Personal chats with a
+separate `supportsFiles = true` manifest profile,
+`application/vnd.microsoft.teams.file.download.info` attachments. Microsoft
+states that file-consent APIs support Personal context only; wider file support
+requires Microsoft Graph. This proposal remains Graph-free, so it supports only
+inline images and Personal image or UTF-8 text files.
+
+The existing Gateway attachment envelope can carry base64 bytes or a local
+path. Neither existing delivery mode is sufficient as the Teams security
+contract:
+
+- Gateway receives Microsoft credentials and download URLs, but it does not own
+  Core's configured L2 scope and L3 identity decision.
+- Core owns the authoritative trust gate, but Microsoft credentials and URLs
+  must not cross into Core or the ACP child.
+- A Gateway-local path is invalid when Standalone Gateway and Core use separate
+  filesystems.
+- Downloading before the Core gate would let an authenticated but untrusted
+  sender consume network, memory, and image-processing resources.
+
+The attachment-ingress design therefore needs a two-phase contract that works
+identically in Unified and Standalone deployments while preserving default-off behavior and
+rolling compatibility.
+
+## Decision
+
+### Choose metadata-first materialization
+
+Use metadata-first materialization: Gateway publishes bounded attachment
+metadata plus an opaque reference, and Core asks Gateway to materialize that
+reference only after the shared trust gate returns Allow.
+
+Do not copy Core trust configuration into Gateway. A duplicated evaluator would
+create two policy authorities and could drift across rolling upgrades. The
+existing Core gate remains the sole L2/L3 decision point.
+
+The flow is:
+
+```text
+Microsoft activity
+  -> Gateway validates JWT, tenant, route fields, and service URL
+  -> Gateway stores URL/auth metadata only in the bounded process-local route
+  -> GatewayEvent carries filename/MIME/declared size + opaque reference
+  -> Core runs structural filter, typed L2, and shared L3
+  -> Deny: no materialization command and no download
+  -> Allow: Core requests each reference sequentially
+  -> Gateway validates event/route/reference ownership, then downloads
+  -> Gateway returns bounded normalized attachment bytes or rejected metadata
+  -> Core converts the result to ACP ContentBlocks before dispatcher admission
+```
+
+No ACP session, processing indicator, streaming placeholder, or proactive
+promotion begins before materialization completes.
+
+### Additive v1 wire fields and capability
+
+Keep the existing schema and protocol version. Add only optional fields:
+
+- `Attachment.reference`: opaque Gateway-generated materialization reference;
+- `GatewayReply.attachment_ref`: requested opaque reference;
+- `GatewayResponse.attachment`: one normalized attachment result; and
+- `AdapterCapabilities.supports_attachment_materialization`: fail-closed
+  operation capability.
+
+The operation is `command = "materialize_attachment"`. It always carries a
+non-empty `request_id`; Core sends it only after a valid hello explicitly
+advertises the capability. Unknown or legacy peers are never probed
+optimistically.
+
+`reply_to` remains the authenticated Gateway event correlation, and
+`channel.id` remains the conversation correlation. Gateway must validate both
+against the process-local route before resolving `attachment_ref`. A reference
+is random, contains no URL or platform ID, is scoped to one event, and expires
+with that event's route. It is not promoted to proactive state and does not
+survive restart or replica changes.
+
+Core makes at most one materialization request per reference in a turn and does
+not automatically retry timeout, disconnect, malformed response, or rejection.
+A download is read-only at Microsoft, but unbounded retry would still amplify
+attacker-controlled resource use.
+
+### One bounded base64 response for both deployment modes
+
+Both Standalone and Unified return normalized bytes in
+`GatewayResponse.attachment.data` as bounded base64. Unified deliberately uses
+the same logical transport instead of a Gateway-local path so both modes share
+validation, limits, failure behavior, and tests.
+
+Existing `Attachment.path` remains available to other colocated adapters; Teams
+attachment ingress neither emits nor accepts a path. This prevents a Standalone
+Gateway path from being interpreted in the Core container.
+
+The materialized response must fit the explicit internal WebSocket frame cap.
+Core rejects an oversized response before JSON or base64 processing. The URL,
+query, OAuth token, and raw Microsoft attachment object never enter the event,
+response, Core log, agent prompt, or ACP child environment.
+
+### Explicit opt-in
+
+Add one first-class Teams setting:
+
+```toml
+[teams]
+inbound_attachments = false
+```
+
+The environment fallback is `TEAMS_INBOUND_ATTACHMENTS`. Only `true`, `false`,
+`1`, and `0` are accepted; malformed values fail closed to `false`. The default
+remains disabled.
+
+When disabled, Teams text behavior is unchanged and attachment metadata is
+ignored. An attachment-only activity creates no Core turn. Enabling the setting
+still requires the negotiated materialization capability.
+
+### Supported Microsoft attachment forms
+
+This proposal supports:
+
+1. **Inline images in Personal, groupChat, and channel scopes**
+   - declared MIME must be `image/*`;
+   - `contentUrl` remains Gateway-local;
+   - downloaded bytes must decode as an accepted image;
+   - images are resized to at most 1200 pixels on the longest side and encoded
+     as JPEG, except bounded GIF passthrough.
+
+2. **Personal `file.download.info` attachments**
+   - conversation type must be Personal;
+   - the app uses a separate manifest profile with `supportsFiles = true`;
+   - image extensions use the image pipeline;
+   - the existing text-extension whitelist is accepted only with strict UTF-8;
+   - the preauthenticated `downloadUrl` is fetched without the Bot bearer
+     token.
+
+3. **Attachment-only events**
+   - empty text is accepted only when at least one bounded attachment metadata
+     entry exists;
+   - the turn proceeds only if materialization produces a usable content block
+     or a rejected-attachment system block.
+
+Adaptive Cards, file-info cards sent by the bot, audio, video, PDF, archives,
+Office binaries, non-UTF-8 text, and channel/groupChat paperclip files are not
+materialized. They become `Attachment::rejected` metadata after trust, rather
+than being silently reclassified or downloaded.
+
+### URL, redirect, and credential policy
+
+Every attachment request uses a dedicated manual-redirect downloader:
+
+- HTTPS only in production, port 443, no userinfo or fragment;
+- URL query is permitted because Microsoft download URLs can be
+  preauthenticated, but it is always redacted;
+- IP literals, loopback, link-local, private destinations, and arbitrary
+  operator-provided hosts are rejected;
+- inline-image `contentUrl` is bound to the validated Bot Connector public-cloud
+  origin;
+- Personal file URLs and every redirect hop must match the compiled Microsoft
+  commercial-cloud file-host profile;
+- each redirect is resolved and revalidated before the next request;
+- the Bot bearer token is attached only to an inline-image request and is never
+  forwarded across an origin change;
+- Personal `downloadUrl` requests never receive the Bot bearer token; and
+- error messages contain operation class and rejection category, never URL,
+  query, token, tenant, conversation, activity, or opaque-reference values.
+
+The commercial public-cloud profile does not add a user-configurable host
+allowlist. New Microsoft cloud profiles or observed official hosts require a
+reviewed policy update.
+
+### Resource limits
+
+| Control | Limit |
+| --- | ---: |
+| Metadata entries examined | 10 per activity |
+| Opaque references retained | 10 per accepted route |
+| Inline image raw download | 10 MiB |
+| Personal text file | 512 KiB |
+| Aggregate raw download budget | 20 MiB per event |
+| GIF passthrough | 5 MiB |
+| Materialized response / WS text frame | 8 MiB |
+| Redirect hops | 4 |
+| Individual HTTP request | existing Teams request timeout |
+| Whole materialization batch | 45 seconds |
+| Filename after sanitization | 200 Unicode scalars |
+
+`Content-Length`, when present, is checked before reading but never trusted as
+the only bound. Bodies are streamed and stopped before appending bytes past the
+remaining per-file or per-event budget. Declared size, actual raw size, output
+size, MIME, image decoding, text extension, and UTF-8 are validated
+independently.
+
+Materialization is sequential per event. Existing per-event route capacity,
+TTL, dedupe, and one-consumer topology remain in force.
+
+### Rejection behavior
+
+A metadata or materialization failure returns `Attachment::rejected` with a
+stable category and sanitized detail:
+
+- `size exceeded`;
+- `unsupported format`;
+- `download failed`;
+- `processing failed`;
+- `invalid content`;
+- `security rejected`; or
+- `configuration error`.
+
+A rejected attachment has empty `data`, no `path`, and no reusable reference.
+Core surfaces the rejected metadata as a system content block only after Allow.
+One failed attachment does not discard usable text or another valid attachment.
+
+Protocol-level failures such as missing capability, unknown reference, expired
+route, cross-conversation request, oversized frame, or malformed base64 also
+fail closed and never trigger a second download.
+
+### Rolling compatibility
+
+| Core | Gateway | Result when configured |
+| --- | --- | --- |
+| old | new | Text behavior unchanged; unknown references are ignored and no download occurs. |
+| new | old or no valid hello | Attachments disabled because materialization capability is absent. |
+| new | new with valid capability | Metadata is materialized only after Core Allow. |
+| Unified | embedded new adapter | Uses the same reference, limits, and normalized response contract. |
+
+A new Gateway may publish metadata references before a client hello because
+this has no external side effect. Only a new, capability-aware Core can issue
+the materialization command. An old Core drops attachment-only metadata and
+continues processing text exactly as before.
+
+## Security and reliability boundaries
+
+- JWT and tenant validation remain L1 at Gateway.
+- Core typed L2 and shared L3 remain authoritative and precede download.
+- Attachment URLs and Microsoft credentials stay Gateway-local.
+- Opaque references are process-local capabilities, not bearer URLs.
+- The internal WebSocket token still authenticates Core-to-Gateway commands.
+- Route expiry, restart, replica change, malformed reference, and conversation
+  mismatch fail closed.
+- No Graph, RSC, delegated token, durable attachment queue, replay, or
+  exactly-once download is introduced.
+- Microsoft commercial public cloud remains the only supported cloud profile.
+
+## Manifest profiles
+
+The base manifest keeps:
+
+```json
+"supportsFiles": false
+```
+
+Operators enabling Personal paperclip files use a separate reviewed profile
+with `supportsFiles = true`. Inline images do not require this manifest opt-in.
+The profile adds no Microsoft Graph or RSC permission.
+
+## Acceptance criteria
+
+Automated verification must prove:
+
+- default off and malformed environment fail closed;
+- no download command before structural, L2, and L3 Allow;
+- denied text-plus-attachment and attachment-only events cause zero download;
+- missing capability and old peers cause zero download;
+- opaque reference event/conversation/TTL enforcement;
+- URL and every redirect hop are validated without leaking URL or token;
+- strict streamed limits, image decode, text extension, and UTF-8;
+- unsupported and failed attachments become sanitized rejected metadata;
+- attachment-only dispatch after one successful or rejected materialization;
+- Standalone and Unified produce equivalent content blocks;
+- response and WebSocket frame ceilings; and
+- no path crosses a non-shared deployment boundary.
+
+## Consequences
+
+### Positive
+
+- Trust-before-fetch is enforced by one authoritative Core policy.
+- Gateway retains Microsoft credentials and sensitive URLs.
+- Standalone no longer depends on an accidental shared filesystem.
+- Additive capability negotiation keeps rolling upgrades fail closed.
+- Unified and Standalone share observable behavior and limits.
+
+### Negative
+
+- Materialization adds one internal request/response per attachment.
+- Base64 adds bounded memory and approximately one-third encoding overhead.
+- Attachment-only turns wait for materialization before showing progress.
+- Route-local references are intentionally lost on restart or expiry.
+- Strict Microsoft host policy may reject a newly introduced official host until
+  the profile is reviewed and updated.

--- a/docs/adr/teams-ephemeral-ingress-state.md
+++ b/docs/adr/teams-ephemeral-ingress-state.md
@@ -1,0 +1,151 @@
+# ADR: Teams Ephemeral Ingress Route and Duplicate Suppression
+
+- **Status:** Proposed
+- **Date:** 2026-08-07
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Custom Gateway](custom-gateway.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+
+---
+
+## Context
+
+Bot Framework may retry the same webhook activity. Before this decision, the
+Teams adapter published every authenticated retry, keyed reply routing only by
+conversation ID, accepted messages with missing routing identifiers, and
+ignored the result of the local Gateway broadcast. An HTTP 200 could therefore
+mean that no Core consumer received the event.
+
+The proposed delivery boundary remains deliberately narrow:
+
+- one Gateway process replica;
+- one supported Standalone Core consumer;
+- process-local state only;
+- no crash replay, durable inbox, shared idempotency store, or exactly-once
+  claim.
+
+## Decision
+
+### Required message fields
+
+A message activity proceeds only when it contains non-empty values for:
+
+- Bot Framework channel ID;
+- tenant ID;
+- conversation ID;
+- activity ID;
+- sender ID;
+- service URL.
+
+Structural presence is checked before JWT key lookup; route and dedupe state are
+created only after JWT and tenant authorization. The service URL must also pass
+the Microsoft commercial public-cloud endpoint policy. Invalid or missing
+fields return HTTP 400 and do not create route or dedupe state. Non-message and
+structurally valid empty-text activities retain their existing HTTP 200 ignore
+behavior.
+
+The adapter also parses optional Bot Framework `replyToId`, Team ID, and channel
+ID into gateway-local route state. These values are not sent to the agent.
+
+### Composite identity
+
+Both route correlation and duplicate suppression use the composite identity:
+
+```text
+(app_id, tenant_id, conversation_id, activity_id)
+```
+
+This prevents an activity ID collision from crossing applications, tenants, or
+conversations. A generated `GatewayEvent.event_id` is a separate correlation
+index for the future outbound route lookup. It is never a Bot Framework
+activity ID.
+
+### Publication state machine
+
+Each composite key follows:
+
+```text
+Vacant -> Publishing -> Accepted
+             |
+             +-> local publish failure -> Vacant
+```
+
+The first request owns publication. A concurrent duplicate that observes
+`Publishing` waits on the same in-process completion signal. It returns HTTP
+200 only if the owner reaches `Accepted`; otherwise it returns HTTP 503.
+
+An `Accepted` duplicate returns HTTP 200 without publishing another
+`GatewayEvent`. A failed local broadcast removes the publishing entry before
+returning HTTP 503, so a later Bot Framework retry may publish again.
+
+The Gateway checks the result of `broadcast::Sender::send` rather than a
+separate receiver-count preflight, avoiding a check-then-send race. A successful
+local broadcast is the process-local acknowledgement boundary; it does not prove ACP or
+outbound completion.
+
+### Bounded process-local state
+
+Three positive settings control state:
+
+| Setting | Default | Purpose |
+| --- | ---: | --- |
+| `teams.dedupe_ttl_secs` | 600 | Accepted duplicate suppression window |
+| `teams.route_ttl_secs` | 3600 | Authenticated ephemeral route lifetime |
+| `teams.max_route_entries` | 10000 | Independent capacity bound for route and dedupe maps; bot-owned mutation state uses the same independent bound |
+
+Equivalent Standalone environment variables are
+`TEAMS_DEDUPE_TTL_SECS`, `TEAMS_ROUTE_TTL_SECS`, and
+`TEAMS_MAX_ROUTE_ENTRIES`.
+
+Expired entries are removed during reservation and by a shared background
+sweeper used in both Standalone and Unified mode. At capacity, the oldest
+accepted dedupe entry or route may be evicted with a warning. Active
+`Publishing` entries are never evicted to admit another key; saturation returns
+HTTP 503. A stale publishing owner is failed after a bounded internal timeout so
+waiters cannot remain blocked indefinitely.
+
+The initial route implementation retained the legacy conversation-to-service-URL
+cache for the existing outbound path. The real-send implementation removed that
+compatibility cache: outbound sends
+now resolve the authenticated route directly by `event_id` and verify the
+reply's conversation before using its gateway-local service URL.
+
+## Security and privacy
+
+- Service URLs remain gateway-local and are excluded from Gateway wire events,
+  agent prompts, response payloads, and logs.
+- Endpoint validation happens before route persistence.
+- Logs may include tenant, conversation, sender, and validated service host,
+  but never the full service URL or app secret.
+- Route state is not promoted to a proactive conversation reference.
+- Duplicate suppression occurs only after JWT and tenant checks; unauthenticated
+  input cannot poison the cache.
+
+## Compatibility
+
+This is a correctness change for malformed or undeliverable Teams webhooks:
+
+| Condition | Previous behavior | New behavior |
+| --- | --- | --- |
+| Missing required route field | Often HTTP 200 | HTTP 400 |
+| Accepted duplicate | Published again | HTTP 200 without republish |
+| No local event consumer | HTTP 200 | HTTP 503, no tombstone |
+| Local publish succeeds | HTTP 200 | HTTP 200 and route accepted |
+
+No Gateway wire field is removed or made mandatory. Unified and Standalone use
+the same adapter state machine. Existing configuration remains valid through
+the documented defaults.
+
+
+## Consequences
+
+- Duplicate suppression does not survive restart and does not span replicas.
+- Capacity eviction may shorten the effective dedupe window under sustained
+  overload; warnings make this visible.
+- A successful broadcast can still be lost after process failure or consumer
+  lag. Durable delivery requires a later inbox/outbox design.
+- [Real send acknowledgement](teams-real-send-acknowledgement.md) uses this
+  route for real activity IDs and outbound correlation.

--- a/docs/adr/teams-formatting-and-long-messages.md
+++ b/docs/adr/teams-formatting-and-long-messages.md
@@ -1,0 +1,284 @@
+# ADR: Teams Budget-Aware Formatting and Ordered Long Messages
+
+- **Status:** Proposed
+- **Date:** 2026-08-10
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams progressive edit response](teams-progressive-response.md)
+  - [Multi-platform adapters](multi-platform-adapters.md)
+
+---
+
+## Context
+
+At the initial long-message design baseline, OpenAB advertised Teams with a conservative
+4,096-character message limit. Core converted every negotiated non-character
+`MessageLimit` into an even smaller character count before calling
+`format::split_message`. This was a safe
+compatibility default, but it does not model the Teams platform contract:
+
+- Microsoft documents an approximate 100 KB agent-message limit;
+- the size includes message text, image links, mentions, and reactions encoded
+  as UTF-16, but excludes base64-encoded images;
+- Microsoft recommends keeping the message itself within 80 KB for reliable
+  delivery; and
+- an oversized message returns HTTP 413 with `MessageSizeTooBig`.
+
+The existing capability schema already has additive `characters`, `bytes`,
+`utf16_bytes`, and `unlimited` variants. The missing work is exact budget-aware
+splitting and a Teams capability value that reflects the documented unit.
+
+Teams receives OpenAB content as text-only Bot Framework activities with
+`textFormat = markdown`. Microsoft documents only a subset of Markdown and
+states that text-only messages do not support tables. Rich cards likewise do
+not add Markdown-table support. OpenAB already has a table pre-pass whose default `code` mode converts a
+Markdown table to an aligned fenced block before message splitting, but at that
+baseline the Teams setup guide recommended bypassing the fallback with
+`tables = "off"`.
+
+Long-message delivery also has two different safety levels. Structured Teams
+progressive finalization already waits for each required ACK, sends overflow in
+order, and stops on the first rejected or unknown write. The ordinary
+send-once branch awaits each `Result`, but continues with later chunks after an
+earlier failure. That can show a suffix without the missing middle and does not
+report a precise partial-delivery boundary.
+
+## Decision
+
+### 1. Teams advertises an exact UTF-16 byte budget
+
+The Teams capability in both Standalone Gateway hello and Unified mode will be:
+
+```text
+MessageLimit::Utf16Bytes { max: 80_000 }
+```
+
+`80_000` is deliberately decimal, not `80 * 1024`. It follows Microsoft's
+recommended 80 KB implementation target rather than treating the approximate
+100 KB rejection threshold as a guaranteed text allowance.
+
+For this limit, Core measures a string as:
+
+```text
+utf16_bytes(text) = 2 * text.encode_utf16().count()
+```
+
+A BMP scalar therefore costs two bytes and a supplementary-plane scalar costs
+four. The limit is not a Unicode-scalar, grapheme, UTF-8-byte, or display-column
+count. Table rendering and final display composition happen before the budget
+is applied, so their expanded output is included.
+
+OpenAB's current Teams content activity does not emit outbound mention entities,
+cards, or inline base64 images. If those fields are added later, their encoded
+size must receive an explicit reserve or a lower text budget before they share
+this capability. This proposal does not infer authenticated mentions from plain
+text.
+
+### 2. Core gains one budget-aware splitter
+
+Keep `format::split_message(text, character_limit)` as the compatibility wrapper
+for existing direct callers. Add an internal splitter driven by the negotiated
+`MessageLimit` with these unit definitions:
+
+| Limit | Measurement |
+| --- | --- |
+| `characters` | Unicode scalar count, preserving current behavior |
+| `bytes` | UTF-8 byte length |
+| `utf16_bytes` | UTF-16 code units multiplied by two |
+| `unlimited` | One unchanged chunk |
+
+The splitter must preserve the existing structural behavior:
+
+- prefer newline boundaries, then whitespace boundaries;
+- preserve valid UTF-8;
+- keep an extended grapheme cluster together whenever that cluster fits in an
+  empty chunk;
+- if one grapheme is larger than the budget, fall back only to Unicode-scalar
+  boundaries; and
+- fail before any final-content write if even one scalar cannot fit the
+  advertised non-zero budget.
+
+Fenced code blocks remain balanced independently in every chunk. The complete
+opener, including its language tag, is repeated after a split; synthetic close
+and reopen markers are included in the selected unit's budget. A zero limit or
+an otherwise unsplittable non-empty value is an error, not an infinite loop,
+truncation, invalid UTF-8, or oversized final-content write. A streaming turn
+may already own its acknowledged placeholder; that existing activity follows
+the [progressive-response failure lifecycle](teams-progressive-response.md) and
+is never converted into a blind fresh send.
+
+The 1.5-second cosmetic Teams edit path may retain its existing conservative
+character preview. Authoritative final PUT/POST chunks use the exact negotiated
+budget. This keeps intermediate writes safely below the limit without widening
+this proposal into a streaming-preview redesign.
+
+### 3. Markdown remains text-only and tables use the existing fallback
+
+Teams outbound activities continue to set `textFormat = markdown`. This
+proposal does not create Adaptive Cards or rich cards.
+
+OpenAB preserves the agent's Markdown source except for the existing configured
+table conversion:
+
+- `tables = "code"` remains the default and recommended Teams setting;
+- `tables = "bullets"` remains an accessibility-oriented fallback;
+- `tables = "off"` remains an explicit operator bypass, but raw Markdown tables
+  are not claimed to render as tables in Teams; and
+- Teams continues to report `renders_native_tables = false` in both deployment
+  modes.
+
+The Teams setup documentation will stop recommending `tables = "off"`.
+Mention-looking text and Markdown links are not rewritten, dropped, or copied
+into later chunks; an individual token longer than the whole budget may still
+be split at a valid Unicode boundary. Existing Discord mention-footer
+propagation is unchanged and is not applied to Teams. Headings, lists,
+strikethrough, and other Markdown remain subject to Microsoft's published
+desktop/iOS/Android support differences. This proposal does not rewrite them
+into a new rich-message schema or claim identical presentation across clients.
+
+### 4. Required-ACK chunk delivery is sequential and terminal
+
+Core builds the complete final chunk list before the first platform write. When
+the resolved capability requires send ACKs, every POST is delivered through an
+outcome-preserving method and the sequence obeys:
+
+1. Send chunk `N` only after chunk `N - 1` is `Delivered`.
+2. A delivered POST requires a non-empty real activity ID.
+3. Stop at the first `Rejected` or `Unknown`; never skip it and send a suffix.
+4. Never retry a rejected or unknown POST in Core. In particular, the existing
+   Teams rule that records a 429 `Retry-After` without retrying POST remains
+   unchanged.
+5. An `Unknown` terminal outcome suppresses retry, fresh-send, cleanup, and the
+   router's warning activity because the selected chunk may have committed.
+6. A `Rejected` terminal outcome may use the existing single warning route,
+   because rejection is explicit, but it does not resume the chunk sequence.
+
+The delivery result records, without message content or activity IDs:
+
+- total chunk count;
+- number known delivered;
+- zero-based failed chunk index; and
+- terminal outcome kind and sanitized code.
+
+If at least one earlier chunk was delivered, the error is explicitly classified
+as partial delivery. Already-delivered activities are not deleted or edited in
+an attempted rollback. Processing status and reaction progress become failed,
+and status is cleared only after every final chunk is delivered.
+
+This rule applies to ordinary send-once, explicit-reply-first, progressive
+overflow, and rejected-placeholder recovery paths when required send ACK is
+available. Existing progressive helpers already implement the ordering and
+ambiguity rules; this proposal unifies the send-once branch with that behavior
+rather than adding a second Teams-specific retry loop.
+
+### 5. Rolling compatibility remains fail closed
+
+| Core | Gateway | Result |
+| --- | --- | --- |
+| old Core without hello | new Gateway | Legacy behavior; Gateway accepts the first reply and sends no unsolicited control requirement. |
+| capability-aware old Core | new Gateway | Decodes the existing `utf16_bytes` variant and uses its conservative quarter-size character bound; still safe, but not exact. |
+| new Core | old Gateway or no valid hello | Existing `characters = 4096` legacy limit and legacy delivery semantics. |
+| new Core | new Gateway | Exact 80,000 UTF-16-byte split plus required-ACK ordered delivery. |
+| new Unified | embedded Teams adapter | Same exact budget and delivery semantics as new↔new Standalone. |
+
+A valid hello remains authoritative. Missing Teams capabilities in a valid hello
+do not fall back optimistically. Protocol version stays v1 because the
+`utf16_bytes` wire variant was already additive before this proposal.
+
+### 6. Observability is content-free
+
+One finalization summary may record platform, total chunks, delivered chunks,
+failed index, outcome kind, and sanitized error code. It must not log message
+content, activity IDs, conversation IDs, request IDs, URLs, tokens, or serialized
+Connector bodies.
+
+A Microsoft HTTP 413 remains `Rejected / message_too_large`. It is evidence that
+the conservative target was insufficient for that activity shape, not a reason
+to retry the same body or silently change the limit during the turn.
+
+## Security and reliability boundaries
+
+- Trust admission, route ownership, tenant/conversation checks, and write
+  serialization are unchanged.
+- No Graph, RSC, delegated token, Adaptive Card permission, or manifest
+  permission is added.
+- POST `Unknown` is never retried or converted into a fresh warning activity.
+- Partial delivery is not transactional; delivered prefix activities may remain
+  when a later chunk fails.
+- The feature does not claim exactly-once delivery, crash replay, durable
+  ownership, or multi-consumer work distribution.
+- Microsoft commercial public cloud remains the only supported Teams profile.
+
+## Acceptance criteria
+
+Automated verification must cover:
+
+- exact character, UTF-8-byte, UTF-16-byte, and unlimited measurements;
+- BMP, CJK, supplementary emoji, combining marks, ZWJ sequences, and mixed text;
+- every emitted chunk fitting its own budget, including synthetic code-fence
+  close/reopen markers and language tags;
+- newline/whitespace preference, order preservation, no truncation, valid UTF-8,
+  and explicit unsplittable-budget failure;
+- Teams Standalone hello and Unified parity advertising
+  `utf16_bytes = 80_000`;
+- new Core→old Gateway/no-hello 4,096-character fallback and decoding by a
+  capability-aware old Core;
+- table conversion before splitting, Teams native-table=false behavior, and the
+  explicit `off` bypass;
+- send-once, explicit reply, progressive overflow, and recovery chunk order;
+- stop-on-first `Rejected` and stop-on-first `Unknown`, with no later chunk;
+- delivered/total/failed-index partial-delivery classification;
+- no warning, delete, retry, or fresh send after an unknown POST;
+- HTTP 413 mapping to `message_too_large`; and
+- no regressions in existing character-based Discord/Slack splitting or Teams
+  progressive ambiguity tests.
+
+## Consequences
+
+### Positive
+
+- Teams uses the platform's documented unit instead of a fictional character
+  limit.
+- ASCII and BMP-heavy long replies require fewer activities while emoji-heavy
+  replies remain correctly bounded.
+- Code fences and table fallbacks are budgeted after rendering.
+- Users never receive a later suffix after a known missing middle chunk.
+- Rolling upgrades remain safe without a protocol bump.
+
+### Negative
+
+- The generic splitter becomes more complex and must carry unit-aware tests.
+- Larger individual activities may take longer to render or edit even though
+  they remain within Microsoft's recommendation.
+- Partial delivery cannot be made atomic with Bot Connector primitives.
+- Cosmetic streaming previews remain more conservative than final messages.
+
+## Alternatives rejected
+
+1. **Keep 4,096 characters permanently.** Safe but knowingly misrepresents the
+   platform, produces unnecessary activities, and leaves the UTF-16 capability
+   unused.
+2. **Advertise 100 KB.** Rejected because Microsoft labels it approximate and
+   recommends an 80 KB implementation target.
+3. **Use 80,000 Unicode scalars.** Rejected because supplementary characters
+   consume twice the UTF-16 bytes of BMP characters.
+4. **Use UTF-8 bytes.** Rejected because it is not the unit Microsoft documents
+   for this limit.
+5. **Split inside Gateway.** Rejected because Core owns final formatting,
+   directive handling, ordered delivery health, and Unified/Standalone parity;
+   Gateway-side splitting would hide per-chunk outcomes from Core.
+6. **Continue after a rejected middle chunk.** Rejected because a suffix without
+   its missing middle is a corrupt user view.
+7. **Retry an unknown POST.** Rejected because it can duplicate an activity that
+   Microsoft already committed.
+8. **Use Adaptive Cards for every answer.** Rejected because cards have different
+   formatting semantics, do not solve Markdown tables, and belong to a later
+   explicitly reviewed feature.
+
+## References
+
+- [Microsoft: Format your agent messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages)
+- [Microsoft: Update and delete messages sent from agent](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages)
+- [OpenAB platform schema: Teams](../platforms/schema/teams.toml)

--- a/docs/adr/teams-message-reactions-preview.md
+++ b/docs/adr/teams-message-reactions-preview.md
@@ -1,0 +1,133 @@
+# ADR: Teams Public-Preview Message Reactions
+
+- **Status:** Proposed
+- **Date:** 2026-08-09
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+
+---
+
+## Context
+
+Microsoft's Teams SDK exposes public-preview add/remove reaction operations on
+the Bot Connector conversation API. They use the authenticated Bot Framework
+`serviceUrl`, conversation ID, activity ID, and bot token already required for
+normal sends. They do not require Microsoft Graph, RSC, a delegated user token,
+or a new manifest permission.
+
+OpenAB previously treated `add_reaction` and `remove_reaction` as successful
+no-ops for Teams. Enabling the preview by default would change existing
+behavior, create new status side effects, and rely on a tenant feature that is
+not yet generally available.
+
+## Decision
+
+### Explicit opt-in
+
+Add this first-class setting:
+
+```toml
+[teams]
+reactions_enabled = false
+```
+
+The environment fallback is `TEAMS_REACTIONS_ENABLED`. Only `true` or `1`
+enables the preview. Missing, false, zero, empty, or invalid values remain
+fail-closed at `false`.
+
+When disabled:
+
+- reaction commands preserve the legacy successful no-op;
+- no route lookup, token request, or Connector write occurs;
+- Teams advertises `status_backend = none` to a negotiated Core.
+
+When enabled, Standalone and Unified advertise `supports_reactions = true`.
+They select `status_backend = reactions` unless Core explicitly selects a
+separate processing-message backend. In that combined mode, reactions provide
+only permanent queued receipts while a turn-local message provides transient
+progress. Streaming remains disabled and reaction support does not enable any
+other Teams capability.
+
+### Bot Connector operations
+
+OpenAB uses the existing Bot Framework token and validated public-cloud
+`serviceUrl`:
+
+```text
+PUT    {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}/reactions/{reactionType}
+DELETE {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}/reactions/{reactionType}
+```
+
+All path values are appended as URL path segments. Empty reaction writes send
+`Content-Length: 0`; the Connector otherwise rejects PUT requests that have
+neither content length nor chunked framing. The
+existing same-origin redirect policy, timeout, bounded error body, token
+redaction, and commercial public-cloud endpoint policy apply unchanged.
+
+Reaction writes share the idempotent PUT/DELETE outcome classifier. HTTP
+success is `Delivered`; explicit 3xx/4xx is `Rejected`; timeout, disconnect, or
+5xx is `Unknown`. An explicit `429` with `Retry-After` no greater than one
+second receives at most one internal retry. A bounded retry emits a warning
+containing only the static operation name and `retry_after_ms`; it does not log
+the Connector URL, conversation, activity ID, or token. There is no
+POST/fresh-send fallback.
+
+### Scope and target trust
+
+A reaction target may be:
+
+- an authenticated inbound activity retained in the process-local route index;
+- the authenticated reply-chain root of the command's origin route; or
+- a confirmed bot-owned activity in the process-local ownership index.
+
+New-field commands require a live origin event route and cannot cross app,
+tenant, or conversation scope. Legacy commands without a separate origin are
+accepted only when app, conversation, and activity resolve to one unique route;
+cross-tenant ambiguity fails closed.
+
+Reaction writes use the same fixed tenant/conversation write shards as sends,
+edits, and deletes, with route state revalidated after lock acquisition.
+
+### Reaction IDs
+
+Core emits Unicode status emoji, while the Connector preview expects Teams
+reaction IDs. OpenAB maps all default status and completion emoji to IDs from
+the Microsoft Teams reactions reference. The generic controller's hard-coded
+soft- and hard-stall states are included: `🥱` maps to
+`1f971_yawningface`, while `😨` maps to the distinct `fearful` ID so a later
+`😱` / `screamingfear` error swap cannot add and remove the same reaction. A
+configured value may also be an ASCII reaction ID containing only letters,
+digits, `_`, or `-`, up to 128 bytes. Unknown Unicode and unsafe identifiers
+are rejected before HTTP.
+
+### Deliberate exclusions
+
+This preview slice does not:
+
+- process inbound `messageReaction` activities;
+- add Graph or RSC permissions;
+- add reaction-specific required ACK negotiation;
+- promise availability outside Microsoft commercial public cloud;
+- make native reactions part of the default processing-indicator contract;
+- persist route evidence across restart or replicas.
+
+
+## Consequences
+
+### Positive
+
+- Operators can test visible Teams reactions without widening Graph authority.
+- Existing deployments remain unchanged until explicit opt-in.
+- Reactions cannot be aimed at arbitrary activity IDs or leak `serviceUrl`.
+- Default OpenAB status emoji work without operator-specific mapping.
+
+### Negative
+
+- Preview availability and rendering remain tenant-dependent.
+- Rapid generic status transitions may encounter the platform's reaction rate
+  limit; bounded retries do not guarantee every cosmetic transition is shown.
+- Inbound user reactions remain ignored until a separate behavior and trust
+  contract is approved.

--- a/docs/adr/teams-operator-cron-delivery.md
+++ b/docs/adr/teams-operator-cron-delivery.md
@@ -1,0 +1,378 @@
+# ADR: Teams Operator Cron over Trusted Persistent Conversations
+
+- **Status:** Proposed
+- **Date:** 2026-08-20
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams trusted persistent conversation registry](teams-trusted-persistent-conversation-registry.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Basic cron scheduler](basic-cronjob.md)
+
+---
+
+## Context
+
+OpenAB's scheduler can dispatch operator-configured prompts through Discord,
+Slack, Telegram, Google Chat, and LINE WORKS adapters. It first posts a visible
+cron trigger, then starts or reuses the ACP session only after that trigger send
+succeeds. Teams is intentionally absent from `VALID_PLATFORMS` and from the cron
+adapter map because ordinary Teams sends require a short-lived inbound event
+route.
+
+The [persistent-registry proposal](teams-trusted-persistent-conversation-registry.md)
+adds an explicit-path, default-off Gateway-local registry. A route enters that
+registry only after Bot Framework authentication plus Core structural,
+typed L2, and L3 admission. The registry retains the complete
+app/tenant/Bot-Framework-channel/conversation identity and validated
+`serviceUrl`, and exposes only active, non-expired records for
+operator-scheduled delivery. Core and ACP never receive the stored reference or `serviceUrl`.
+
+This proposal connects the existing operator scheduler to that registry without
+turning agent-writable usercron into cross-conversation authority. It does not add a new
+scheduler, create Teams conversations, install an app, or implement `/remind`.
+
+## Constraints
+
+- Existing deployments and non-Teams cron behavior remain unchanged by default.
+- A Teams cron job may target only an exact active, non-expired registry record.
+- The complete registry identity must be enforced; conversation ID alone is not
+  a registry key.
+- `serviceUrl`, the stored record, and app credentials remain Gateway-local and
+  never enter Core config, the Gateway wire, ACP input, responses, or logs.
+- Config-defined baseline cron is operator authority. The hot-reloaded
+  `cronjob.toml` is explicitly agent-writable in current OpenAB documentation and
+  is not equivalent authority.
+- Standalone and Unified must apply the same lookup, send, delivery-outcome, and
+  registry-reconciliation rules.
+- Every accepted content POST has a real Bot Framework activity ID. Ambiguous
+  writes are `Unknown` and are never retried blindly.
+- The baseline remains one Gateway writer and one active Standalone Core consumer.
+
+## Current-System Findings
+
+### Scheduler authority and ordering
+
+`[[cron.jobs]]` is immutable process config and is validated at startup. The
+scheduler sends the visible cron trigger before it calls `AdapterRouter`, so a
+failed destination consumes no ACP session or agent work. The scheduler also
+prevents overlap for one job and treats the next matching schedule as a new
+execution rather than retrying a failed tick.
+
+The separate `cronjob.toml` overlay is disabled by default but may be
+hot-reloaded and written by the agent. It can also execute an operator-approved
+local `disable_on_success` command. It therefore cannot safely select an
+arbitrary trusted Teams record without a future user/scope binding design.
+
+### Standalone adapter lifetime
+
+At the design baseline, Unified mode retained one shared adapter for cron.
+Standalone constructed a new `GatewayAdapter` inside each WebSocket connection
+loop and did not expose it to the scheduler. This proposal needs a stable
+reconnect-aware proxy: the
+proxy delegates to the current negotiated connection, clears it on disconnect,
+and never creates a second Gateway WebSocket consumer.
+
+### Microsoft Teams proactive delivery
+
+Microsoft documents scheduled messages as proactive messages. The app must
+already be installed in the destination; a stored conversation ID or
+conversation reference is required, and the incoming `serviceUrl` should be
+retained instead of hardcoding an endpoint. Proactive messaging cannot create a
+new group chat or a new Team channel. A blocked or uninstalled app can return
+HTTP 403 with `MessageWritesBlocked`; Microsoft also documents
+`BotNotInConversationRoster` when the bot is no longer a member of the
+conversation.
+
+### Reviewed prior art
+
+OpenClaw revision
+[`4994f7bacf308269a0770b4a912c44a746cccec7`](https://github.com/openclaw/openclaw/tree/4994f7bacf308269a0770b4a912c44a746cccec7)
+resolves an outbound target through its conversation store, validates the
+stored service endpoint/cloud boundary, reconstructs the SDK reference inside
+the Teams plugin, and sends directly to the stored conversation. OpenAB adopts
+the Gateway-local resolution and endpoint validation, but requires the complete
+registry key and active state rather than a conversation-ID-only lookup.
+
+Hermes Agent revision
+[`00e5a361b60f621ae2246dffdd0a0252895d8493`](https://github.com/NousResearch/hermes-agent/tree/00e5a361b60f621ae2246dffdd0a0252895d8493)
+uses an operator-configured standalone Teams destination and validates its
+service host and conversation identifier. OpenAB adopts explicit operator
+selection but not a static service URL in Core or config; the trusted registry
+remains the only source of the endpoint.
+
+## Decision
+
+### 1. Authority boundary
+
+Only baseline `[[cron.jobs]]` entries may set `platform = "teams"` under this proposal.
+These entries are operator-controlled process configuration and intentionally
+bypass inbound user L2/L3 checks at execution time, as existing operator cron
+does. Their destination is still constrained to a record that previously
+passed those checks and remains active.
+
+The usercron loader rejects every Teams entry with a bounded, identifier-free
+warning. It does not partially execute the job, resolve a registry record, send
+a message, or start ACP. `/remind`, agent-created recurring schedules, and any
+user-facing target selector remain separate follow-ups that must bind the
+initiating user and scope and revalidate them at execution.
+
+### 2. Additive target configuration
+
+A Teams baseline job keeps `channel` as the stored Teams conversation ID and
+adds one required field:
+
+```toml
+[[cron.jobs]]
+enabled = true
+schedule = "0 9 * * 1-5"
+platform = "teams"
+channel = "<conversation-id>"
+teams_tenant_id = "<tenant-id>"
+message = "summarize yesterday's merged work"
+sender_name = "DailyOps"
+timezone = "Asia/Taipei"
+```
+
+For Teams jobs:
+
+- `teams_tenant_id` must be present, non-empty, and bounded;
+- `thread_id` is rejected because the trusted conversation already encodes the
+  Teams Personal, groupChat, or channel route;
+- fields used only by agent-writable usercron remain rejected in baseline config;
+- a Teams-specific field on any other platform is rejected as a configuration
+  error; and
+- `bot_framework_channel_id` is the verified Teams transport constant
+  `msteams`, while `app_id` comes from the configured Gateway credential. Neither
+  is operator-selectable in Core.
+
+Gateway therefore reconstructs and validates the complete registry key:
+
+```text
+(configured_app_id, teams_tenant_id, "msteams", channel)
+```
+
+The raw `configToml`/`configUrl` chart contract remains authoritative; this proposal does
+not restore removed Helm field rendering or create a second cron configuration
+surface.
+
+### 3. Platform-neutral Core route marker
+
+`ChannelRef` gains an optional bounded persistent-conversation target carrying
+only tenant ID, Bot Framework channel ID, and conversation ID. It participates
+in routing equality so two distinct persistent targets cannot alias, but the
+existing session key continues to use the Teams conversation route and does not
+serialize the target into ACP sender context.
+
+All existing reactive and non-Teams `ChannelRef` values set the field to
+`None`. A Teams cron `ChannelRef` sets it before the visible trigger send; clones
+and returned `MessageRef` values preserve it for agent response chunks and
+turn-local bot-owned mutations.
+
+### 4. Additive Gateway capability and wire field
+
+`AdapterCapabilities` gains
+`supports_persistent_conversation_send`, defaulting to `false`. Gateway
+advertises it for Teams only when:
+
+- the trusted persistent registry opened safely;
+- Teams send ACK is supported; and
+- Standalone reports exactly one active Core consumer.
+
+`openab.gateway.reply.v1` gains an optional closed
+`persistent_conversation` object containing the non-secret tenant,
+Bot-Framework-channel, and conversation identity. It never contains app secret,
+OAuth token, `serviceUrl`, message/activity history, or the serialized registry
+record. `reply.channel.id` must equal the target conversation ID and proactive
+frames have no inbound `reply_to` correlation.
+
+New Core does not emit this field unless the exact capability is available.
+Gateway rejects an unnegotiated field, an unsupported topology, malformed or
+mismatched identity, or a non-Teams use before lookup or HTTP. The existing
+registration capability is not reused as an optimistic send capability, so
+registry-only Gateway peers fail closed.
+
+### 5. Exact Gateway-local lookup
+
+Gateway combines the wire target with its configured app ID and validates all
+fields before acquiring the registry lock. It also reapplies the current
+Gateway tenant allowlist. It then obtains a clone only if the exact record is
+active and non-expired.
+
+Missing, expired, disabled, revoked, cross-tenant, cross-conversation, wrong
+Bot-Framework-channel, unsafe-endpoint, unavailable-registry, and ambiguous
+records all return a bounded `Rejected` outcome without OAuth, Connector HTTP,
+filesystem mutation, ACP work, or fallback to the ephemeral route cache.
+Expired records are not refreshed by cron; only a new trusted inbound activity
+can refresh or reactivate them.
+
+### 6. Delivery and turn ordering
+
+For each Teams execution:
+
+1. the scheduler builds the persistent target from operator config;
+2. Gateway performs the exact active lookup and conversation write lock;
+3. Gateway rechecks active state after locking;
+4. the existing outcome-aware Connector path posts one visible cron trigger;
+5. only `Delivered` with a non-empty real activity ID allows session/ACP work;
+6. agent response sends and ordered chunks repeat the active lookup using the
+   preserved target; and
+7. turn-local ownership records permit only the activities created by this
+   process to be edited, deleted, or reacted to.
+
+Teams is added to the scheduler's threadless platforms. It never calls
+`create_thread` or `rename_thread`, and no operator-cron path creates a new Teams
+conversation. Personal, groupChat, and channel behavior comes from the trusted
+stored conversation itself.
+
+### 7. Registry reconciliation
+
+After a Connector write, Gateway updates the exact registry key without holding
+its filesystem mutex across network I/O:
+
+- `Delivered` clears one prior consecutive forbidden-write count;
+- an exact HTTP 403 `MessageWritesBlocked` or
+  `BotNotInConversationRoster` increments the count and disables the active
+  record on the second consecutive result;
+- generic 401/403, 404, 413, 429, other 4xx, 5xx, timeout, disconnect, and every
+  `Unknown` outcome leave state unchanged; and
+- only a later trusted inbound promotion can reactivate a disabled or revoked
+  record.
+
+The 403 classifier parses only bounded structured error bodies and emits a
+bounded internal reason code; it does not log or persist the response body or
+user identity. A registry reconciliation failure is logged count-only and does
+not rewrite the already authoritative Connector outcome. No outcome is retried
+inside the cron execution.
+
+### 8. Reconnect-aware Standalone proxy
+
+Main creates one stable `ChatAdapter` proxy before spawning the existing
+Standalone Gateway connection loop and registers that proxy for Teams cron.
+Each connection generation installs its negotiated concrete adapter; disconnect
+clears only that generation and wakes pending requests. The proxy never opens a
+socket itself.
+
+A call made while disconnected or before the persistent-send capability is
+negotiated is rejected before wire output. A call whose frame was accepted but
+whose ACK is lost remains `Unknown`. After reconnect, later independent cron
+executions use the new adapter and re-resolve the durable record, while an old
+connection cannot clear or satisfy requests owned by the new generation.
+
+### 9. Observability and privacy
+
+Teams cron logs may expose platform, schedule/source class, operation class,
+outcome class, elapsed time, aggregate registry state counts, and bounded reason
+codes. They must not expose the configured prompt, app/tenant/conversation,
+Team/channel/activity/sender IDs, target object, full registry path,
+`serviceUrl`, credentials, or Connector response body.
+
+The scheduled prompt necessarily enters the selected ACP session, but the
+persistent target does not. Tests and validation records use only synthetic values or sanitized counts,
+order, and UI structure.
+
+## Compatibility and Rollout
+
+| Core | Gateway | Behavior |
+| --- | --- | --- |
+| old | old | Teams cron remains unsupported. |
+| old | new | No persistent target is emitted; reactive registry behavior is unchanged. |
+| new | registry-only Gateway | Capability defaults false; Teams cron stops before wire/ACP. |
+| new | new, registry off | Capability false; Teams cron stops before wire/ACP. |
+| new | new, registry on | Exact active lookup, required ACK, and reconciliation are enabled. |
+
+Existing non-Teams cron jobs retain their defaults and routing. A recommended
+Standalone rollout is Core first with no imminently firing Teams job, verify the
+old Gateway fail-closed path, then upgrade Gateway, verify the negotiated
+capability, and only then enable a Teams baseline job. Gateway rollback leaves
+the registry file untouched; a new Core paired with the rolled-back Gateway simply
+cannot fire Teams cron.
+
+## Acceptance criteria
+
+Automated coverage must include:
+
+1. additive config parsing/defaults plus Teams tenant, field-bound, thread, and
+   cross-platform validation;
+2. baseline Teams acceptance and unconditional usercron Teams rejection;
+3. `VALID_PLATFORMS`, threadless behavior, configured-platform detection, and
+   exactly one selected cron adapter in Unified and Standalone modes;
+4. stable Standalone proxy behavior before connect, after hello, during ACK,
+   after disconnect, and after a new connection generation;
+5. additive capability and target wire round trips, missing-field defaults, old
+   peers, unsupported topology, and no pre-negotiation send;
+6. exact complete-key lookup with current tenant allowlist and no HTTP for
+   missing/expired/disabled/revoked/mismatched targets;
+7. one real-ID trigger before session/ACP work, no synthetic Teams thread, and
+   target preservation through content chunks and turn-local ownership;
+8. `Delivered`, `Rejected`, and `Unknown` propagation with no blind retry;
+9. exact blocked/not-in-roster parsing, two-result disable, successful reset,
+   generic-403/429/5xx/timeout no-state-change, and reconciliation-write failure;
+10. same-conversation serialization without cross-conversation head-of-line
+    blocking;
+11. Unified/Standalone parity and Core-first/new-old rolling combinations;
+12. serialization/logging guards proving that persistent records, target IDs,
+    response bodies, `serviceUrl`, credentials, and prompts do not leak to ACP,
+    responses, or logs; and
+13. targeted Core/Gateway/Unified/platform-schema tests, config documentation,
+    changed-line formatting, shipping-target Clippy, LSP, links, secret scans,
+    and `git diff --check`.
+
+
+## Consequences
+
+### Positive
+
+- Teams scheduled delivery reuses the trust already proven by PR 11.
+- The first platform write gates agent cost and every write retains structured
+  delivery semantics.
+- Core selects a complete logical target without receiving `serviceUrl` or the
+  stored reference.
+- Explicit capability negotiation preserves rolling fail-closed behavior.
+- Usercron cannot turn agent filesystem access into arbitrary Teams proactive
+  authority.
+
+### Negative
+
+- Operators must copy a tenant ID and conversation ID into baseline config.
+- `ChannelRef`, capability DTOs, and the mirrored Gateway reply schema gain one
+  more additive routing concept.
+- Standalone needs a reconnect-aware adapter proxy shared with the scheduler.
+- Each proactive write performs a registry lookup and may perform an atomic
+  state reconciliation.
+- A blocked installation is disabled only after two exact outcomes.
+
+## Alternatives Rejected
+
+1. **Allow `platform = "teams"` in usercron.** The documented agent-writable file
+   has no initiating-user/scope binding and would grant arbitrary registry
+   selection.
+2. **Lookup by conversation ID alone.** PR 11 explicitly requires the complete
+   app/tenant/Bot-Framework-channel/conversation identity.
+3. **Put `serviceUrl` in `[[cron.jobs]]` or Core.** This bypasses registry state,
+   refresh, revocation, endpoint validation, and the established secret boundary.
+4. **Reuse `supports_conversation_registry` as send support.** A PR 11 Gateway
+   can register but cannot proactively resolve and send; optimistic reuse would
+   break rolling compatibility.
+5. **Create a second Standalone WebSocket for cron.** Broadcast fan-out would
+   create an unsupported second Core consumer and duplicate inbound events.
+6. **Create a new Teams conversation at fire time.** It requires different
+   authority and platform semantics, cannot create group chats/channels, and
+   bypasses the trusted stored route.
+7. **Treat every 403 as uninstall evidence.** Authentication/config failures and
+   unrelated forbidden operations must not disable a trusted route.
+8. **Retry timeout, disconnect, or 5xx automatically.** A POST may already have
+   committed, so retry can duplicate a user-visible scheduled activity.
+9. **Apply Discord thread creation to Teams.** The persistent conversation
+   already represents the Teams routing surface; a synthetic child thread is
+   neither portable nor authorized.
+
+## References
+
+- [Microsoft: Send proactive messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages)
+- [Microsoft: Send and receive targeted messages](https://learn.microsoft.com/en-us/microsoftteams/platform/agents-in-teams/targeted-messages)
+- [Microsoft: Conversation events and installation updates](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events)
+- [Microsoft: Bot Connector authentication](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0)
+- [OpenClaw Teams proactive send at reviewed revision](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/sdk-proactive.ts)
+- [OpenClaw Teams send-context resolution at reviewed revision](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/send-context.ts)
+- [Hermes Teams adapter at reviewed revision](https://github.com/NousResearch/hermes-agent/blob/00e5a361b60f621ae2246dffdd0a0252895d8493/plugins/platforms/teams/adapter.py)

--- a/docs/adr/teams-owned-message-mutations.md
+++ b/docs/adr/teams-owned-message-mutations.md
@@ -1,0 +1,229 @@
+# ADR: Teams Bot-Owned Message Mutations
+
+- **Status:** Proposed
+- **Date:** 2026-08-09
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams public-preview message reactions](teams-message-reactions-preview.md)
+
+---
+
+## Context
+
+The [real-send decision](teams-real-send-acknowledgement.md) returns the Bot
+Framework activity ID for every confirmed Teams send.
+That ID is required for Bot Connector update and delete APIs, but accepting an
+arbitrary activity ID from Core would allow OpenAB to attempt mutation of an
+inbound user message or a bot message from another tenant or conversation.
+
+The existing `GatewayReply.reply_to` field is overloaded by older command
+paths: normal sends use it as the origin OpenAB event ID, while edit and delete
+commands historically place the platform message target in it. Keeping that
+overload for new peers would again risk passing an OpenAB event ID to a Bot
+Connector activity URL.
+
+The reliability boundary remains single-process and process-local. It does not
+provide durable ownership, cross-replica coordination, or mutation of messages
+created before restart.
+
+## Decision
+
+### Additive command target
+
+`openab.gateway.reply.v1` gains an optional `target_message_id` field. The
+capability contract gains a fail-closed `supports_target_message_id` flag.
+
+For a negotiated peer that advertises support, Core sends command replies as:
+
+```json
+{
+  "reply_to": "evt_origin",
+  "target_message_id": "platform_activity_id",
+  "command": "edit_message"
+}
+```
+
+`reply_to` remains origin event correlation. `target_message_id` is the
+platform activity targeted by edit, delete, or an opt-in reaction command.
+Normal sends never interpret `reply_to` as a command target.
+
+Compatibility behavior is:
+
+- new Core + new Gateway: preserve the origin event and send the explicit
+  target field;
+- new Core + old Gateway, or an operation before hello completes: omit the new
+  field and copy the command target into legacy `reply_to`;
+- old Core + new Gateway: when the field is absent, treat `reply_to` as the
+  legacy command target;
+- Unified: use the explicit field for Teams and legacy form for adapters that
+  do not advertise support.
+
+Missing capability fields default to false. The protocol version remains v1
+because both capability and reply fields are additive and covered by
+old-peer decoding tests.
+
+### Process-local ownership index
+
+After a Teams create/send returns `Delivered` with a non-empty activity ID, the
+Gateway records:
+
+```text
+(app_id, tenant_id, conversation_id, activity_id)
+    -> authenticated route + ownership_created_at
+```
+
+The ownership index:
+
+- is process-local;
+- uses `teams.route_ttl_secs` as its lifetime;
+- has an independent `teams.max_route_entries` capacity bound;
+- evicts its oldest entry at capacity with an operator warning;
+- is swept by the existing Teams ingress cleanup task;
+- stores the already validated gateway-local service URL and never exposes it
+  to Core, the agent, ACK payloads, or logs.
+
+Inbound activity IDs are not inserted. Only a confirmed outbound activity can
+be edited or deleted.
+
+A new-field command must still have a live origin event route. The route fixes
+the app, tenant, and conversation scope before ownership lookup. A missing or
+expired origin returns `target_origin_not_found`; a channel mismatch returns
+`target_scope_mismatch`; a target outside that exact scope returns
+`message_not_owned`.
+
+A legacy command has no separate origin event. Gateway may use a unique owned
+entry matching the configured app, command conversation, and target activity.
+If the same legacy tuple exists in more than one tenant, it fails closed with
+`target_scope_ambiguous`.
+
+### Bot Connector operations
+
+Owned edits call:
+
+```text
+PUT {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}
+```
+
+Owned deletes call:
+
+```text
+DELETE {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}
+```
+
+Conversation and activity IDs continue to use URL path-segment encoding and the
+commercial-public-cloud endpoint policy. OAuth acquisition, same-origin
+redirect policy, 5-second connect timeout, 10-second request timeout, 4 KiB
+error body cap, and redaction rules are unchanged.
+
+Mutation outcomes are classified as follows:
+
+- HTTP success: `Delivered` without a required message ID;
+- explicit `3xx` or `4xx`: `Rejected`;
+- `429`: `Rejected` with parsed `retry_after_ms` unless the bounded internal
+  retry succeeds;
+- `5xx`, request timeout, disconnect, or transport failure: `Unknown`;
+- route, ownership, target, or command validation failure before HTTP:
+  `Rejected`.
+
+POST sends are never retried. PUT and DELETE perform at most one internal retry
+only after an explicit `429` response proves that attempt was rejected, and
+only when `Retry-After` is present and no greater than one second. A second
+`429`, a longer delay, a timeout, disconnect, or `5xx` is returned immediately.
+Core does not retry a terminal `Rejected` or `Unknown` outcome.
+
+A delivered delete removes the ownership entry. A rejected delete retains it
+for a later corrected attempt; an unknown delete retains it because the Gateway
+cannot safely infer whether Teams applied the operation. Delivered edits retain
+the original ownership timestamp rather than turning active mutation into
+unbounded retention.
+
+### Operation-specific acknowledgement
+
+A configured Teams adapter advertises:
+
+```text
+send_ack = true
+edit_ack = true
+delete_ack = true
+supports_target_message_id = true
+can_edit = true
+can_delete = true
+streaming_mode = disabled
+```
+
+New Standalone peers wait for the existing configured Gateway ACK timeout on
+edit and delete. Delivered edit/delete ACKs do not require a message ID.
+Rejected and unknown outcomes propagate as errors and are not converted to
+fire-and-forget success.
+
+Legacy peers retain their previous missing-ACK semantics. Unified returns the
+same outcome directly and overrides native delete instead of falling back to an
+edit-to-zero-width operation.
+
+Enabling edit/delete capability does not enable progressive response. Teams
+`streaming_mode` remains disabled; progressive response owns its policy and
+lifecycle separately.
+
+### Same-conversation ordering
+
+Every Teams send, edit, and delete acquires a fixed process-local write shard
+computed from tenant and conversation ID. There are 64 shards:
+
+- writes in the same tenant/conversation are serialized;
+- different conversations normally proceed independently;
+- a hash collision may conservatively serialize unrelated conversations;
+- the fixed array prevents an attacker or busy tenant from growing a lock map
+  without bound.
+
+Ownership and route state are revalidated after lock acquisition. This prevents
+a queued edit from running after a preceding delete removed ownership.
+
+## Compatibility matrix
+
+| Core | Gateway | Command targeting and ACK behavior |
+| --- | --- | --- |
+| old | old | Legacy `reply_to` wire shape; Teams edit/delete remain unsupported and fail closed in a legacy Gateway without bot-owned mutation support. |
+| old | new | Legacy target fallback is accepted only if it resolves to a unique bot-owned activity; missing ACK remains non-fatal to old Core. |
+| new | old | No target-field capability is advertised, so Core copies the target into legacy `reply_to`; missing required ACK is not enabled. |
+| new | new | Origin and target remain separate; ownership is enforced; edit/delete receive operation-specific structured ACKs. |
+| Unified | embedded | Teams uses the explicit target and returns the structured mutation outcome directly. |
+
+## Security and reliability boundaries
+
+- Inbound user activities cannot enter the ownership index and therefore cannot
+  be edited or deleted.
+- New-field mutation cannot cross app, tenant, or conversation scope.
+- Ambiguous legacy scope fails closed.
+- Service URLs and credentials remain Gateway-local.
+- Ownership disappears on restart and is not shared across replicas.
+- A successful write ACK is not a durable event log or exactly-once guarantee.
+- External deletion, app uninstall, or platform-side retention can make a
+  locally owned ID invalid; the Connector response remains authoritative.
+- This decision does not add proactive references, persistent ownership, or
+  multi-consumer coordination.
+
+
+## Consequences
+
+### Positive
+
+- OpenAB can update and delete only activities it confirmed creating.
+- Event correlation and platform command targets are no longer overloaded for
+  new peers.
+- Edit/delete uncertainty is explicit and cannot trigger blind fresh sends.
+- Same-conversation writes cannot overtake one another within a process.
+- Rolling upgrades remain non-lockstep.
+
+### Negative
+
+- Restart, TTL expiry, or capacity eviction makes older bot messages immutable
+  through OpenAB.
+- New-field commands require their origin route to remain live even if ownership
+  was recorded slightly later.
+- Fixed lock-shard collisions can reduce concurrency.
+- The one-second `429` retry bound may return a retryable rejection to Core
+  instead of waiting for a longer platform delay.
+- Connector mutation behavior and availability remain controlled by Microsoft.

--- a/docs/adr/teams-processing-indicator.md
+++ b/docs/adr/teams-processing-indicator.md
@@ -1,0 +1,201 @@
+# ADR: Teams Processing-Message Indicator
+
+- **Status:** Proposed
+- **Date:** 2026-08-07
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+  - [Teams public-preview message reactions](teams-message-reactions-preview.md)
+  - [Teams progressive edit response](teams-progressive-response.md)
+  - [Turn-boundary message batching](turn-boundary-batching.md)
+
+---
+
+## Context
+
+Teams has no generally available native status API equivalent to Slack
+`assistant.threads.setStatus`. Bot Connector typing activities are transient and
+not part of a generally available processing-status guarantee. The implemented
+Teams reaction backend is Microsoft public preview, explicitly opt-in, and therefore cannot be the
+default processing-indicator contract.
+
+This proposal needs a visible, Graph-free processing lifecycle without enabling
+content streaming or weakening the existing route and bot-ownership checks. It must
+also preserve the batching contract: every event may keep its permanent queued
+receipt when reaction preview is enabled, while only the final event in a batch
+anchors transient progress.
+
+## Decision
+
+### Explicit opt-in
+
+Add one first-class Teams setting:
+
+```toml
+[teams]
+processing_indicator = "off" # off | message
+```
+
+The environment fallback is `TEAMS_PROCESSING_INDICATOR`. Missing or malformed
+environment values resolve to `off`; malformed TOML enum values fail config
+parsing. The default is `off`, preserving existing deployments.
+
+`processing_indicator = "message"` selects a processing **message** lifecycle.
+It does not enable streaming, reactions, typing activities, Graph, RSC, or any
+new manifest permission.
+
+### Capability selection and rolling upgrades
+
+Core gains an internal `StatusBackend::Message` value. The processing message
+uses only the existing commandless send plus bot-owned edit/delete operations;
+no new Gateway command or protocol-version bump is introduced.
+
+Standalone Core selects the message backend only after a valid Gateway hello
+advertises all required primitives for Teams:
+
+- required send, edit, and delete acknowledgements;
+- `supports_target_message_id`;
+- bot-owned edit and delete support.
+
+Before a valid hello, or when any required primitive is absent, configured
+message status fails closed to `StatusBackend::None`. Final answer delivery is
+unaffected. Unified mode selects the backend only when the in-process Teams
+adapter provides the same primitives.
+
+Reaction availability and progress-backend choice are independent. Add an
+additive `supports_reactions` capability bit. A peer that advertises the older
+`status_backend = reactions` shape is normalized to reaction support for
+rolling compatibility; old Core ignores the new bit.
+
+When both opt-ins are active:
+
+- `supports_reactions = true` keeps permanent queued receipts on every event in
+  the batch; and
+- `status_backend = message` drives transient thinking/tool progress only on the
+  final event.
+
+When `processing_indicator = "off"`, the existing reaction-preview behavior is
+unchanged.
+
+### One turn-local status activity
+
+Each admitted dispatch turn creates one turn-local processing controller. Its
+identity is the controller instance plus the real Bot Connector activity ID
+returned by the initial status send. The controller is constructed from the
+final event's `ChannelRef`, including its authenticated `origin_event_id`, so
+successive turns never share a status target.
+
+For a batched turn, Core creates exactly one controller from
+`batch.last().trigger_msg`. It never creates one status message per queued
+receipt.
+
+The controller emits at most one new status activity:
+
+| Transition | Visible text | Transport |
+| --- | --- | --- |
+| start / thinking | `⏳ Processing…` | commandless POST |
+| tool start | `🛠️ Using <tool>…` | PUT same activity |
+| tool done / thinking | `⏳ Processing…` | PUT same activity |
+| successful terminal | `✅ Completed` | PUT same activity |
+| agent error | `❌ Failed` | PUT same activity |
+| hard timeout | `⏱️ Timed out` | PUT same activity |
+| final delivery failure | `❌ Delivery failed` | PUT same activity |
+| clear after delivered final content | — | DELETE same activity |
+
+Tool labels are broker-generated metadata, not user prompt text. Normalize line
+breaks and backticks and cap the rendered label before sending it to Teams.
+Duplicate states are no-ops.
+
+### Terminal-before-final ordering
+
+Status and content streaming remain separate lifecycles:
+
+1. mark the processing activity terminal before the first final-content write;
+2. deliver every final-content chunk through the normal send path;
+3. after complete delivery, delete the terminal status activity;
+4. if final delivery is incomplete, change the status to
+   `❌ Delivery failed` and leave it visible.
+
+This ordering prevents a failed delete from leaving an apparently active
+`Processing…` message. If terminal edit succeeds but delete is rejected or
+unknown, the recognizable terminal text remains. Ambiguous POST, PUT, or DELETE
+outcomes never trigger a fresh status send or blind retry.
+
+Status writes are cosmetic: a status failure is logged and must not suppress,
+duplicate, or fresh-send the final answer.
+
+### Receipt and progress separation
+
+`docs/adr/turn-boundary-batching.md` §6.7 remains authoritative:
+
+- each batch event receives its permanent queued receipt sequentially when the
+  adapter explicitly supports reactions and global reactions are enabled;
+- the turn-local processing controller anchors only on the final event; and
+- the controller never removes queued receipts.
+
+Teams with reaction preview disabled has no native queued-receipt side effect;
+it still creates at most one opt-in processing message for the turn.
+
+## Failure boundaries
+
+- Initial status POST `Rejected` or `Unknown`: disable message status for that
+  turn; do not fresh-send another status.
+- Status PUT `Rejected` or `Unknown`: keep the known activity handle for final
+  terminal/delete cleanup; do not blind retry.
+- Terminal PUT succeeds but DELETE fails: leave terminal text visible.
+- Final answer delivery fails: report the existing delivery error and leave a
+  delivery-failed terminal status when possible.
+- Gateway/Core restart or ownership/route expiry may prevent terminal cleanup.
+  Status state is intentionally process-local, matching existing route and
+  ownership boundaries; this proposal does not add crash replay or durable
+  cleanup.
+
+## Security boundaries
+
+- L1 tenant/JWT, typed L2 scope, structured mention, and L3 identity gates run
+  before status creation.
+- The initial POST resolves only through the authenticated origin event route.
+- PUT/DELETE target only the returned bot-owned activity ID and reuse existing
+  tenant/conversation ownership validation and write serialization.
+- Status text contains no prompt, service URL, token, tenant ID, conversation
+  ID, activity ID, or attachment URL.
+- No Graph, RSC, delegated token, proactive registry, or new permission is
+  introduced.
+
+## Acceptance criteria
+
+Automated tests must cover:
+
+- config/TOML/environment resolution and fail-closed defaults;
+- additive `supports_reactions` old/new capability decoding;
+- configured message status remaining disabled before hello or when one
+  required primitive is absent;
+- Standalone and Unified selecting identical Teams backend semantics;
+- one POST followed only by PUTs against its real returned activity ID;
+- thinking, tool, success, error, timeout, delivery-failure, and clear order;
+- terminal PUT before final content and DELETE only after complete delivery;
+- POST/PUT/DELETE rejection or unknown outcomes without fresh-send fallback;
+- one status activity per batch, anchored to the final event;
+- permanent queued receipts surviving when reaction preview and processing
+  message are both enabled; and
+- no status side effect before trust gates pass.
+
+## Consequences
+
+### Positive
+
+- Teams gains a visible processing lifecycle without Graph or preview APIs.
+- One real activity ID gives deterministic, turn-local mutation ownership.
+- Processing messages and queued reaction receipts can coexist without
+  conflating their lifecycles.
+- Existing deployments remain unchanged by default.
+
+### Negative
+
+- Each enabled turn adds one POST, several bounded PUTs, and normally one
+  DELETE to the conversation write stream.
+- A process restart can orphan a processing message because status state is
+  process-local and not durable.
+- Tool-heavy turns need transition coalescing to avoid cosmetic write pressure.

--- a/docs/adr/teams-progressive-response.md
+++ b/docs/adr/teams-progressive-response.md
@@ -1,0 +1,220 @@
+# ADR: Teams Progressive Edit Response
+
+- **Status:** Proposed
+- **Date:** 2026-08-08
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+  - [Teams processing-message indicator](teams-processing-indicator.md)
+  - [Turn-boundary message batching](turn-boundary-batching.md)
+
+---
+
+## Context
+
+OpenAB already has a platform-neutral post-and-edit streaming path. Teams could
+not safely use it before
+[real-send acknowledgement](teams-real-send-acknowledgement.md) and
+[bot-owned mutations](teams-owned-message-mutations.md), because a placeholder
+POST did not return a real Bot Connector activity ID and later PUT/DELETE operations had no
+operation-specific acknowledgement or bot-ownership boundary.
+
+The linked real-send and mutation decisions supply those primitives. This
+proposal may opt Teams into progressive content, but it must not reintroduce synthetic IDs, fixed best-effort waits, blind retries, or a
+fresh final message after an ambiguous write. It must also preserve the
+capability separation rule: the [processing message](teams-processing-indicator.md) and content placeholder are
+independent activities and lifecycles.
+
+## Decision
+
+### Explicit, default-off setting
+
+Add one first-class Teams setting:
+
+```toml
+[teams]
+streaming = false
+```
+
+The environment fallback is `TEAMS_STREAMING`. Missing or malformed environment
+values resolve to `false`; malformed TOML values fail config parsing. The
+existing generic `[gateway].streaming` setting must not implicitly enable Teams.
+Existing deployments therefore remain send-once.
+
+Streaming does not enable reactions, processing messages, attachments, Graph,
+RSC, delegated tokens, or new manifest permissions.
+
+### Capability selection and rolling upgrades
+
+Teams progressive response requires all of these primitives:
+
+- a valid Gateway hello;
+- required send, edit, and delete acknowledgements;
+- `supports_target_message_id`;
+- bot-owned edit and delete support; and
+- `show_streaming_placeholder = true`.
+
+When configured and all primitives are present, new Core selects internal
+`StreamingMode::Edit`. Otherwise it fails closed to `StreamingMode::Disabled`.
+Unified selects the same mode only when its in-process Teams adapter provides
+the same primitives.
+
+The Gateway hello continues to advertise Teams `streaming_mode = disabled` so
+an old Core with an unrelated generic gateway streaming switch cannot begin
+streaming merely because Gateway was upgraded first. New Core derives the
+opt-in mode from the explicit Teams setting plus the existing primitive flags;
+no protocol version or new command is required.
+
+Compatibility behavior is:
+
+| Core | Gateway | Configured Teams result |
+| --- | --- | --- |
+| old | new | Send-once; new Gateway does not advertise selected Teams streaming. |
+| new | old without valid hello | Send-once, fail closed. |
+| new | valid hello with every required primitive | Edit streaming may be selected. |
+| new | hello missing any primitive | Send-once, fail closed. |
+| Unified | embedded Teams adapter | Edit streaming only under the explicit Teams opt-in. |
+
+### One real placeholder per turn
+
+After L1/L2/L3 admission and successful ACP prompt start, Core creates at most
+one content placeholder for the turn through the authenticated event route.
+Required send ACK must return a non-empty real activity ID. That ID is the only
+placeholder target the turn may edit or delete.
+
+A batched turn still runs one ACP turn and therefore creates one placeholder,
+anchored to the final event's authenticated `origin_event_id`. Concurrent or
+successive turns never share placeholder state. Multi-bot participation keeps
+the existing per-turn streaming disable and falls back to send-once.
+
+Placeholder POST outcomes are handled as follows:
+
+- `Delivered` with a real ID: begin progressive edits;
+- `Rejected`: no activity was created, so complete the ACP turn and safely use
+  the normal send-once final path;
+- `Unknown`, required-ACK timeout, or closed ACK channel: do not create another
+  placeholder or fresh-send the final answer, because the first POST may have
+  committed without returning its ID.
+
+### Coalesced cosmetic edits
+
+The existing edit loop remains the common implementation:
+
+- publish only changed display content;
+- coalesce at a minimum 1.5-second interval;
+- wait for the negotiated edit ACK budget, never the legacy Feishu 800 ms
+  observation window;
+- let Gateway perform only its existing explicit short `429 Retry-After`
+  bounded retry;
+- never retry the same content after a rejected or unknown PUT; a later edit is
+  allowed only when newer content supersedes it; and
+- stop cosmetic edits after three consecutive failed changed-content writes.
+
+All Teams POST, PUT, DELETE, and reaction writes continue to share the existing
+per-conversation write shard. Core aborts and joins the cosmetic edit task before
+the authoritative final write so a stale edit cannot overtake finalization.
+
+### Outcome-aware finalization
+
+The first final chunk is authoritative. Core must retain the structured outcome
+instead of flattening it to an undifferentiated error.
+
+| Final operation | Required behavior |
+| --- | --- |
+| Placeholder PUT `Delivered` | Send overflow chunks sequentially. |
+| Placeholder PUT `Rejected` | Attempt one placeholder DELETE, then use one fresh POST recovery unless DELETE is `Unknown`. |
+| Placeholder PUT `Unknown` | Do not DELETE, retry PUT, or fresh-send. Mark delivery ambiguous. |
+| Recovery DELETE `Delivered` | Fresh-send the first final chunk once. |
+| Recovery DELETE `Rejected` | Fresh-send once; the rejected delete may leave partial placeholder overlap, but no full final activity exists. |
+| Recovery DELETE `Unknown` | Do not fresh-send because deletion may have committed. |
+| Recovery POST `Rejected` or `Unknown` | Do not retry. |
+
+An explicit `[[reply_to:...]]` directive remains a deliberate new-message path:
+Core sends the quoted final activity first and deletes the placeholder only
+after that send is `Delivered`. An unknown quoted POST is not retried and does
+not trigger placeholder deletion.
+
+Overflow chunks are sent in order only after the first final chunk is known to
+be delivered. Core stops at the first rejected or unknown overflow POST; every
+chunk contributes to delivery health. It never skips a failed chunk and sends a
+later one.
+
+An ambiguous progressive write returns a delivery error that suppresses the
+router's usual fresh warning message. Reactions or a separate processing status
+may still show failure, but Core must not turn ambiguity into another Teams
+activity.
+
+### Processing-status coexistence
+
+`processing_indicator = "message"` and `streaming = true` may coexist. They
+produce two distinct activities:
+
+1. the processing status follows its thinking/tool/terminal lifecycle; and
+2. the streaming placeholder contains progressively rendered answer content.
+
+Core marks the processing activity terminal before the authoritative final
+content write and clears it only after every final chunk is delivered. A final
+delivery failure leaves or updates the separate status to a recognizable
+failure state when possible. Neither controller edits or deletes the other's
+activity ID.
+
+Reaction preview remains independent. When enabled, queued `👀` receipts stay
+permanent while content progress uses the placeholder.
+
+## Security and reliability boundaries
+
+- Trust gates run before placeholder creation.
+- Placeholder POST uses only the authenticated process-local event route.
+- PUT/DELETE reuse bot-owned activity validation, tenant/conversation matching,
+  TTL bounds, and write serialization.
+- No placeholder ID survives restart, route expiry, or replica changes.
+- `Unknown` is never reclassified as rejection and never causes blind retry or
+  fresh-send.
+- This proposal does not claim exactly-once delivery, crash cleanup, replay,
+  durable ownership, or multi-consumer work distribution.
+- Microsoft commercial public cloud remains the only supported cloud profile.
+
+## Acceptance criteria
+
+Automated verification must cover:
+
+- config, environment fallback, malformed-value fail-closed behavior, and the
+  default-off invariant;
+- Teams not inheriting generic Gateway or Telegram streaming settings;
+- valid-hello and every-required-primitive capability gating in Standalone;
+- identical Unified capability selection;
+- one placeholder POST returning and reusing one real activity ID;
+- coalescing, changed-content-only writes, three-failure cutoff, and edit-loop
+  abort/join before finalization;
+- required ACK timeout rather than the legacy 800 ms path;
+- final PUT `Delivered`, `Rejected`, and `Unknown` branches;
+- recovery DELETE `Delivered`, `Rejected`, and `Unknown` branches;
+- no fresh-send or warning activity after ambiguous POST, PUT, or DELETE;
+- explicit-reply finalization;
+- ordered overflow delivery stopping on first failure;
+- processing-message and permanent receipt coexistence; and
+- no placeholder side effect before trust admission.
+
+## Consequences
+
+### Positive
+
+- Teams gains progressive answer content using already-authenticated Connector
+  writes and real activity IDs.
+- Explicit outcome handling preserves duplicate safety during transport
+  ambiguity.
+- Rolling upgrades cannot accidentally enable streaming in an old Core.
+- Status, receipts, and content progress remain independently configurable.
+
+### Negative
+
+- Enabled turns add repeated acknowledged PUTs and can increase Connector write
+  pressure.
+- An ambiguous write may leave a partial placeholder and intentionally suppress
+  a fresh final answer.
+- Recovery after an explicitly rejected DELETE may show partial placeholder
+  overlap beside the complete fresh answer.
+- Process restart can orphan a placeholder because state remains intentionally
+  non-durable.

--- a/docs/adr/teams-real-send-acknowledgement.md
+++ b/docs/adr/teams-real-send-acknowledgement.md
@@ -1,0 +1,205 @@
+# ADR: Teams Real Send Acknowledgement and Reply Correlation
+
+- **Status:** Proposed
+- **Date:** 2026-08-08
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Custom Gateway](custom-gateway.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+
+---
+
+## Context
+
+The [ephemeral-ingress decision](teams-ephemeral-ingress-state.md) introduced an
+authenticated, bounded, gateway-local route for each Teams message activity. Before this decision, outbound Teams delivery still used a
+conversation-only service URL cache, copied the OpenAB `event_id` into Bot
+Connector `replyToId`, and discarded the activity ID returned by Teams in
+Unified mode. Standalone Core could not require a send acknowledgement because
+the Teams capability advertised `send_ack = false`.
+
+Those behaviors violated the identifier contract:
+
+- `GatewayEvent.event_id` is OpenAB correlation metadata, not a Bot Framework
+  activity ID;
+- a successful create/send must return the real platform activity ID;
+- a timed-out or disconnected POST may already have completed and must not be
+  represented as a safe rejection or retried blindly.
+
+Teams controls channel-root, channel-reply, Personal, and group-chat
+presentation; HTTP transport tests cannot define or guarantee that UX.
+
+## Decision
+
+### Route resolution
+
+A commandless outbound reply resolves `GatewayReply.reply_to` exclusively as an
+OpenAB `event_id` in the bounded ingress registry. The resolved route supplies:
+
+- bot app and tenant scope;
+- conversation ID and type;
+- inbound activity and reply-chain identifiers;
+- the validated gateway-local service URL;
+- optional Team and channel identifiers.
+
+The outbound `GatewayReply.channel.id` must equal the route's conversation ID.
+A missing, expired, or capacity-evicted event route returns
+`route_not_found`; a conversation mismatch returns `route_mismatch`. Both are
+`Rejected` outcomes and occur before OAuth or Bot Connector I/O.
+
+The conversation-only compatibility service URL map is removed. Service URLs
+remain inside authenticated route state and are never sent to Core or the
+agent.
+
+### Normal send and explicit quote
+
+Normal responses do not infer a Bot Connector `replyToId` from `event_id` or
+from the triggering inbound activity. They use the Bot Connector
+`SendToConversation` endpoint:
+
+```text
+POST {serviceUrl}/v3/conversations/{conversationId}/activities
+```
+
+Only `GatewayReply.quote_message_id` expresses an explicit quote request. The
+adapter uses the Bot Connector `ReplyToActivity` endpoint and also carries the
+target as `Activity.replyToId`, but only when the target is known in the same
+app, tenant, and conversation scope:
+
+```text
+POST {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}
+```
+
+Known targets include:
+
+- the current authenticated inbound activity;
+- its authenticated `replyToId` reply-chain root;
+- another activity still present in the same bounded ingress route index.
+
+An empty or unknown target falls back to a plain send. It is never looked up in
+another tenant or conversation and never causes `event_id` to reach a Bot
+Connector activity URL or body field. This endpoint distinction follows
+Microsoft's [Bot Connector API reference](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#reply-to-activity),
+which directs replies to a specific activity through `ReplyToActivity` rather
+than `SendToConversation`.
+
+### Structured send outcomes
+
+Teams sends produce one of the existing protocol outcomes:
+
+| Condition | Outcome | Code / data |
+| --- | --- | --- |
+| HTTP success with non-empty activity ID | `Delivered` | real `message_id` |
+| Invalid or missing route | `Rejected` | `invalid_route`, `route_not_found`, or `route_mismatch` |
+| OAuth acquisition fails before Connector POST | `Rejected` | `connector_auth_failed` |
+| Connector `3xx` or `4xx` response | `Rejected` | stable rejection code |
+| Connector `429` | `Rejected` | `rate_limited` plus bounded `retry_after_ms` |
+| Connector `5xx` | `Unknown` | `connector_server_error` |
+| POST timeout, disconnect, or transport error | `Unknown` | `request_timeout` or `transport_error` |
+| Success response is malformed or omits activity ID | `Unknown` | `invalid_success_response` or `missing_activity_id` |
+
+A success response without a usable activity ID is `Unknown`, not `Rejected`,
+because Teams may already have created the message. OpenAB does not
+fresh-send or automatically retry `Rejected` or `Unknown` results on this path.
+Error body size, redaction, endpoint validation, redirect policy, and request
+timeouts remain governed by the Bot Connector transport-hardening decision.
+
+`Retry-After` accepts either delta seconds or an HTTP date and is converted to a
+bounded millisecond value. Recording it does not introduce an automatic retry.
+
+### Standalone acknowledgement
+
+A configured Teams adapter now advertises:
+
+```text
+send_ack = true
+edit_ack = false
+delete_ack = false
+```
+
+After a valid new↔new hello negotiation, Core includes a request ID and waits for
+the operation-specific send ACK. Gateway emits
+`openab.gateway.response.v1` with additive structured outcome fields on every
+terminal commandless-send path. `Delivered` must contain a non-empty real
+Bot Framework activity ID; Core rejects an otherwise successful ACK without
+one.
+
+A legacy Core may omit the request ID or include one for its existing
+best-effort streaming correlation. New Gateway emits no unsolicited frame when
+the ID is absent. When it is present, the response keeps the legacy fields and
+adds outcome metadata that old peers can ignore; a missing response remains
+non-fatal under legacy Core semantics. New Core connected to an old Gateway
+receives no supported hello and likewise retains legacy missing-ACK behavior.
+
+### Unified acknowledgement
+
+Unified mode calls the same Teams route and Connector implementation in
+process. `ChatAdapter::send_message` and `send_message_with_reply` return a
+`MessageRef` containing the real Bot Framework activity ID. `Rejected` and
+`Unknown` outcomes become errors; Unified no longer fabricates a synthetic ID
+for Teams delivery.
+
+Other Unified platforms retain their existing behavior. At this decision's
+boundary, Teams capabilities report required send acknowledgement while edit,
+delete, streaming, and status remain disabled. The later
+[bot-owned mutation decision](teams-owned-message-mutations.md) enables guarded
+edit/delete without enabling streaming.
+
+### Activity DTO
+
+The inbound DTO parses the route and presentation fields, including
+`activity.id`, `activity.replyToId`, `conversation.id`, `conversation.conversationType`,
+`channelData.team.id`, `channelData.channel.id`, and `recipient.id`.
+Parsing these fields does not define or guarantee Teams presentation behavior.
+
+## Compatibility
+
+| Core | Gateway | Send behavior |
+| --- | --- | --- |
+| old | old | Existing legacy fire-and-forget behavior. |
+| old | new | Event route is used; no request ID means no response frame, while a legacy request ID receives a backward-compatible response. Missing ACK remains non-fatal to old Core. |
+| new | old | No valid hello; Core keeps legacy missing-ACK semantics. |
+| new | new | Teams advertises required send ACK and returns a structured terminal outcome with the real activity ID on delivery. |
+| Unified | embedded | The same outcome is returned directly without a WebSocket ACK frame. |
+
+Operations emitted before a valid hello is processed continue to use legacy
+Core semantics. The Gateway still classifies the internal result, but does not
+send an unsolicited response when the reply has no request ID.
+
+## Security and reliability boundaries
+
+- Route lookup is process-local, bounded, and TTL-limited.
+- Service URLs never cross the Gateway boundary or appear in outcome messages.
+- Quote targets cannot cross app, tenant, or conversation scope.
+- Unsupported commands are rejected before route lookup and network I/O;
+  reactions remain an intentional no-op until a Teams status backend exists.
+- A Gateway broadcast ACK is not a durable record and does not provide crash
+  replay.
+- This decision does not claim exactly-once delivery, multi-consumer work
+  distribution, proactive-send support, or restart-persistent message
+  ownership.
+
+
+## Consequences
+
+### Positive
+
+- OpenAB correlation IDs can no longer leak into Bot Connector activity fields.
+- New Standalone and Unified sends expose the real Teams activity ID.
+- Rejection and ambiguous delivery are distinct, preventing blind duplicate
+  sends after POST uncertainty.
+- The temporary conversation-only service URL cache is eliminated.
+- Explicit quote targets fail safely to plain send when route evidence is
+  missing.
+
+### Negative
+
+- Replies fail after route expiry, capacity eviction, or process restart.
+- A successful Teams write with a malformed response is reported as unknown
+  even though a message may be visible to the user.
+- Teams clients control scope-specific thread and quote presentation; successful
+  transport correlation does not guarantee visible quote chrome.
+- Required ACKs make Connector latency visible to new Core peers and consume
+  the configured 12-second Gateway ACK budget.

--- a/docs/adr/teams-text-command-parity.md
+++ b/docs/adr/teams-text-command-parity.md
@@ -1,0 +1,323 @@
+# ADR: Teams Text Command Parity
+
+- **Status:** Proposed
+- **Date:** 2026-08-13
+- **Author:** @NeoHsu
+- **Related:**
+  - [Slash commands](../slash-commands.md)
+  - [Teams typed scope and mention routing](teams-typed-scope-and-mention-routing.md)
+  - [Multi-platform adapters](multi-platform-adapters.md)
+
+---
+
+## Context
+
+Teams bot command menus do not create a Discord-style interaction callback.
+The stable Teams app-manifest `bots[].commandLists[]` surface inserts configured
+text into the compose box, and the user sends it as an ordinary authenticated
+`message` activity. OpenAB must therefore parse commands only after the normal
+Bot Framework validation, typed scope, identity, and structured-mention gates.
+
+The first parity set is:
+
+- `/models`
+- `/agents`
+- `/cancel`
+- `/reset`
+- `/cancel-all`
+- `/usage`
+
+At the reviewed design baseline, the implementation was split across platform entry points:
+
+| Command | Discord native interaction | Gateway text path |
+| --- | --- | --- |
+| `/models` | Ephemeral select menu | Numbered text list through `/models` and `/model …` |
+| `/agents` | Ephemeral select menu | Numbered text list through `/agents` and `/agent …` |
+| `/cancel` | Implemented | Implemented in both Standalone and Unified loops |
+| `/reset` | Implemented | Implemented in both Standalone and Unified loops |
+| `/cancel-all` | Implemented | Missing |
+| `/usage` | Ephemeral, Kiro-specific ACP query | Missing |
+
+The two Gateway paths also duplicated command dispatch. At that baseline, the
+Standalone path executed inside the WebSocket reader and used an unacknowledged
+fire-and-forget response to avoid waiting for a reply that only the same reader
+could dispatch. That was incompatible with Teams required send acknowledgements.
+
+`/usage` has an additional privacy boundary. Discord responses are ephemeral,
+but an ordinary Teams reply in a group chat or Team channel is visible to the
+conversation. Account plan, limit, and overage information must not be exposed
+there merely because the command text is valid.
+
+## Prior Art
+
+### OpenClaw
+
+OpenClaw separates a shared command registry and parser from native-platform
+fast paths. Definitions describe native names, text aliases, scope, arguments,
+and tiers, while authorization is resolved before command execution. Unknown or
+colliding prefixes are not accidentally consumed.
+
+- [Shared command registry](https://github.com/openclaw/openclaw/blob/7179d21d977aacd0b07c0d5b12c31d1be251df7d/src/auto-reply/commands-registry.shared.ts)
+- [Boundary-aware text parser](https://github.com/openclaw/openclaw/blob/7179d21d977aacd0b07c0d5b12c31d1be251df7d/src/auto-reply/reply/commands-slash-parse.ts)
+- [Native command fast path](https://github.com/openclaw/openclaw/blob/7179d21d977aacd0b07c0d5b12c31d1be251df7d/src/auto-reply/reply/get-reply-native-slash-fast-path.ts)
+
+### Hermes Agent
+
+Hermes exposes a central messaging command surface, applies a separate
+per-platform and per-scope command-access policy, and declares native command
+manifests independently from command execution. Relay interactions normalize
+back into the same command dispatcher rather than creating a second handler.
+
+- [Messaging command handlers](https://github.com/NousResearch/hermes-agent/blob/a871948d8d4b0f774d4ec40467bab1078a9f28d5/gateway/slash_commands.py)
+- [Per-platform command access](https://github.com/NousResearch/hermes-agent/blob/a871948d8d4b0f774d4ec40467bab1078a9f28d5/gateway/slash_access.py)
+- [Relay command manifest](https://github.com/NousResearch/hermes-agent/blob/a871948d8d4b0f774d4ec40467bab1078a9f28d5/gateway/relay/command_manifest.py)
+
+OpenAB does not need either project's full registry or permission-tier system.
+The useful common pattern is a small semantic command service with separate
+ingress admission and platform rendering.
+
+## Decision
+
+### 1. Add one platform-neutral command service
+
+Core will own a small command module used by Discord native interactions,
+Standalone Gateway events, and Unified Gateway events. It will contain:
+
+- an exact parser for the six canonical commands and the existing Gateway
+  `/model …` and `/agent …` compatibility forms;
+- command execution against `SessionPool` and `Dispatcher`;
+- structured, platform-neutral results for config options, session-control
+  acknowledgements, usage data, validation errors, and unavailable operations;
+- bounded user-facing error classes rather than raw backend errors; and
+- shared config-option selection validation.
+
+The command service will not depend on Serenity, Gateway wire types, Teams Bot
+Framework types, Adaptive Cards, or any platform SDK. Platform adapters retain
+presentation responsibilities:
+
+- Discord renders ephemeral messages, selects, pagination controls, and the
+  existing usage colour/footer embed.
+- Teams and other approved text surfaces render bounded Markdown/plain text.
+
+### 2. Parse only standalone, boundary-valid commands
+
+Outer whitespace is ignored. Canonical command names are lowercase ASCII and
+must end at the input boundary because the first set takes no arguments.
+Recognized compatibility forms retain their current syntax:
+
+```text
+/model
+/model list
+/model set <number or exact name>
+/agent
+/agent list
+/agent set <number or exact name>
+```
+
+A known command with unsupported trailing arguments returns a bounded usage
+message. Prefix collisions such as `/reset-now`, `/usage-report`, or
+`/cancel-all-now` are not commands and continue through the ordinary agent
+prompt path. Unknown slash-prefixed text also continues to the ACP backend so
+agent-native commands such as `/compact` remain usable.
+
+Command interception occurs after structural, L2 scope, L3 identity, and Teams
+recipient-mention handling, but before attachment materialization and dispatcher
+submission. A recognized command does not create a session, consume an agent
+turn, add queued/progress reactions, create a placeholder, or download an
+attachment.
+
+### 3. Keep one logical-thread command key
+
+Commands use the same session key as normal dispatch:
+
+```text
+{platform}:{thread_id-or-channel_id}
+```
+
+`/reset` and `/cancel-all` clear all dispatcher handles whose key belongs to the
+same `(platform, logical_thread_id)`, including every per-sender lane. They do
+not affect another platform or conversation with a coincidentally equal native
+ID.
+
+### 4. Define the six command semantics
+
+| Command | Core behavior |
+| --- | --- |
+| `/models` | Require existing session config options; return model options with current selection. Discord keeps its paginated select UI. Text rendering is current-first, displays at most 25 entries, and reports the omitted count. Existing `/model set …` searches the full option set. |
+| `/agents` | Same as `/models`, accepting both `agent` and `mode` ACP categories. Existing `/agent set …` searches the full option set. |
+| `/cancel` | Send one lock-free ACP `session/cancel` notification for the logical session. Do not clear buffered messages. |
+| `/cancel-all` | Remove and abort all buffered dispatcher lanes for the logical thread, then send the same ACP cancel notification when a session exists. Report only whether buffering was cleared, not a race-prone exact count. |
+| `/reset` | Remove and abort all buffered lanes, issue best-effort ACP cancellation, purge active/suspended/persisted session state through `SessionPool::reset_session`, and let the next ordinary message create a fresh session. |
+| `/usage` | Require an active session, a backend that supports the existing usage extension, and a response surface proven private. Return the existing plan, breakdown, overage, currency, and reset information without logging it. |
+
+Config mutations validate the requested `config_id` and value against the
+current active session options before calling `session/set_config_option`.
+Discord component payloads and text set commands use the same validation.
+
+No command retries an ACP control notification or a platform response. A
+platform write that is `Rejected` or `Unknown` remains terminal for that
+response.
+
+### 5. Preserve privacy and trust before execution
+
+All command entry points must pass their normal platform admission before the
+service is called.
+
+For Teams:
+
+1. JWT, tenant, required route fields, and public-cloud service URL are already
+   validated by Gateway.
+2. Structural bot/mention filtering runs.
+3. Typed L2 scope and L3 identity admission runs.
+4. Only an authenticated recipient mention entity is removed.
+5. The remaining text is parsed as a command.
+
+Plain-text `@OpenAB`, an unbound `<at>OpenAB</at>`, malformed typed scope, a
+disallowed surface, or a denied identity cannot invoke a command.
+
+Discord native interactions will be routed through the existing adapter-level
+DM/channel/user policy and shared L3 identity gate before a shared command is
+executed. Denial is acknowledged ephemerally and does not disclose another
+user's or session's state.
+
+`/usage` executes only when the response is private by construction:
+
+- Discord native interaction: ephemeral response;
+- Teams: authenticated typed `personal` scope with `is_dm = true`.
+
+A Team channel, group chat, or old Teams event without typed privacy proof gets
+a generic private-chat-only response and does not call the ACP usage extension.
+No account values are logged or included in that rejection.
+
+### 6. Keep Standalone and Unified execution equivalent
+
+Both Gateway paths will call the same post-gate command helper. The duplicated
+`/reset`, `/cancel`, and config-command blocks are removed.
+
+The Standalone WebSocket reader must never await a command response whose
+required Gateway ACK is dispatched by that same reader. It spawns bounded
+command execution/delivery work, continues reading frames, and uses the normal
+outcome-aware `ChatAdapter` send path from the spawned task. Unified uses the
+same command service and renderer without a wire hop.
+
+Command response delivery therefore follows negotiated Teams semantics:
+
+- valid new-peer hello: required real-ID send ACK;
+- old Gateway or no valid hello: existing legacy send behavior;
+- first `Rejected` or `Unknown`: stop without retry or a second warning send.
+
+No Gateway protocol version or capability field is added.
+
+### 7. Add a conservative Teams manifest command menu
+
+The documented manifest v1.25 profile will add classic
+`bots[].commandLists[]`. Titles contain the exact text command, including the
+leading slash.
+
+The Personal list advertises all six commands. The Team/group-chat list omits
+`/usage` and advertises the other five. This is discoverability only; selecting
+an item still produces an ordinary message and all runtime trust/mention gates
+remain authoritative.
+
+This proposal does **not** enable the newer `supportsTargetedMessages` plus
+`commandLists[].triggers = ["slash"]` agent surface. Microsoft's current agent
+slash-command guidance says that surface switches group conversations into
+private targeted-message mode. OpenAB does not negotiate, route, or support that privacy model, and manifest
+v1.25 does not define those fields.
+
+Changing an installed app manifest remains an operator-controlled package
+upgrade. Runtime deployment does not silently mutate a tenant app package.
+
+### 8. Keep observability content-free
+
+One command completion record may include platform, canonical command name,
+semantic outcome class, and response write outcome. It must not include command
+arguments, option values, usage values, sender/conversation/activity IDs,
+serialized responses, tokens, or URLs.
+
+## Rolling Compatibility
+
+| Core | Gateway / surface | Result |
+| --- | --- | --- |
+| old Core | new Gateway or unchanged manifest | Existing partial text-command behavior; new Gateway does not execute commands. |
+| new Core | old Gateway / no valid hello | Ordinary event decoding remains compatible; non-sensitive commands use legacy response delivery. `/usage` fails closed without authenticated typed privacy proof. |
+| new Core | new Gateway | Shared service plus negotiated response ACKs. |
+| new Unified | embedded Teams adapter | Same parser, execution, privacy, and result semantics without WebSocket transport. |
+| any runtime | old installed manifest | Commands remain manually typeable; no menu is required for correctness. |
+| any runtime | updated command-list manifest | Menu selection sends ordinary text; runtime gates remain authoritative. |
+
+## Acceptance criteria
+
+Automated verification must cover:
+
+- exact command boundaries, outer whitespace, known invalid arguments, and
+  unknown slash text passing through to ACP;
+- all six semantic command results plus existing `/model` and `/agent`
+  compatibility forms;
+- current-first 25-entry text rendering with deterministic truncation count;
+- full-option validation for config selection and rejection of stale or forged
+  IDs/values before ACP mutation;
+- `/cancel` preserving buffers, `/cancel-all` clearing every lane, and `/reset`
+  clearing every lane plus session state without cross-thread/platform effects;
+- active, absent, unsupported, malformed, over-limit, and no-cap usage reports;
+- `/usage` denied before backend access on public or unproven-private surfaces;
+- Teams structural → typed L2 → L3 → mention cleanup → command ordering in both
+  Standalone and Unified paths;
+- recognized command events skipping attachments, dispatcher submission,
+  reactions, processing status, and progressive placeholders;
+- Standalone command execution not blocking the WebSocket response reader;
+- required-ACK response `Delivered`, `Rejected`, `Unknown`, and timeout behavior
+  without retry or duplicate response;
+- new Core ↔ old Gateway/no-hello behavior and Unified parity;
+- Discord interaction admission, ephemeral presentation, config pagination, and
+  existing `/models`, `/agents`, `/cancel`, `/cancel-all`, `/reset`, and `/usage`
+  regressions;
+- manifest v1.25 schema validation, command-list scope separation, command count,
+  and absence of targeted-message, Graph, RSC, delegated, or Adaptive Card
+  permissions; and
+- platform-schema conformance plus existing Core/Gateway/Unified tests.
+
+
+## Consequences
+
+### Positive
+
+- Command semantics stop drifting between Discord, Standalone, and Unified.
+- Teams gains the missing control and usage commands without a new protocol or
+  permission.
+- Usage data cannot be accidentally published to a group or channel.
+- Required ACKs can be used without blocking the Standalone WebSocket reader.
+- Manifest discovery remains independent from runtime authorization.
+
+### Negative
+
+- The shared service introduces structured semantic results and platform
+  renderers instead of a single string-returning helper.
+- Discord native command admission must be made explicit during the refactor.
+- Teams text menus cannot match Discord's interactive select controls without
+  the deferred Adaptive Card work.
+- Operators must install a revised app package before command-menu entries
+  appear.
+
+## Alternatives Rejected
+
+1. **Copy Discord handlers into Teams.** This preserves drift and imports
+   platform-specific interaction assumptions into ordinary messages.
+2. **Forward every command to the agent.** Session control and account usage are
+   broker responsibilities and must work without consuming an agent turn.
+3. **Keep the duplicated Gateway blocks.** `/cancel-all` and `/usage` would still
+   diverge, and Standalone response ACKs would remain unsafe.
+4. **Publish `/usage` in all scopes.** Teams ordinary replies are not ephemeral
+   and could expose account information.
+5. **Enable targeted messages now.** The newer manifest surface changes group
+   privacy and delivery semantics that OpenAB has not modeled or validated.
+6. **Use Adaptive Cards for parity.** Cards add a separate callback trust path
+   and are explicitly deferred.
+7. **Add a new Gateway command protocol.** Commands already arrive as ordinary
+   authenticated events; a protocol change adds rolling risk without need.
+
+## References
+
+- [Microsoft: expose slash commands from agents and apps](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-commands-menu)
+- [Microsoft Teams manifest v1.25 schema](https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json)
+- [Microsoft classic bot command-menu source at reviewed commit](https://github.com/MicrosoftDocs/msteams-docs/blob/c4611ef2586b/msteams-platform/bots/how-to/create-a-bot-commands-menu.md)

--- a/docs/adr/teams-trusted-persistent-conversation-registry.md
+++ b/docs/adr/teams-trusted-persistent-conversation-registry.md
@@ -1,0 +1,375 @@
+# ADR: Teams Trusted Persistent Conversation Registry
+
+- **Status:** Proposed
+- **Date:** 2026-08-19
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Teams typed scope and mention routing](teams-typed-scope-and-mention-routing.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Basic cron scheduler](basic-cronjob.md)
+
+---
+
+## Context
+
+OpenAB can reply to an authenticated Teams activity only while its bounded
+Gateway-local `TeamsIngressRoute` remains available. That route contains the
+validated Bot Framework `serviceUrl` and is indexed by an OpenAB event ID. It is
+deliberately process-local, expires after `route_ttl_secs`, and disappears when
+the Gateway restarts.
+
+Operator-scheduled delivery needs a trustworthy Teams destination after the
+original turn and ephemeral route have ended. Persisting every JWT-valid
+webhook is unsafe because Teams L2 scope and L3 sender identity are decided in
+Core, after Gateway publication. Persisting only after an agent reply is also
+incorrect: a trusted conversation remains a valid destination when a command
+short-circuits, an attachment is rejected, the ACP backend fails, or the turn is
+cancelled.
+
+The trust and secret boundary is therefore split:
+
+- Gateway alone validates Bot Framework JWT, tenant, endpoint, and route fields
+  and retains `serviceUrl`;
+- Core alone has the authoritative shared L2/L3 Allow decision; and
+- neither Core nor an ACP child may receive a persistent conversation
+  reference or `serviceUrl`.
+
+This proposal creates the registry and post-trust promotion handshake. It does
+not send proactive messages or schedule work.
+
+## Constraints
+
+- Existing deployments must remain behaviorally unchanged unless an operator
+  configures a registry path.
+- A denied, malformed, unauthenticated, cross-tenant, or expired route must
+  never create or refresh a persistent record.
+- The registry is routing authority and must be treated as sensitive state even
+  though it contains no bot credential or message body.
+- `serviceUrl` remains Gateway-local and must not appear in Gateway wire events,
+  ACP input, command responses, or application logs.
+- Standalone and Unified mode must apply the same promotion and storage rules.
+- The baseline supports one Gateway process and one direct Core consumer; this
+  is not a distributed registry or durable inbox.
+
+## Prior Art and Industry Research
+
+Research was performed against immutable source revisions on 2026-08-19.
+
+### Microsoft Teams and Bot Framework
+
+Microsoft requires a bot to retain a `conversationId` or
+`conversationReference` for out-of-context delivery and recommends using the
+`serviceUrl` from the incoming activity. The app must already be installed in
+the target scope. A blocked or uninstalled bot may receive HTTP 403 with
+`MessageWritesBlocked`; Teams also emits authenticated `installationUpdate`
+activities with `action = add` or `remove`.
+
+OpenAB adopts the incoming-reference and uninstall-signal model, but adds its
+own shared L2/L3 promotion gate because JWT validation alone is not OpenAB user
+or scope authorization. This proposal does not use Microsoft Graph to install the app
+or discover new conversations.
+
+### OpenClaw
+
+Reviewed revision:
+[`4994f7bacf308269a0770b4a912c44a746cccec7`](https://github.com/openclaw/openclaw/tree/4994f7bacf308269a0770b4a912c44a746cccec7).
+
+OpenClaw's Teams plugin stores conversation references in keyed SQLite state,
+hashes the conversation ID for its storage key, bounds retained conversations,
+uses a one-year TTL, merges sparse refreshes, and validates stored
+`serviceUrl` hosts before proactive use:
+
+- [`conversation-store-state.ts`](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/conversation-store-state.ts)
+- [`conversation-store-helpers.ts`](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/conversation-store-helpers.ts)
+- [`bot-framework-service-url.ts`](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/bot-framework-service-url.ts)
+
+Its normal admitted-message path asynchronously upserts the reference after
+access checks, although its pairing path intentionally stores a reference for a
+not-yet-allowlisted DM. OpenAB adopts bounded versioned storage, sparse-field
+refresh, and endpoint revalidation. It diverges by prohibiting pairing or any
+other denied activity from promotion, keying by app plus tenant plus Bot
+Framework channel plus conversation, and recording disabled/revoked state
+rather than exposing every stored route as immediately usable.
+
+### Hermes Agent
+
+Reviewed revision:
+[`00e5a361b60f621ae2246dffdd0a0252895d8493`](https://github.com/NousResearch/hermes-agent/tree/00e5a361b60f621ae2246dffdd0a0252895d8493).
+
+Hermes keeps Teams `ConversationReference` objects in an in-memory `chat_id`
+map for cards and captures them before its shared `handle_message` admission.
+The map disappears on restart. Separate-process cron instead requires an
+operator-configured home conversation, tenant, and service URL; that path
+allowlists service hosts and validates conversation IDs:
+
+- [`plugins/platforms/teams/adapter.py`](https://github.com/NousResearch/hermes-agent/blob/00e5a361b60f621ae2246dffdd0a0252895d8493/plugins/platforms/teams/adapter.py)
+
+OpenAB adopts the explicit endpoint and identifier validation but not the
+pre-admission cache or static global home route. Those approaches cannot prove
+that a dynamically observed conversation passed OpenAB's shared L2/L3 gate and
+do not provide restart-safe per-conversation authority.
+
+## Decision
+
+### Opt-in configuration
+
+Persistence is disabled when `teams.conversation_registry_path` is absent or
+empty. This preserves all existing route and filesystem behavior.
+
+When configured, the registry resolves:
+
+| Setting | Default when enabled | Purpose |
+| --- | ---: | --- |
+| `conversation_registry_path` | none | Registry JSON file; absence disables the feature |
+| `conversation_registry_max_entries` | `1000` | Independent persistent-record cap |
+| `conversation_registry_ttl_secs` | `31536000` | One-year active/disabled retention window |
+
+Standalone environment fallbacks are
+`TEAMS_CONVERSATION_REGISTRY_PATH`,
+`TEAMS_CONVERSATION_REGISTRY_MAX_ENTRIES`, and
+`TEAMS_CONVERSATION_REGISTRY_TTL_SECS`.
+
+A relative path resolves beneath `$HOME/.openab/`; an absolute path is accepted
+as an explicit operator choice. Empty components, `.`/`..`, NUL, and any
+existing symlink component are rejected. Helm does not silently create a new
+Gateway PVC: Standalone operators must mount durable storage explicitly, while
+Unified deployments may place the file on their existing HOME volume.
+
+### Versioned record
+
+The file has a closed top-level schema and records a generation number plus a
+bounded list of entries. Each entry contains only:
+
+- schema version;
+- bot app ID;
+- tenant ID;
+- Bot Framework channel ID;
+- conversation ID and canonical type;
+- validated `serviceUrl`;
+- optional Team and Teams channel IDs;
+- `last_validated_at` and `updated_at` wall-clock timestamps;
+- `active`, `disabled`, or `revoked` state;
+- a bounded reason code and consecutive forbidden-write count.
+
+No sender ID, user display name, message/activity ID, message text, attachment,
+credential, OAuth token, or agent/session identifier is persisted. Configuration
+accepts `1..=10000` entries; the serialized file is independently capped at 16
+MiB. App, tenant, Bot Framework channel, conversation type, and reason fields
+are capped at 256 UTF-8 bytes; conversation, Team, and Teams channel IDs at
+2048 bytes; and the already endpoint-validated service URL at 4096 bytes.
+
+The composite identity is:
+
+```text
+(app_id, tenant_id, bot_framework_channel_id, conversation_id)
+```
+
+Lookup always requires the complete identity. Conversation IDs alone are never
+global keys.
+
+### Trust-confirmed promotion
+
+Gateway advertises an additive Teams capability only when the registry is
+configured, safely opened, and the supported single-consumer topology is in
+use. New Core treats an absent capability as persistence unavailable and sends
+no new command. Old Core and old Gateway combinations retain process-local
+behavior.
+
+After structural admission and shared L2/L3 `Allow`, Core submits a bounded
+`register_conversation` Gateway command before command, attachment, session, or
+agent work can determine the turn outcome. The command carries only the
+existing origin event ID and logical channel correlation. It never carries a
+`serviceUrl` or serialized reference.
+
+Gateway resolves the origin event ID back to the still-valid authenticated
+`TeamsIngressRoute`, verifies the reply channel and single-consumer topology,
+and atomically upserts that route into the persistent registry. Missing,
+expired, evicted, cross-conversation, or capability-mismatched routes are
+rejected before filesystem mutation.
+
+Standalone registration runs in a tracked bounded task outside the WebSocket
+reader because its correlated response can only be dispatched by that reader.
+Unified invokes the same Gateway method in process. Registration is independent
+from ACP success and is allowed for trusted recognized commands, ordinary
+turns, and trusted turns that later become empty after mention cleanup.
+
+A storage failure does not retroactively reject the already authenticated
+inbound message or prevent its current reactive turn. It returns a correlated
+`Rejected` or `Unknown` registration outcome, leaves no new usable record, and
+is never blindly retried. A later independently authenticated inbound activity
+may safely attempt a fresh upsert.
+
+### Refresh and state transitions
+
+Only a newly authenticated ephemeral route plus a new shared L2/L3 Allow may
+refresh address fields or `last_validated_at`:
+
+```text
+Absent   -- trusted inbound + committed write --> Active
+Active   -- trusted inbound + committed write --> Active (refreshed)
+Disabled -- trusted inbound + committed write --> Active (re-enabled)
+Revoked  -- trusted inbound + committed write --> Active (re-installed proof)
+```
+
+Gateway-local delivery reconciliation exposes transitions for
+operator-scheduled delivery:
+
+- two consecutive explicit blocked/not-in-roster 403 outcomes disable an active
+  record;
+- a successful proactive write clears the consecutive forbidden count;
+- 429, 5xx, timeout, disconnect, and ambiguous outcomes do not disable or
+  refresh a record; and
+- an authenticated, tenant-allowed `installationUpdate` with `remove` or
+  `remove-upgrade` marks an existing matching record revoked without creating a
+  new record.
+
+An `installationUpdate add` does not activate a route by itself because it has
+not passed user L3 admission. A subsequent trusted inbound activity may
+reactivate the record. This proposal records and tests these transitions;
+operator-scheduled delivery is the first caller of reconciliation.
+
+### Filesystem transaction and recovery
+
+All mutations are serialized by one registry lock and follow
+clone → validate → write temporary file → flush → atomic rename → parent
+flush → publish in-memory state. Readers never observe a candidate state before
+its durable commit.
+
+On Unix, newly created directories are mode `0700` and the registry and
+temporary files are mode `0600`. Existing registry permissions are tightened
+before use. The final file, temporary file, and every existing path component
+must be regular/non-symlink objects of the expected type. Record fields, entry
+count, and total JSON bytes are bounded before allocation or replacement.
+
+Malformed JSON, an unknown schema version, an oversized file, unsafe path, or
+permission failure makes the persistent capability unavailable and does not
+replace the existing file. Reactive Teams messaging continues with the current
+process-local route contract, while health/logging reports a content-free
+registry initialization error.
+
+A crash before rename leaves the prior generation authoritative. Startup
+ignores and safely removes only this registry's own validated temporary-file
+pattern; unrelated files are never touched. No automatic migration from an
+unknown future schema is attempted.
+
+### Capacity and retention
+
+Expired active or disabled entries are removed during load and mutation.
+Revoked tombstones are retained within the same hard cap so a restart does not
+silently erase the last known platform revocation before fresh trusted evidence
+arrives. At capacity, the oldest expired, then disabled, then active record may
+be evicted deterministically. Revoked records are not evicted to admit a new
+key; saturation rejects the new promotion and emits a count-only warning.
+
+This registry is not shared between replicas. Two Gateway processes must not
+write the same path. The registry performs no cross-process locking and advertises no
+persistent capability when the existing topology report is unsupported.
+
+### Observability and privacy
+
+Logs and tests may expose schema/generation, aggregate entry/state counts,
+operation class, result class, elapsed time, and bounded reason codes. They must
+not expose app, tenant, conversation, Team/channel, activity, sender, full path,
+or service URL values. Filesystem tests use synthetic identifiers only.
+
+The registry is never mounted into or passed through the agent subprocess
+environment. Core and ACP observe only registration capability and the
+correlated outcome.
+
+## Compatibility and rollout
+
+- Missing configuration means no disk read/write and no advertised capability.
+- New Gateway with old Core never receives promotion and remains process-local.
+- New Core with old or unavailable Gateway sees capability false and sends no
+  unsupported command.
+- Registry state is Gateway-local; rolling Core replacement does not require a
+  file migration.
+- A Gateway rollback leaves the versioned file untouched. The old binary does
+  not know its path unless separately configured.
+- Enabling Standalone persistence requires an operator-owned durable mount and
+  a rollback backup. It does not recreate Core or change the Teams app
+  manifest.
+
+## Acceptance criteria
+
+Automated coverage must include:
+
+1. versioned round-trip, stable composite keys, sparse refresh, and complete
+   record-field bounds;
+2. absent-path no-op defaults and config/env/Unified/Standalone equivalence;
+3. `0600`/`0700`, traversal and symlink rejection, temporary-file isolation,
+   corrupt/unknown/oversized file fail-closed behavior, and old-or-new recovery
+   across an interrupted write;
+4. deterministic TTL/capacity behavior and revoked-tombstone saturation;
+5. no promotion for structural, tenant, typed L2, L3, malformed-scope, expired
+   route, cross-conversation, or unsupported-topology rejection;
+6. promotion before command/attachment/session/agent side effects and
+   independence from ACP failure;
+7. correlated Standalone response without WebSocket reader deadlock, timeout
+   retry, or unsolicited old-peer response;
+8. Unified and Standalone promotion parity;
+9. refresh/reactivation, consecutive blocked-403 disable, successful-write
+   reset, ambiguous-outcome no-disable, and authenticated uninstall revocation;
+10. serialization/logging guards proving that route identifiers, `serviceUrl`,
+    messages, and credentials do not cross into Core, ACP, or logs; and
+11. changed-line formatting, targeted Core/Gateway/platform-schema tests,
+    Clippy, config documentation, relative links, secret scanning, and
+    `git diff --check`.
+
+
+## Consequences
+
+### Positive
+
+- Restart-safe Teams destinations inherit OpenAB's existing L2/L3 trust rather
+  than JWT validity alone.
+- Gateway retains full ownership of service URLs and persistent route data.
+- PR 12 receives an explicit active/disabled/revoked lookup contract instead of
+  reconstructing routes from session IDs.
+- Default deployments gain no new filesystem side effect.
+- Atomic versioned storage gives rollback and corruption behavior a testable
+  boundary.
+
+### Negative
+
+- One trusted inbound event now creates an additional asynchronous control
+  exchange when persistence is enabled.
+- A JSON rewrite is proportional to the bounded registry size.
+- Standalone operators must provide a durable Gateway mount explicitly.
+- The one-writer restriction prevents active-active Gateway replicas from
+  sharing this file.
+- Filesystem permissions protect confidentiality only as strongly as the
+  Gateway account and volume.
+
+## Alternatives Rejected
+
+1. **Persist every JWT-valid webhook in Gateway.** This bypasses Core L2/L3 and
+   turns denied conversations into proactive authority.
+2. **Persist only after a bot reply succeeds.** Commands, ACP failures, and
+   cancelled turns would fail to register otherwise trusted conversations.
+3. **Send the full conversation reference to Core.** This leaks `serviceUrl`
+   across the established Gateway-local boundary and risks agent exposure.
+4. **Infer a route from Core session keys.** Session identifiers do not contain
+   authenticated service URL, tenant, app, or install-state evidence.
+5. **Use only a static home channel.** It cannot represent per-conversation
+   trust, refresh, disable, or revocation and invites cross-scope mistakes.
+6. **Enable a default HOME file automatically.** Existing deployments would
+   gain a new sensitive persistent side effect without operator opt-in or a
+   guaranteed durable Gateway mount.
+7. **Use SQLite in PR 11.** A single-writer bounded registry does not yet need a
+   new database dependency; atomic JSON is inspectable and sufficient. A shared
+   transactional store remains the multi-replica follow-up.
+8. **Delete on the first 403.** A single response may be transient or
+   misclassified; bounded consecutive evidence preserves the record while
+   stopping future use after sustained explicit rejection.
+
+## References
+
+- [Microsoft: Send proactive messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages)
+- [Microsoft: Conversation events and installation updates](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events)
+- [Microsoft: Bot Connector authentication](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0)
+- [Microsoft: Bot Connector REST API](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0)
+- [OpenClaw Teams conversation store at reviewed revision](https://github.com/openclaw/openclaw/tree/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src)
+- [Hermes Teams adapter at reviewed revision](https://github.com/NousResearch/hermes-agent/blob/00e5a361b60f621ae2246dffdd0a0252895d8493/plugins/platforms/teams/adapter.py)

--- a/docs/adr/teams-typed-scope-and-mention-routing.md
+++ b/docs/adr/teams-typed-scope-and-mention-routing.md
@@ -1,0 +1,191 @@
+# ADR: Teams Typed Scope and Mention Routing
+
+- **Status:** Proposed
+- **Date:** 2026-08-07
+- **Author:** @NeoHsu
+- **Related:**
+  - [Multi-platform adapter architecture](multi-platform-adapters.md)
+  - [Identity trust-none](identity-trust-none.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+
+---
+
+## Context
+
+Before typed scope was added, Teams published only a conversation route,
+sender, raw text, and an empty mention list. Core therefore evaluated every Gateway event with
+`is_dm = false`, could not distinguish Personal, group chat, and Team channel
+scope, and could not prove that a structured Teams mention targeted the
+receiving bot. Pure text could also resemble an `@mention` without carrying an
+authenticated mention entity.
+
+This proposal must add scope and mention evidence without changing outbound
+routing, widening Graph authority, or requiring a lockstep Core/Gateway rollout.
+
+## Decision
+
+### Additive wire fields
+
+`openab.gateway.event.v1` gains three optional fields. The schema and protocol
+version remain unchanged because old decoders ignore unknown fields and new
+decoders default absent fields:
+
+```rust
+struct GatewayScope {
+    tenant_id: Option<String>,
+    team_id: Option<String>,
+    channel_id: Option<String>,
+    conversation_type: String,
+    trust_scope_id: String,
+    is_dm: bool,
+}
+
+struct RecipientInfo {
+    id: String,
+    name: String,
+}
+
+struct MentionInfo {
+    id: String,
+    text: String,
+}
+
+struct GatewayEvent {
+    // existing fields remain unchanged
+    scope: Option<GatewayScope>,
+    recipient: Option<RecipientInfo>,
+    mention_entities: Vec<MentionInfo>,
+}
+```
+
+The existing `mentions` array remains a list of mentioned entity IDs for
+cross-platform structural gating. `mention_entities` carries the exact Teams
+entity text needed for safe recipient-mention removal. Neither field carries a
+service URL, token, or proactive conversation reference.
+
+`ChannelInfo.id` remains the Bot Connector conversation ID used for session and
+outbound routing. It must not be replaced by `trust_scope_id`.
+
+### Teams scope derivation
+
+After JWT, tenant, required-route, and public-cloud service URL validation, the
+Gateway canonicalizes known Bot Framework conversation types:
+
+| `conversationType` | `is_dm` | Required typed fields | Opaque `trust_scope_id` shape |
+| --- | --- | --- | --- |
+| `personal` | `true` | tenant + conversation | `teams:{tenant}:personal:{conversation}` |
+| `groupChat` | `false` | tenant + conversation | `teams:{tenant}:group-chat:{conversation}` |
+| `channel` | `false` | tenant + Team + channel | `teams:{tenant}:team:{team}:channel:{channel}` |
+
+The key is opaque and is never parsed for authorization. Raw Team and channel
+IDs remain separate fields for allowlist matching. Unknown conversation types,
+`is_dm` contradictions, empty `trust_scope_id`, or channel scope missing Team or
+channel IDs fail closed in the new Core.
+
+### Scope policy and compatibility
+
+First-class Teams scope settings are:
+
+```toml
+[teams]
+allowed_teams = []
+allowed_channels = []
+allow_personal = true
+allow_group_chats = true
+```
+
+Rules:
+
+- Personal is admitted only when `allow_personal = true`.
+- Group chat is admitted only when `allow_group_chats = true`.
+- For Team channels, both lists empty means L2 open. If either list is non-empty,
+  a Team ID or channel ID match admits the scope.
+- L3 `allowed_users` remains an independent security gate and is never bypassed
+  by an L2 scope match.
+
+Presence of any new Teams scope field or corresponding environment variable
+opts into typed policy. If none is present, Core preserves the existing generic
+Gateway L2 behavior: `GATEWAY_ALLOWED_CHANNELS` and `[gateway].allowed_channels`
+continue matching `ChannelInfo.id` (the conversation ID). This legacy fallback
+is explicit and observable; it prevents a rolling upgrade from silently
+opening or closing an existing deployment. New Gateway events without a new
+Core are ignored additively. New Core receiving an old event without `scope`
+uses the legacy gate.
+
+### Mention trust and trigger matrix
+
+The Gateway parses only `Activity.entities[]` entries whose type is `mention`
+and whose `mentioned.id` is non-empty. It publishes their IDs in `mentions` and
+their ID/text pairs in `mention_entities`. `Activity.recipient.id` is published
+separately.
+
+New↔new trigger behavior is:
+
+| Scope | Trigger |
+| --- | --- |
+| Personal | Every otherwise trusted user message; mention not required |
+| Group chat | A structured mention entity has `mentioned.id == recipient.id` |
+| Team channel root/reply | A structured mention entity has `mentioned.id == recipient.id` |
+| Unknown/malformed scope | Drop before commands, sessions, reactions, or ACP |
+
+Pure text such as `@OpenAB` or `<at>OpenAB</at>` without a matching entity never
+satisfies group/channel mention gating. Thread presence does not bypass Teams
+mention gating; ambient/RSC reading remains a separate feature.
+
+After structural mention and L2/L3 trust gates allow the event, Core removes
+only entity text associated with the recipient bot ID. It maps entity order to
+text occurrences, removes matched recipient ranges in reverse order, and trims
+only the resulting edges. Other user/bot mentions and arbitrary whitespace are
+preserved. A malformed recipient entity may trigger by ID but is not removed
+unless its exact non-empty text occurs. Mention-only text is ignored when no
+attachment blocks remain.
+
+Core sets `SenderContext.receiver_id` from `recipient.id`; sender identity,
+conversation routing, event correlation, and message ID semantics remain
+unchanged.
+
+## Security and reliability boundaries
+
+- Scope and mention evidence is created only after existing Bot Framework JWT,
+  tenant, and service URL validation.
+- Mention markup is not authority; structured entity IDs are.
+- Scope allowlists do not replace L3 user trust.
+- This decision adds no Graph, RSC, delegated token, manifest permission, ambient
+  reading, attachment download, or persistent conversation state.
+- Service URLs and credentials remain Gateway-local.
+- Standalone and Unified paths use the same Core scope, mention, and prompt
+  normalization helpers.
+
+## Acceptance criteria
+
+Automated tests must cover:
+
+- additive new/old wire decoding;
+- Personal, groupChat, and channel scope derivation;
+- missing Team/channel fields and unknown conversation types;
+- typed Team-or-channel allowlist semantics and legacy conversation fallback;
+- correct `is_dm` and L3 identity ordering;
+- genuine recipient mention, pure-text spoof, reply mention, multi-mention,
+  duplicate mention, and malformed entity cases;
+- removal of only the recipient mention while preserving other text;
+- slash-command recognition after recipient mention removal;
+- Standalone and Unified use of the same helpers;
+- config, environment fallback, Helm, and platform-schema conformance.
+
+## Consequences
+
+### Positive
+
+- Core receives an explicit, authenticated Teams scope instead of guessing from
+  a route ID.
+- Structured mention gating prevents textual mention spoofing.
+- Personal behavior remains mention-free and existing generic L2 restrictions
+  retain a non-lockstep fallback.
+- Agent context can identify the receiving bot in multi-agent deployments.
+
+### Negative
+
+- Typed Teams L2 policy requires additional Core configuration and tests.
+- Old Core cannot enforce new group/channel mention semantics until upgraded.
+- Mention text lacks explicit character offsets, so cleanup relies on entity
+  order plus exact text matching and deliberately leaves unmatched markup.


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked draft:** logical base `docs/teams-adr-response-content` is PR #1488. GitHub requires an upstream PR base to exist in `openabdev/openab`, so this draft temporarily targets `main` and may show preceding stack layers. Do not merge it until #1488 is merged and this branch is rebased onto current `main`; then review only its single incremental commit.

## What problem does this solve?

Define command admission, persistent route authority, and proactive operator scheduling before those capabilities are implemented.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1531339032527765655  
Microsoft Teams roadmap discussion.

## Review Contract

### Goal

Define command admission, persistent route authority, and proactive operator scheduling before those capabilities are implemented.

### Non-goals

No command execution, filesystem registry, proactive send, cron target, live evidence, or tenant configuration is added.

### Accepted Residual Risks

The registry design accepts single-writer filesystem limits, while proactive delivery is limited to operator baseline jobs and exact trusted routes.

### Acceptance Criteria

The ADRs keep secrets and service URLs Gateway-local, make command admission precede side effects, require explicit registry opt-in, reject usercron Teams authority, and retain Proposed metadata with valid links.

### Follow-ups

Land text commands, registry persistence, and operator cron as separate implementation PRs; design user-created reminders under a separate authority contract.

## At a Glance

```
N/A — this PR changes documentation only; it introduces no runtime flow.
```

## Prior Art & Industry Research

Not applicable — this is a documentation-only decision or guidance slice. The ADRs and guides cite the authoritative Microsoft and repository sources used for their claims.

## Proposed Solution

- Add Proposed ADRs for text commands, the trusted persistent conversation registry, and operator-owned Teams cron delivery.
- Clarify that persistent route authority stays Gateway-local and agent-writable schedules cannot inherit it.
- Update the historical Custom Gateway ADR without adding a project-specific ADR index.

## Why this approach?

Separating durable ADRs from mutable guides and evidence keeps architecture review stable while allowing operational status to evolve.

## Alternatives Considered

Embed implementation chronology and tenant evidence in ADRs (rejected: it becomes stale) or publish no routing guide (rejected: operators cannot discover the supported path).

## Validation

- `git diff --check`
- Relative Markdown link and form audit
- ADR metadata and mutable-section guards
