### PR TITLE
fix(teams): reject unsupported gateway commands

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -61,6 +61,7 @@ allowed_channels = ["1234567890"]       # ↑ omitted + non-empty list → auto-
 #                                       #       send-once (streaming is forced off to avoid
 #                                       #       posting duplicate, growing messages)
 # streaming_placeholder = false         # set false for draft-based platforms (e.g. Telegram Rich Messages)
+# gateway_ack_timeout_secs = 12         # only enforced for ACKs advertised by a negotiated gateway
 
 # --- Telegram (first-class section; alternative to TELEGRAM_* env vars) ---
 # Config-authoritative with ${} expansion; each field falls back to its

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{error, warn};
 
@@ -310,6 +310,119 @@ pub struct SenderContext {
     pub receiver_id: Option<String>,
 }
 
+// --- Adapter capability and delivery contracts ---
+
+/// How an adapter can progressively deliver response content.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamingMode {
+    /// Send one final message; no placeholder or edit loop.
+    #[default]
+    Disabled,
+    /// Send a placeholder and edit it with complete snapshots.
+    Edit,
+    /// Use a platform-native append/finalize streaming API.
+    Native,
+}
+
+/// Platform message-size budget. The router converts non-character limits to a
+/// conservative character bound until byte-aware splitting is implemented.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "unit", rename_all = "snake_case")]
+pub enum MessageLimit {
+    Characters { max: usize },
+    Bytes { max: usize },
+    Utf16Bytes { max: usize },
+    Unlimited,
+}
+
+impl Default for MessageLimit {
+    fn default() -> Self {
+        Self::Characters { max: 4096 }
+    }
+}
+
+impl MessageLimit {
+    pub fn conservative_char_limit(self) -> usize {
+        match self {
+            Self::Characters { max } => max.max(1),
+            Self::Bytes { max } => (max / 4).max(1),
+            Self::Utf16Bytes { max } => (max / 4).max(1),
+            Self::Unlimited => usize::MAX,
+        }
+    }
+}
+
+/// User-visible status mechanism, kept independent from content streaming.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusBackend {
+    #[default]
+    None,
+    Reactions,
+    Assistant,
+    Typing,
+}
+
+/// Platform-aware behavior contract used by direct, unified, and standalone
+/// gateway adapters. Defaults are deliberately conservative for unknown peers.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AdapterCapabilities {
+    pub send_ack: bool,
+    pub edit_ack: bool,
+    pub delete_ack: bool,
+    pub can_edit: bool,
+    pub can_delete: bool,
+    pub streaming_mode: StreamingMode,
+    pub show_streaming_placeholder: bool,
+    pub message_limit: MessageLimit,
+    pub status_backend: StatusBackend,
+}
+
+impl Default for AdapterCapabilities {
+    fn default() -> Self {
+        Self {
+            send_ack: false,
+            edit_ack: false,
+            delete_ack: false,
+            can_edit: false,
+            can_delete: false,
+            streaming_mode: StreamingMode::Disabled,
+            show_streaming_placeholder: true,
+            message_limit: MessageLimit::default(),
+            status_backend: StatusBackend::None,
+        }
+    }
+}
+
+/// Result of a platform write. `Unknown` is distinct from rejection because a
+/// timed-out POST may have reached the platform and must not be blindly retried.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WriteOutcome {
+    Delivered {
+        message_id: Option<String>,
+    },
+    Rejected {
+        code: String,
+        message: String,
+        retry_after_ms: Option<u64>,
+    },
+    Unknown {
+        code: String,
+        message: String,
+    },
+}
+
+/// Stable wire discriminator carried by additive GatewayResponse fields.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteOutcomeKind {
+    Delivered,
+    Rejected,
+    Unknown,
+}
+
 // --- ChatAdapter trait ---
 
 #[async_trait]
@@ -321,6 +434,39 @@ pub trait ChatAdapter: Send + Sync + 'static {
     /// replies into multiple messages at this bound. Platform-specific (e.g. 2000
     /// for Discord; Slack uses its Block Kit `markdown` block cap).
     fn message_limit(&self) -> usize;
+
+    /// Platform-aware capability view. Shared adapters override this method to
+    /// select behavior using `ChannelRef.platform`; direct adapters inherit a
+    /// backward-compatible view derived from their existing trait methods.
+    fn capabilities(&self, platform: &str) -> AdapterCapabilities {
+        let streaming_mode = if self.uses_native_streaming(false) {
+            StreamingMode::Native
+        } else if self.use_streaming(false) {
+            StreamingMode::Edit
+        } else {
+            StreamingMode::Disabled
+        };
+        let message_limit = if platform == "acp" {
+            MessageLimit::Unlimited
+        } else {
+            MessageLimit::Characters {
+                max: self.message_limit(),
+            }
+        };
+        AdapterCapabilities {
+            can_edit: streaming_mode != StreamingMode::Disabled,
+            can_delete: streaming_mode != StreamingMode::Disabled,
+            streaming_mode,
+            show_streaming_placeholder: self.show_streaming_placeholder(),
+            message_limit,
+            status_backend: if self.uses_assistant_status() {
+                StatusBackend::Assistant
+            } else {
+                StatusBackend::Reactions
+            },
+            ..AdapterCapabilities::default()
+        }
+    }
 
     /// Send a new message, returns a reference to the sent message.
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef>;
@@ -605,10 +751,13 @@ impl AdapterRouter {
             return Err(e);
         }
 
-        // In assistant-status mode (e.g. Slack assistant_mode), status is conveyed
-        // via assistant.threads.setStatus, so the emoji-reaction lifecycle is skipped
-        // entirely — mirrors dispatch_batch so per-message and batched modes agree.
-        let assistant_status = adapter.uses_assistant_status();
+        // Status and content streaming are separate capabilities. Only the
+        // reactions backend drives the emoji lifecycle here; assistant status is
+        // handled inside stream_prompt_blocks and `none` remains side-effect free.
+        let reaction_status = adapter
+            .capabilities(&ctx.thread_channel.platform)
+            .status_backend
+            == StatusBackend::Reactions;
 
         let reactions = Arc::new(StatusReactionController::new(
             self.reactions_config.enabled,
@@ -617,7 +766,7 @@ impl AdapterRouter {
             self.reactions_config.emojis.clone(),
             self.reactions_config.timing.clone(),
         ));
-        if !assistant_status {
+        if reaction_status {
             reactions.set_queued().await;
         }
 
@@ -632,7 +781,7 @@ impl AdapterRouter {
             )
             .await;
 
-        if !assistant_status {
+        if reaction_status {
             match &result {
                 Ok(()) => reactions.set_done().await,
                 Err(_) => reactions.set_error().await,
@@ -700,16 +849,15 @@ impl AdapterRouter {
     ) -> Result<()> {
         let adapter = adapter.clone();
         let thread_channel = thread_channel.clone();
-        let message_limit = reply_message_limit(&thread_channel.platform, adapter.message_limit());
-        // ACP must not inherit the unified adapter's Telegram streaming flag (wrong
-        // coupling): it streams append-only `agent_message_chunk` deltas built from the
-        // post+edit (`edit_message` snapshot) path, i.e. streaming=false. Decide it
-        // explicitly by platform rather than by whatever Telegram happens to be set to.
-        let streaming = if thread_channel.platform == "acp" {
-            false
-        } else {
-            adapter.use_streaming(other_bot_present)
-        };
+        let capabilities = adapter.capabilities(&thread_channel.platform);
+        let capability_limit = capabilities.message_limit.conservative_char_limit();
+        let message_limit = reply_message_limit(&thread_channel.platform, capability_limit);
+        // ACP stays append-only and cannot use the post+edit path. For all other
+        // platforms, the platform-aware capability is authoritative; multi-bot
+        // participation still disables streaming for the current turn.
+        let streaming = thread_channel.platform != "acp"
+            && capabilities.streaming_mode != StreamingMode::Disabled
+            && !other_bot_present;
         // Keep the full turn text (incl. inter-tool narration) when streaming
         // (it was already shown live) OR when `[reactions] narration_display` is
         // set. Otherwise a send-once turn delivers only the final answer block.
@@ -717,8 +865,9 @@ impl AdapterRouter {
         // `tool_display`. `streaming` still drives the placeholder / native-stream
         // paths below; only the final-text selection uses `keep_full_text`.
         let keep_full_text = streaming || self.reactions_config.narration_display;
-        let native = adapter.uses_native_streaming(other_bot_present);
-        let assistant_status = adapter.uses_assistant_status();
+        let native = streaming && capabilities.streaming_mode == StreamingMode::Native;
+        let assistant_status = capabilities.status_backend == StatusBackend::Assistant;
+        let reaction_status = capabilities.status_backend == StatusBackend::Reactions;
         // Platforms that render Markdown tables natively (e.g. Slack Block Kit
         // `markdown` blocks / `markdown_text` stream chunks) skip the
         // table→code/bullets pre-pass so the raw table renders natively.
@@ -745,7 +894,7 @@ impl AdapterRouter {
                     let (mut rx, request_id) = conn.session_prompt(content_blocks).await?;
                     if assistant_status {
                         let _ = adapter.set_status(&thread_channel, "Thinking…").await;
-                    } else {
+                    } else if reaction_status {
                         reactions.set_thinking().await;
                     }
 
@@ -780,7 +929,7 @@ impl AdapterRouter {
                         } else {
                             "…".to_string()
                         };
-                        let msg = if adapter.show_streaming_placeholder() {
+                        let msg = if capabilities.show_streaming_placeholder {
                             adapter.send_message(&thread_channel, &initial).await?
                         } else {
                             // Dummy ref for edit loop — gateway uses drafts, doesn't need real msg_id
@@ -973,7 +1122,7 @@ impl AdapterRouter {
                                         let _ = adapter
                                             .set_status(&thread_channel, "Thinking…")
                                             .await;
-                                    } else {
+                                    } else if reaction_status {
                                         reactions.set_thinking().await;
                                     }
                                 }
@@ -986,7 +1135,7 @@ impl AdapterRouter {
                                                 &format!("Using {title}…"),
                                             )
                                             .await;
-                                    } else {
+                                    } else if reaction_status {
                                         reactions.set_tool(&title).await;
                                     }
                                     // Record the tool in BOTH modes so the finalized message keeps
@@ -1030,7 +1179,7 @@ impl AdapterRouter {
                                         let _ = adapter
                                             .set_status(&thread_channel, "Thinking…")
                                             .await;
-                                    } else {
+                                    } else if reaction_status {
                                         reactions.set_thinking().await;
                                     }
                                     // Update the tool's state in BOTH modes (see ToolStart) so the
@@ -1744,6 +1893,34 @@ mod tests {
         // and a long reply under the ACP limit is a single chunk (delivered whole)
         let long = "x".repeat(50_000);
         assert_eq!(crate::format::split_message(&long, reply_message_limit("acp", 4096)).len(), 1);
+    }
+
+    #[test]
+    fn capability_message_limits_are_authoritative_and_conservative() {
+        assert_eq!(
+            MessageLimit::Characters { max: 8_000 }.conservative_char_limit(),
+            8_000
+        );
+        assert_eq!(
+            MessageLimit::Bytes { max: 4_000 }.conservative_char_limit(),
+            1_000
+        );
+        assert_eq!(
+            MessageLimit::Utf16Bytes { max: 4_000 }.conservative_char_limit(),
+            1_000
+        );
+        assert_eq!(
+            MessageLimit::Unlimited.conservative_char_limit(),
+            usize::MAX
+        );
+        assert_eq!(
+            MessageLimit::Characters { max: 0 }.conservative_char_limit(),
+            1
+        );
+        assert_eq!(
+            AdapterCapabilities::default().status_backend,
+            StatusBackend::None
+        );
     }
 
     #[test]

--- a/crates/openab-core/src/config.rs
+++ b/crates/openab-core/src/config.rs
@@ -687,6 +687,10 @@ pub struct GatewayConfig {
     /// Show "…" placeholder at streaming start. Default: true. Set false for platforms using drafts.
     #[serde(default = "default_true")]
     pub streaming_placeholder: bool,
+    /// Maximum time to wait for a write acknowledgement advertised by a new
+    /// gateway peer. Legacy peers remain fire-and-forget. Default: 12 seconds.
+    #[serde(default = "default_gateway_ack_timeout_secs")]
+    pub gateway_ack_timeout_secs: u64,
     /// Whether the connected gateway renders tables natively (e.g. Telegram Rich Messages).
     /// Default: true (matches Telegram default). Set false if Rich Messages is disabled
     /// on the gateway daemon to preserve table code-block wrapping.
@@ -705,6 +709,10 @@ pub struct GatewayConfig {
 
 fn default_gateway_platform() -> String {
     "telegram".into()
+}
+
+fn default_gateway_ack_timeout_secs() -> u64 {
+    12
 }
 
 /// First-class `[telegram]` configuration section (see ADR: first-class
@@ -2321,6 +2329,20 @@ fn parse_config_inner(expanded: &str, source: &str) -> anyhow::Result<Config> {
             g.max_batch_tokens > 0,
             "gateway.max_batch_tokens must be > 0"
         );
+        anyhow::ensure!(
+            g.gateway_ack_timeout_secs > 0,
+            "gateway.gateway_ack_timeout_secs must be > 0"
+        );
+        anyhow::ensure!(
+            g.gateway_ack_timeout_secs < config.pool.prompt_hard_timeout_secs,
+            "gateway.gateway_ack_timeout_secs must be less than pool.prompt_hard_timeout_secs"
+        );
+        if g.platform == "teams" {
+            anyhow::ensure!(
+                g.gateway_ack_timeout_secs > 10,
+                "gateway.gateway_ack_timeout_secs must exceed the 10-second Teams Connector request timeout"
+            );
+        }
     }
     anyhow::ensure!(
         config.pool.liveness_check_secs > 0,
@@ -3545,6 +3567,7 @@ command = "echo"
         let gw = cfg.gateway.unwrap();
         assert_eq!(gw.url, "ws://gw:8080/ws");
         assert_eq!(gw.platform, "telegram");
+        assert_eq!(gw.gateway_ack_timeout_secs, 12);
         assert!(gw.allowed_users.is_empty());
         assert!(gw.allowed_channels.is_empty());
         assert!(gw.allow_all_users.is_none());
@@ -3555,6 +3578,57 @@ command = "echo"
             gw.allow_all_channels,
             &gw.allowed_channels
         ));
+    }
+
+    #[test]
+    fn parse_gateway_ack_timeout_override() {
+        let toml = r#"
+[gateway]
+url = "wss://gw.example/ws"
+gateway_ack_timeout_secs = 30
+
+[agent]
+command = "echo"
+"#;
+        let cfg = parse_config(toml, "test").unwrap();
+        assert_eq!(cfg.gateway.unwrap().gateway_ack_timeout_secs, 30);
+    }
+
+    #[test]
+    fn parse_gateway_ack_timeout_rejects_invalid_budgets() {
+        let zero = r#"
+[gateway]
+url = "wss://gw.example/ws"
+gateway_ack_timeout_secs = 0
+
+[agent]
+command = "echo"
+"#;
+        assert!(parse_config(zero, "test").is_err());
+
+        let teams_too_short = r#"
+[gateway]
+url = "wss://gw.example/ws"
+platform = "teams"
+gateway_ack_timeout_secs = 10
+
+[agent]
+command = "echo"
+"#;
+        assert!(parse_config(teams_too_short, "test").is_err());
+
+        let beyond_turn = r#"
+[gateway]
+url = "wss://gw.example/ws"
+gateway_ack_timeout_secs = 12
+
+[pool]
+prompt_hard_timeout_secs = 12
+
+[agent]
+command = "echo"
+"#;
+        assert!(parse_config(beyond_turn, "test").is_err());
     }
 
     #[test]

--- a/crates/openab-core/src/dispatch.rs
+++ b/crates/openab-core/src/dispatch.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use tracing::{debug, error, info, info_span, warn};
 
 use crate::acp::ContentBlock;
-use crate::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef};
+use crate::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef, StatusBackend};
 use crate::config::ReactionsConfig;
 use crate::error_display::format_user_error;
 use crate::reactions::StatusReactionController;
@@ -625,11 +625,13 @@ async fn dispatch_batch(
     let batch_size = batch.len();
     let session_key = Dispatcher::session_key(thread_channel);
 
-    // Apply 👀 reaction to every message in the batch before dispatch (§6.7).
-    // Skip when assistant status API is active — uses
-    // assistant.threads.setStatus instead of emoji reactions.
-    let assistant_status = adapter.uses_assistant_status();
-    if !assistant_status {
+    // Apply 👀 only when the platform selected the reactions status backend.
+    // Assistant/typing/none backends must not leak into the emoji lifecycle.
+    let reaction_status = adapter
+        .capabilities(&thread_channel.platform)
+        .status_backend
+        == StatusBackend::Reactions;
+    if reaction_status {
         let queued_emoji = &target.reactions_config().emojis.queued;
         for msg in batch.iter() {
             let _ = adapter.add_reaction(&msg.trigger_msg, queued_emoji).await;
@@ -779,9 +781,9 @@ async fn dispatch_batch(
         )
         .await;
 
-    // In assistant status mode, all status is conveyed via
-    // assistant.threads.setStatus — skip emoji reactions entirely.
-    if !assistant_status {
+    // Finalize only the reactions backend; other status lifecycles are handled
+    // independently by stream_prompt_blocks or their platform adapter.
+    if reaction_status {
         match &result {
             Ok(()) => reactions.set_done().await,
             Err(_) => reactions.set_error().await,

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -1,5 +1,8 @@
 use crate::acp::ContentBlock;
-use crate::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef, SenderContext};
+use crate::adapter::{
+    AdapterCapabilities, AdapterRouter, ChannelRef, ChatAdapter, MessageLimit, MessageRef,
+    SenderContext, StatusBackend, StreamingMode, WriteOutcome, WriteOutcomeKind,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
@@ -10,59 +13,39 @@ use tokio::sync::Mutex;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::{error, info, warn};
 
-/// Timeout for waiting on gateway reply acknowledgement.
-const GATEWAY_REPLY_TIMEOUT_SECS: u64 = 5;
+const LEGACY_GATEWAY_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
-/// Platforms whose gateway adapter emits a `GatewayResponse` for `edit_message`
-/// so core can observe edit success or failure (used to gate the per-edit
-/// response-wait below).
-///
-/// Today only Feishu does, because it is the only adapter with a known
-/// per-message edit cap (errcode 230072) that requires core-side recovery, and
-/// the only one wired to ack edits.
-///
-/// NOTE: this gates the `edit_message` response-wait only. `delete_message` is
-/// unconditionally fire-and-forget (the recovery path sends fresh content
-/// regardless of the delete outcome), so it does not consult this list.
-///
-/// TECH DEBT: this is platform-identity standing in for a *capability*. The
-/// right model is a capability handshake at gateway-connect time ("does this
-/// adapter acknowledge edits?") rather than a hardcoded platform name. We
-/// accept the hardcode now because there is no handshake protocol yet; when one
-/// lands, replace this allowlist with a negotiated capability flag. Any new
-/// adapter that wires request/response for edits MUST be added here, or its
-/// edit failures stay invisible to core (silent failure mode).
-const EDIT_RESPONSE_PLATFORMS: &[&str] = &["feishu"];
-
-/// Whether `platform` acknowledges `edit_message` with a `GatewayResponse`.
-/// See `EDIT_RESPONSE_PLATFORMS`.
-fn platform_acks_writes(platform: &str) -> bool {
-    EDIT_RESPONSE_PLATFORMS.contains(&platform)
-}
-
-/// Gateway platforms whose messaging API cannot edit a message after it is sent.
-///
-/// Cosmetic (typewriter) streaming works by posting a placeholder and then
-/// repeatedly editing it in place with the growing text. On a platform with no
-/// edit endpoint, each of those "edits" is delivered as a brand-new message
-/// instead — so the user sees the same reply posted several times, each copy
-/// longer than the last. Streaming is therefore force-disabled (send-once) for
-/// these platforms regardless of the configured `streaming` flag.
-///
-/// LINE's Messaging API only exposes reply/push (no edit), so it lives here.
-/// (The in-process unified adapter additionally hard-drops stray edit_message
-/// commands in the LINE adapter itself — see `dispatch_line_reply`.)
-///
-/// NOTE: like `EDIT_RESPONSE_PLATFORMS`, this is platform-identity standing in
-/// for a *capability*. The right long-term model is a capability handshake at
-/// gateway-connect time ("can this adapter edit messages?"); until that exists,
-/// any new gateway platform that lacks a message-edit API MUST be added here.
-const NON_EDITABLE_PLATFORMS: &[&str] = &["line", "lineworks"];
-
-/// Whether cosmetic streaming (placeholder + in-place edits) is possible on
-/// `platform`. See `NON_EDITABLE_PLATFORMS`.
-fn platform_supports_streaming(platform: &str) -> bool {
-    !NON_EDITABLE_PLATFORMS.contains(&platform)
+/// Capability fallback used only when the peer does not negotiate a hello.
+/// It preserves the pre-handshake behavior while keeping platform identity out
+/// of the write and streaming control paths themselves.
+fn legacy_gateway_capabilities(
+    platform: &str,
+    streaming: bool,
+    streaming_placeholder: bool,
+) -> AdapterCapabilities {
+    // Preserve the pre-handshake platform behavior exactly. ACP was already
+    // forced send-once by the router; LINE and LINE WORKS were the only legacy
+    // gateway platforms on the non-editable allowlist.
+    let can_edit = !matches!(platform, "line" | "lineworks" | "acp");
+    AdapterCapabilities {
+        send_ack: false,
+        edit_ack: platform == "feishu",
+        delete_ack: false,
+        can_edit,
+        can_delete: platform == "feishu",
+        streaming_mode: if streaming && can_edit {
+            StreamingMode::Edit
+        } else {
+            StreamingMode::Disabled
+        },
+        show_streaming_placeholder: streaming_placeholder,
+        message_limit: if platform == "acp" {
+            MessageLimit::Unlimited
+        } else {
+            MessageLimit::Characters { max: 4096 }
+        },
+        status_backend: StatusBackend::Reactions,
+    }
 }
 
 /// Shared filter parameters for gateway event gating.
@@ -211,6 +194,124 @@ struct GatewayResponse {
     thread_id: Option<String>,
     message_id: Option<String>,
     error: Option<String>,
+    #[serde(default)]
+    outcome: Option<WriteOutcomeKind>,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    retry_after_ms: Option<u64>,
+}
+
+impl GatewayResponse {
+    fn write_outcome(&self) -> WriteOutcome {
+        match self.outcome {
+            Some(WriteOutcomeKind::Delivered) => WriteOutcome::Delivered {
+                message_id: self.message_id.clone(),
+            },
+            Some(WriteOutcomeKind::Rejected) => WriteOutcome::Rejected {
+                code: self.error_code.clone().unwrap_or_else(|| "rejected".into()),
+                message: self
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "gateway rejected write".into()),
+                retry_after_ms: self.retry_after_ms,
+            },
+            Some(WriteOutcomeKind::Unknown) => WriteOutcome::Unknown {
+                code: self.error_code.clone().unwrap_or_else(|| "unknown".into()),
+                message: self
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "gateway write outcome is unknown".into()),
+            },
+            None if self.success => WriteOutcome::Delivered {
+                message_id: self.message_id.clone(),
+            },
+            None => WriteOutcome::Rejected {
+                code: "legacy_failure".into(),
+                message: self
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "gateway reported failure".into()),
+                retry_after_ms: None,
+            },
+        }
+    }
+}
+
+const CLIENT_HELLO_SCHEMA: &str = "openab.gateway.client_hello.v1";
+const GATEWAY_HELLO_SCHEMA: &str = "openab.gateway.hello.v1";
+const GATEWAY_PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Debug, Deserialize)]
+struct GatewayEnvelope {
+    schema: String,
+}
+
+#[derive(Debug, Serialize)]
+struct GatewayClientHello {
+    schema: String,
+    protocol_version: u32,
+    client_name: Option<String>,
+    requested_platforms: Vec<String>,
+}
+
+fn build_client_hello() -> GatewayClientHello {
+    GatewayClientHello {
+        schema: CLIENT_HELLO_SCHEMA.into(),
+        protocol_version: GATEWAY_PROTOCOL_VERSION,
+        client_name: Some(format!("openab-core/{}", env!("CARGO_PKG_VERSION"))),
+        // A standalone Gateway can publish several platforms over one socket,
+        // so Core requests the full configured capability map.
+        requested_platforms: Vec::new(),
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GatewayHello {
+    schema: String,
+    protocol_version: u32,
+    #[serde(default)]
+    capabilities: HashMap<String, AdapterCapabilities>,
+    topology: GatewayTopology,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct GatewayTopology {
+    active_consumers: usize,
+    supported: bool,
+    delivery_mode: String,
+}
+
+#[derive(Default)]
+struct GatewayCapabilityState {
+    hello: std::sync::RwLock<Option<GatewayHello>>,
+}
+
+impl GatewayCapabilityState {
+    fn update(&self, hello: GatewayHello) {
+        *self
+            .hello
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(hello);
+    }
+
+    fn resolve(&self, platform: &str, legacy: &AdapterCapabilities) -> (bool, AdapterCapabilities) {
+        let hello = self
+            .hello
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match hello.as_ref() {
+            Some(hello) => (
+                true,
+                hello
+                    .capabilities
+                    .get(platform)
+                    .cloned()
+                    .unwrap_or_default(),
+            ),
+            None => (false, legacy.clone()),
+        }
+    }
 }
 
 // --- GatewayAdapter: ChatAdapter over WebSocket ---
@@ -227,32 +328,70 @@ type SharedWsTx = Arc<
     >,
 >;
 
-pub struct GatewayAdapter {
-    ws_tx: SharedWsTx,
-    pending: PendingRequests,
+struct GatewayAdapterOptions {
     platform_name: &'static str,
     streaming: bool,
     streaming_placeholder: bool,
     telegram_rich_messages: bool,
+    gateway_ack_timeout_secs: u64,
+}
+
+pub struct GatewayAdapter {
+    ws_tx: SharedWsTx,
+    pending: PendingRequests,
+    capability_state: Arc<GatewayCapabilityState>,
+    legacy_capabilities: AdapterCapabilities,
+    platform_name: &'static str,
+    streaming: bool,
+    streaming_placeholder: bool,
+    telegram_rich_messages: bool,
+    ack_timeout: std::time::Duration,
 }
 
 impl GatewayAdapter {
     fn new(
         ws_tx: SharedWsTx,
         pending: PendingRequests,
-        platform_name: &'static str,
-        streaming: bool,
-        streaming_placeholder: bool,
-        telegram_rich_messages: bool,
+        capability_state: Arc<GatewayCapabilityState>,
+        options: GatewayAdapterOptions,
     ) -> Self {
-        Self {
-            ws_tx,
-            pending,
+        let GatewayAdapterOptions {
             platform_name,
             streaming,
             streaming_placeholder,
             telegram_rich_messages,
+            gateway_ack_timeout_secs,
+        } = options;
+        Self {
+            ws_tx,
+            pending,
+            capability_state,
+            legacy_capabilities: legacy_gateway_capabilities(
+                platform_name,
+                streaming,
+                streaming_placeholder,
+            ),
+            platform_name,
+            streaming,
+            streaming_placeholder,
+            telegram_rich_messages,
+            ack_timeout: std::time::Duration::from_secs(gateway_ack_timeout_secs.max(1)),
         }
+    }
+
+    fn resolved_capabilities_with_mode(&self, platform: &str) -> (bool, AdapterCapabilities) {
+        let (negotiated, mut capabilities) = self
+            .capability_state
+            .resolve(platform, &self.legacy_capabilities);
+        if !self.streaming {
+            capabilities.streaming_mode = StreamingMode::Disabled;
+        }
+        capabilities.show_streaming_placeholder &= self.streaming_placeholder;
+        (negotiated, capabilities)
+    }
+
+    fn resolved_capabilities(&self, platform: &str) -> AdapterCapabilities {
+        self.resolved_capabilities_with_mode(platform).1
     }
 
     /// Internal helper for send_message / send_message_with_reply.
@@ -262,11 +401,12 @@ impl GatewayAdapter {
         content: &str,
         quote_message_id: Option<&str>,
     ) -> Result<MessageRef> {
-        let req_id = if self.streaming {
-            Some(format!("req_{}", uuid::Uuid::new_v4()))
-        } else {
-            None
-        };
+        let (negotiated, capabilities) = self.resolved_capabilities_with_mode(&channel.platform);
+        let required_ack = negotiated && capabilities.send_ack;
+        // Preserve legacy streaming correlation without turning a missing ACK
+        // into failure. New peers request an ACK only when it was advertised.
+        let request_ack = required_ack || (!negotiated && self.streaming);
+        let req_id = request_ack.then(|| format!("req_{}", uuid::Uuid::new_v4()));
         let pending_rx = if let Some(ref id) = req_id {
             let (tx, rx) = tokio::sync::oneshot::channel();
             self.pending.lock().await.insert(id.clone(), tx);
@@ -298,32 +438,63 @@ impl GatewayAdapter {
             return Err(e.into());
         }
         let msg_id = if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
-            match tokio::time::timeout(std::time::Duration::from_secs(GATEWAY_REPLY_TIMEOUT_SECS), rx).await {
-                Ok(Ok(resp)) if resp.success => resp.message_id.unwrap_or_else(|| "gw_sent".into()),
-                Ok(Ok(resp)) => {
-                    // Gateway explicitly reported failure (success=false). Surface
-                    // as Err so dispatch sets ❌ instead of 🆗 over an incomplete
-                    // delivery. Examples: Feishu edit cap reached after append-new
-                    // fallback also failed; chunked send delivered N/M chunks.
-                    let err_msg = resp.error.clone()
-                        .unwrap_or_else(|| "gateway reported failure".to_string());
-                    tracing::warn!(request_id = %id, error = %err_msg, "gateway replied with failure");
-                    return Err(anyhow::anyhow!("gateway reported failure: {err_msg}"));
+            let response_timeout = if required_ack {
+                self.ack_timeout
+            } else {
+                LEGACY_GATEWAY_REPLY_TIMEOUT
+            };
+            match tokio::time::timeout(response_timeout, rx).await {
+                Ok(Ok(resp)) => match resp.write_outcome() {
+                    WriteOutcome::Delivered { message_id } => match message_id {
+                        Some(message_id) if !message_id.is_empty() => message_id,
+                        _ if required_ack => {
+                            return Err(anyhow::anyhow!(
+                                "gateway delivered send without a message id"
+                            ));
+                        }
+                        _ => "gw_sent".into(),
+                    },
+                    WriteOutcome::Rejected {
+                        code,
+                        message,
+                        retry_after_ms,
+                    } => {
+                        warn!(
+                            request_id = %id,
+                            error_code = %code,
+                            retry_after_ms,
+                            error = %message,
+                            "gateway rejected write"
+                        );
+                        return Err(anyhow::anyhow!(
+                            "gateway rejected write ({code}): {message}"
+                        ));
+                    }
+                    WriteOutcome::Unknown { code, message } => {
+                        warn!(
+                            request_id = %id,
+                            error_code = %code,
+                            error = %message,
+                            "gateway write outcome unknown; not retrying"
+                        );
+                        return Err(anyhow::anyhow!(
+                            "gateway write outcome unknown ({code}): {message}"
+                        ));
+                    }
+                },
+                Ok(Err(_)) if required_ack => {
+                    return Err(anyhow::anyhow!("required gateway ACK channel closed"));
                 }
                 Ok(Err(_)) => {
-                    // Channel closed (gateway shutting down or pending dropped).
-                    // Maintain legacy behavior — adapters that don't implement
-                    // GatewayResponse for all reply types (LINE, Teams) rely on
-                    // this for non-failure outcomes.
-                    tracing::warn!(request_id = %id, "gateway response channel closed");
+                    warn!(request_id = %id, "legacy gateway response channel closed");
                     "gw_sent".into()
                 }
+                Err(_) if required_ack => {
+                    self.pending.lock().await.remove(id);
+                    return Err(anyhow::anyhow!("required gateway ACK timed out"));
+                }
                 Err(_) => {
-                    // Timeout. Many adapters (LINE, Teams) intentionally do not
-                    // emit GatewayResponse for replies, so timeout is the expected
-                    // path for them. Maintain legacy behavior to avoid breaking
-                    // platforms that have not yet wired request/response feedback.
-                    tracing::warn!(request_id = %id, "gateway reply timed out");
+                    warn!(request_id = %id, "legacy gateway reply timed out");
                     self.pending.lock().await.remove(id);
                     "gw_sent".into()
                 }
@@ -499,7 +670,11 @@ impl ChatAdapter for GatewayAdapter {
     }
 
     fn message_limit(&self) -> usize {
-        4096 // Telegram limit
+        4096 // Legacy conservative limit; negotiated capabilities are platform-aware.
+    }
+
+    fn capabilities(&self, platform: &str) -> AdapterCapabilities {
+        self.resolved_capabilities(platform)
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
@@ -617,12 +792,19 @@ impl ChatAdapter for GatewayAdapter {
         // signals — cosmetic streaming would keep flushing forever and the final
         // edit fallback to send_message could not trigger.
         //
-        // Scope intentionally limited to platforms that ack writes (see
-        // EDIT_RESPONSE_PLATFORMS). Other adapters (LINE, Teams, Slack, Discord,
-        // …) keep the original fire-and-forget path so cosmetic streaming on
-        // those platforms does not pay a response-wait penalty per flush.
-        const EDIT_RESPONSE_TIMEOUT_MS: u64 = 800;
-        let needs_response = self.streaming && platform_acks_writes(&msg.channel.platform);
+        // Only negotiated/legacy capabilities that explicitly advertise edit
+        // acknowledgements pay the response-wait cost.
+        const LEGACY_EDIT_RESPONSE_TIMEOUT_MS: u64 = 800;
+        let (negotiated, capabilities) =
+            self.resolved_capabilities_with_mode(&msg.channel.platform);
+        let required_ack = negotiated && capabilities.edit_ack;
+        let needs_response =
+            required_ack || (!negotiated && self.streaming && capabilities.edit_ack);
+        let response_timeout = if required_ack {
+            self.ack_timeout
+        } else {
+            std::time::Duration::from_millis(LEGACY_EDIT_RESPONSE_TIMEOUT_MS)
+        };
 
         let req_id = if needs_response {
             Some(format!("req_{}", uuid::Uuid::new_v4()))
@@ -660,32 +842,38 @@ impl ChatAdapter for GatewayAdapter {
             return Err(e.into());
         }
         if let (Some(rx), Some(ref id)) = (pending_rx, &req_id) {
-            match tokio::time::timeout(
-                std::time::Duration::from_millis(EDIT_RESPONSE_TIMEOUT_MS),
-                rx,
-            ).await {
-                Ok(Ok(resp)) if resp.success => Ok(()),
-                Ok(Ok(resp)) => {
-                    let err_msg = resp.error.clone()
-                        .unwrap_or_else(|| "gateway reported edit failure".to_string());
-                    tracing::warn!(request_id = %id, error = %err_msg, "edit_message gateway replied failure");
-                    Err(anyhow::anyhow!("edit failure: {err_msg}"))
+            match tokio::time::timeout(response_timeout, rx).await {
+                Ok(Ok(resp)) => match resp.write_outcome() {
+                    WriteOutcome::Delivered { .. } => Ok(()),
+                    WriteOutcome::Rejected { code, message, .. } => {
+                        warn!(request_id = %id, error_code = %code, error = %message, "gateway rejected edit");
+                        Err(anyhow::anyhow!("edit rejected ({code}): {message}"))
+                    }
+                    WriteOutcome::Unknown { code, message } => {
+                        warn!(request_id = %id, error_code = %code, error = %message, "gateway edit outcome unknown");
+                        Err(anyhow::anyhow!("edit outcome unknown ({code}): {message}"))
+                    }
+                },
+                Ok(Err(_)) if required_ack => {
+                    Err(anyhow::anyhow!("required edit ACK channel closed"))
                 }
                 Ok(Err(_)) => {
-                    tracing::debug!(request_id = %id, "edit_message gateway response channel closed");
+                    tracing::debug!(request_id = %id, "legacy edit response channel closed");
                     Ok(())
                 }
+                Err(_) if required_ack => {
+                    self.pending.lock().await.remove(id);
+                    Err(anyhow::anyhow!("required edit ACK timed out"))
+                }
                 Err(_) => {
-                    // Timeout — feishu didn't respond within the window
-                    // (probably a slow API). Treat as success to avoid
-                    // false-positive ❌; the cap-reached path already short-
-                    // circuits much faster (gateway returns immediately).
+                    // Legacy Feishu used a short best-effort observation window;
+                    // preserve that behavior when no capability was negotiated.
                     self.pending.lock().await.remove(id);
                     Ok(())
                 }
             }
         } else {
-            // Non-feishu (or non-streaming): fire-and-forget, no added latency.
+            // An unadvertised edit remains fire-and-forget with no added latency.
             Ok(())
         }
     }
@@ -698,13 +886,20 @@ impl ChatAdapter for GatewayAdapter {
     /// to avoid duplicated content. The default zero-width-edit fallback would
     /// itself fail on a cap-reached message, leaving the placeholder visible.
     ///
-    /// Fire-and-forget: gateway adapters that don't implement delete will simply
-    /// ignore the command. Failure is non-fatal — if delete fails, the user sees
-    /// the placeholder remain (same behavior as before this override). We do not
-    /// wait on a response here: the recovery path sends fresh content regardless
-    /// of whether the delete landed, so a response would only buy an extra log
-    /// line at the cost of a per-finalize wait.
+    /// Legacy peers remain fire-and-forget. A negotiated peer is awaited only
+    /// when it explicitly advertises `delete_ack`.
     async fn delete_message(&self, msg: &MessageRef) -> Result<()> {
+        let (negotiated, capabilities) =
+            self.resolved_capabilities_with_mode(&msg.channel.platform);
+        let required_ack = negotiated && capabilities.delete_ack;
+        let request_id = required_ack.then(|| format!("req_{}", uuid::Uuid::new_v4()));
+        let pending_rx = if let Some(ref id) = request_id {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.pending.lock().await.insert(id.clone(), tx);
+            Some(rx)
+        } else {
+            None
+        };
         let reply = GatewayReply {
             schema: "openab.gateway.reply.v1".into(),
             reply_to: msg.message_id.clone(),
@@ -719,19 +914,50 @@ impl ChatAdapter for GatewayAdapter {
             },
             command: Some("delete_message".into()),
             quote_message_id: None,
-            request_id: None,
+            request_id: request_id.clone(),
         };
         let json = serde_json::to_string(&reply)?;
-        self.ws_tx.lock().await.send(Message::Text(json)).await?;
-        Ok(())
+        if let Err(error) = self.ws_tx.lock().await.send(Message::Text(json)).await {
+            if let Some(ref id) = request_id {
+                self.pending.lock().await.remove(id);
+            }
+            return Err(error.into());
+        }
+
+        let (Some(rx), Some(id)) = (pending_rx, request_id) else {
+            return Ok(());
+        };
+        match tokio::time::timeout(self.ack_timeout, rx).await {
+            Ok(Ok(response)) => match response.write_outcome() {
+                WriteOutcome::Delivered { .. } => Ok(()),
+                WriteOutcome::Rejected { code, message, .. } => {
+                    warn!(request_id = %id, error_code = %code, error = %message, "gateway rejected delete");
+                    Err(anyhow::anyhow!("delete rejected ({code}): {message}"))
+                }
+                WriteOutcome::Unknown { code, message } => {
+                    warn!(request_id = %id, error_code = %code, error = %message, "gateway delete outcome unknown");
+                    Err(anyhow::anyhow!(
+                        "delete outcome unknown ({code}): {message}"
+                    ))
+                }
+            },
+            Ok(Err(_)) => Err(anyhow::anyhow!("required delete ACK channel closed")),
+            Err(_) => {
+                self.pending.lock().await.remove(&id);
+                Err(anyhow::anyhow!("required delete ACK timed out"))
+            }
+        }
     }
 
     fn use_streaming(&self, _other_bot_present: bool) -> bool {
-        self.streaming
+        self.resolved_capabilities(self.platform_name)
+            .streaming_mode
+            != StreamingMode::Disabled
     }
 
     fn show_streaming_placeholder(&self) -> bool {
-        self.streaming_placeholder
+        self.resolved_capabilities(self.platform_name)
+            .show_streaming_placeholder
     }
 
     fn renders_native_tables(&self, _platform: &str) -> bool {
@@ -759,6 +985,7 @@ pub struct GatewayParams {
     pub streaming: bool,
     pub streaming_placeholder: bool,
     pub telegram_rich_messages: bool,
+    pub gateway_ack_timeout_secs: u64,
     pub stt: crate::config::SttConfig,
 }
 
@@ -776,21 +1003,13 @@ pub async fn run_gateway_adapter(
     let bot_username = params.bot_username;
     let allow_bot_messages = params.allow_bot_messages;
     let trusted_bot_ids: HashSet<String> = params.trusted_bot_ids.into_iter().collect();
-    // Cosmetic streaming edits a placeholder in place. On platforms without an
-    // edit API (e.g. LINE) every edit lands as a new message — growing
-    // duplicates — so force send-once mode there regardless of config.
-    let streaming = if params.streaming && !platform_supports_streaming(platform) {
-        warn!(
-            platform,
-            "streaming is enabled but this platform cannot edit messages; \
-             forcing send-once mode to avoid duplicate messages"
-        );
-        false
-    } else {
-        params.streaming
-    };
+    // The platform-aware capability contract decides whether configured
+    // streaming is usable. Legacy peers resolve through the conservative
+    // fallback; negotiated peers supply this over the hello exchange.
+    let streaming = params.streaming;
     let streaming_placeholder = params.streaming_placeholder;
     let telegram_rich_messages = params.telegram_rich_messages;
+    let gateway_ack_timeout_secs = params.gateway_ack_timeout_secs;
     let stt_config = params.stt;
 
     let connect_url = match &params.token {
@@ -835,13 +1054,23 @@ pub async fn run_gateway_adapter(
         let (ws_tx, mut ws_rx) = ws_stream.split();
         let ws_tx: SharedWsTx = Arc::new(Mutex::new(ws_tx));
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
+        let capability_state = Arc::new(GatewayCapabilityState::default());
+        let client_hello = build_client_hello();
+        let hello_json = serde_json::to_string(&client_hello)?;
+        if let Err(error) = ws_tx.lock().await.send(Message::Text(hello_json)).await {
+            warn!(error = %error, "failed to send optional gateway hello; continuing in legacy mode");
+        }
         let adapter: Arc<dyn ChatAdapter> = Arc::new(GatewayAdapter::new(
             ws_tx.clone(),
             pending.clone(),
-            platform,
-            streaming,
-            streaming_placeholder,
-            telegram_rich_messages,
+            capability_state.clone(),
+            GatewayAdapterOptions {
+                platform_name: platform,
+                streaming,
+                streaming_placeholder,
+                telegram_rich_messages,
+                gateway_ack_timeout_secs,
+            },
         ));
         let slash_ws_tx = ws_tx.clone(); // for fire-and-forget slash command responses
         let mut tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
@@ -869,15 +1098,50 @@ pub async fn run_gateway_adapter(
                             Some(Ok(Message::Text(text))) => {
                                 let text_str: &str = &text;
 
+                                if let Ok(envelope) = serde_json::from_str::<GatewayEnvelope>(text_str) {
+                                    if envelope.schema == GATEWAY_HELLO_SCHEMA {
+                                        match serde_json::from_str::<GatewayHello>(text_str) {
+                                            Ok(hello)
+                                                if hello.schema == GATEWAY_HELLO_SCHEMA
+                                                    && hello.protocol_version == GATEWAY_PROTOCOL_VERSION => {
+                                                if !hello.topology.supported {
+                                                    warn!(
+                                                        active_consumers = hello.topology.active_consumers,
+                                                        delivery_mode = %hello.topology.delivery_mode,
+                                                        "gateway reports unsupported multi-consumer topology"
+                                                    );
+                                                }
+                                                info!(
+                                                    protocol_version = hello.protocol_version,
+                                                    capability_count = hello.capabilities.len(),
+                                                    "gateway capabilities negotiated"
+                                                );
+                                                capability_state.update(hello);
+                                            }
+                                            Ok(hello) => {
+                                                warn!(
+                                                    peer_version = hello.protocol_version,
+                                                    supported_version = GATEWAY_PROTOCOL_VERSION,
+                                                    "gateway hello version is unsupported; continuing in legacy mode"
+                                                );
+                                            }
+                                            Err(error) => {
+                                                warn!(error = %error, "invalid gateway hello; continuing in legacy mode");
+                                            }
+                                        }
+                                        continue;
+                                    }
+                                }
+
                                 // Check if it's a response to a pending command
                                 if let Ok(resp) = serde_json::from_str::<GatewayResponse>(text_str) {
-                                if resp.schema == "openab.gateway.response.v1" {
-                                    if let Some(tx) = pending.lock().await.remove(&resp.request_id) {
-                                        let _ = tx.send(resp);
+                                    if resp.schema == "openab.gateway.response.v1" {
+                                        if let Some(tx) = pending.lock().await.remove(&resp.request_id) {
+                                            let _ = tx.send(resp);
+                                        }
+                                        continue;
                                     }
-                                    continue;
                                 }
-                            }
 
                             match serde_json::from_str::<GatewayEvent>(text_str) {
                                 Ok(event) => {
@@ -1664,27 +1928,118 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn line_cannot_stream_and_is_forced_send_once() {
-        // LINE has no message-edit API, so cosmetic streaming is impossible.
-        assert!(!platform_supports_streaming("line"));
+    fn legacy_non_editable_platforms_are_send_once() {
+        for platform in ["line", "lineworks", "acp"] {
+            let capabilities = legacy_gateway_capabilities(platform, true, true);
+            assert!(!capabilities.can_edit, "{platform} must not advertise edit");
+            assert_eq!(capabilities.streaming_mode, StreamingMode::Disabled);
+        }
     }
 
     #[test]
-    fn editable_platforms_still_allow_streaming() {
+    fn legacy_editable_platforms_preserve_configured_streaming() {
         for platform in [
             "telegram",
             "slack",
             "discord",
             "feishu",
-            "teams",
             "googlechat",
             "wecom",
+            "teams",
         ] {
-            assert!(
-                platform_supports_streaming(platform),
-                "{platform} should still support streaming",
-            );
+            let capabilities = legacy_gateway_capabilities(platform, true, true);
+            assert!(capabilities.can_edit, "{platform} should advertise edit");
+            assert_eq!(capabilities.streaming_mode, StreamingMode::Edit);
         }
+        let feishu = legacy_gateway_capabilities("feishu", true, true);
+        assert!(feishu.edit_ack);
+        assert!(!feishu.send_ack, "legacy peers never require send ACK");
+    }
+
+    #[test]
+    fn capability_state_uses_legacy_only_before_successful_negotiation() {
+        let state = GatewayCapabilityState::default();
+        let legacy = legacy_gateway_capabilities("telegram", true, true);
+        let (negotiated, resolved) = state.resolve("telegram", &legacy);
+        assert!(!negotiated);
+        assert_eq!(resolved, legacy);
+
+        let advertised = AdapterCapabilities {
+            send_ack: true,
+            can_edit: true,
+            streaming_mode: StreamingMode::Edit,
+            status_backend: StatusBackend::Reactions,
+            ..AdapterCapabilities::default()
+        };
+        state.update(GatewayHello {
+            schema: GATEWAY_HELLO_SCHEMA.into(),
+            protocol_version: GATEWAY_PROTOCOL_VERSION,
+            capabilities: HashMap::from([("telegram".into(), advertised.clone())]),
+            topology: GatewayTopology {
+                active_consumers: 1,
+                supported: true,
+                delivery_mode: "best_effort_broadcast".into(),
+            },
+        });
+
+        let (negotiated, resolved) = state.resolve("telegram", &legacy);
+        assert!(negotiated);
+        assert_eq!(resolved, advertised);
+
+        // Once a hello was accepted, an omitted platform is not allowed to
+        // inherit optimistic legacy behavior.
+        let (_, missing) = state.resolve("unadvertised", &legacy);
+        assert_eq!(missing, AdapterCapabilities::default());
+        assert_eq!(missing.status_backend, StatusBackend::None);
+    }
+
+    #[test]
+    fn legacy_and_structured_gateway_responses_map_to_write_outcomes() {
+        let legacy: GatewayResponse = serde_json::from_value(serde_json::json!({
+            "schema": "openab.gateway.response.v1",
+            "request_id": "req-legacy",
+            "success": true,
+            "thread_id": null,
+            "message_id": "activity-1",
+            "error": null
+        }))
+        .unwrap();
+        assert_eq!(
+            legacy.write_outcome(),
+            WriteOutcome::Delivered {
+                message_id: Some("activity-1".into())
+            }
+        );
+
+        let unknown: GatewayResponse = serde_json::from_value(serde_json::json!({
+            "schema": "openab.gateway.response.v1",
+            "request_id": "req-new",
+            "success": false,
+            "thread_id": null,
+            "message_id": null,
+            "error": "delivery may have completed",
+            "outcome": "unknown",
+            "error_code": "request_timeout"
+        }))
+        .unwrap();
+        assert_eq!(
+            unknown.write_outcome(),
+            WriteOutcome::Unknown {
+                code: "request_timeout".into(),
+                message: "delivery may have completed".into()
+            }
+        );
+    }
+
+    #[test]
+    fn client_hello_wire_shape_is_additive_and_versioned() {
+        let value = serde_json::to_value(build_client_hello()).unwrap();
+        assert_eq!(value["schema"], CLIENT_HELLO_SCHEMA);
+        assert_eq!(value["protocol_version"], GATEWAY_PROTOCOL_VERSION);
+        assert!(value["client_name"]
+            .as_str()
+            .is_some_and(|name| name.starts_with("openab-core/")));
+        assert_eq!(value["requested_platforms"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -2550,14 +2550,14 @@ pub async fn handle_reply(
                 );
             }
             if let Some(ref req_id) = reply.request_id {
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success: false,
-                    thread_id: None,
-                    message_id: None,
-                    error: Some("invalid message_id format".to_string()),
-                };
+                let resp = crate::schema::GatewayResponse::from_write_outcome(
+                    req_id.clone(),
+                    crate::schema::WriteOutcome::Rejected {
+                        code: "invalid_target".into(),
+                        message: "invalid message_id format".into(),
+                        retry_after_ms: None,
+                    },
+                );
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
                 }
@@ -2617,14 +2617,14 @@ pub async fn handle_reply(
         Err(e) => {
             tracing::error!(err = %e, "feishu: cannot get token for reply");
             if let Some(ref req_id) = reply.request_id {
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success: false,
-                    thread_id: None,
-                    message_id: None,
-                    error: Some(format!("token error: {e}")),
-                };
+                let resp = crate::schema::GatewayResponse::from_write_outcome(
+                    req_id.clone(),
+                    crate::schema::WriteOutcome::Rejected {
+                        code: "authentication_failed".into(),
+                        message: format!("token error: {e}"),
+                        retry_after_ms: None,
+                    },
+                );
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
                 }
@@ -2673,14 +2673,12 @@ pub async fn handle_reply(
                 }
                 // Send response with message_id back to OAB core (for streaming edit)
                 if let Some(ref req_id) = reply.request_id {
-                    let resp = crate::schema::GatewayResponse {
-                        schema: "openab.gateway.response.v1".into(),
-                        request_id: req_id.clone(),
-                        success: true,
-                        thread_id: None,
-                        message_id: Some(msg_id),
-                        error: None,
-                    };
+                    let resp = crate::schema::GatewayResponse::from_write_outcome(
+                        req_id.clone(),
+                        crate::schema::WriteOutcome::Delivered {
+                            message_id: Some(msg_id),
+                        },
+                    );
                     if let Ok(json) = serde_json::to_string(&resp) {
                         let _ = event_tx.send(json);
                     }
@@ -2689,14 +2687,14 @@ pub async fn handle_reply(
             None => {
                 // Send failure response so core doesn't wait 5s for timeout
                 if let Some(ref req_id) = reply.request_id {
-                    let resp = crate::schema::GatewayResponse {
-                        schema: "openab.gateway.response.v1".into(),
-                        request_id: req_id.clone(),
-                        success: false,
-                        thread_id: None,
-                        message_id: None,
-                        error: Some("send_post_message failed".into()),
-                    };
+                    let resp = crate::schema::GatewayResponse::from_write_outcome(
+                        req_id.clone(),
+                        crate::schema::WriteOutcome::Rejected {
+                            code: "send_failed".into(),
+                            message: "send_post_message failed".into(),
+                            retry_after_ms: None,
+                        },
+                    );
                     if let Ok(json) = serde_json::to_string(&resp) {
                         let _ = event_tx.send(json);
                     }
@@ -2747,14 +2745,21 @@ pub async fn handle_reply(
                     "chunked send delivered {succeeded}/{total_chunks} chunks"
                 ))
             };
-            let resp = crate::schema::GatewayResponse {
-                schema: "openab.gateway.response.v1".into(),
-                request_id: req_id.clone(),
-                success,
-                thread_id: None,
-                message_id: last_msg_id,
-                error,
+            let outcome = if success {
+                crate::schema::WriteOutcome::Delivered {
+                    message_id: last_msg_id,
+                }
+            } else {
+                crate::schema::WriteOutcome::Rejected {
+                    code: "partial_delivery".into(),
+                    message: error.unwrap_or_else(|| "chunked send failed".into()),
+                    retry_after_ms: None,
+                }
             };
+            let resp = crate::schema::GatewayResponse::from_write_outcome(
+                req_id.clone(),
+                outcome,
+            );
             if let Ok(json) = serde_json::to_string(&resp) {
                 let _ = event_tx.send(json);
             }
@@ -2776,14 +2781,16 @@ fn emit_response(
     error: Option<String>,
 ) {
     if let Some(req_id) = request_id {
-        let resp = crate::schema::GatewayResponse {
-            schema: "openab.gateway.response.v1".into(),
-            request_id: req_id.clone(),
-            success,
-            thread_id: None,
-            message_id,
-            error,
+        let outcome = if success {
+            crate::schema::WriteOutcome::Delivered { message_id }
+        } else {
+            crate::schema::WriteOutcome::Rejected {
+                code: "operation_failed".into(),
+                message: error.unwrap_or_else(|| "gateway operation failed".into()),
+                retry_after_ms: None,
+            }
         };
+        let resp = crate::schema::GatewayResponse::from_write_outcome(req_id.clone(), outcome);
         if let Ok(json) = serde_json::to_string(&resp) {
             let _ = event_tx.send(json);
         }
@@ -4663,6 +4670,8 @@ mod tests {
         let resp: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(resp["request_id"], "req_seam_1");
         assert_eq!(resp["success"], false);
+        assert_eq!(resp["outcome"], "rejected");
+        assert_eq!(resp["error_code"], "invalid_target");
         assert_eq!(resp["error"], "invalid message_id format");
     }
 

--- a/crates/openab-gateway/src/adapters/googlechat.rs
+++ b/crates/openab-gateway/src/adapters/googlechat.rs
@@ -384,14 +384,14 @@ impl GoogleChatAdapter {
                 "googlechat reply (dry-run, no credentials configured)"
             );
             if let Some(ref req_id) = reply.request_id {
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success: false,
-                    thread_id: None,
-                    message_id: None,
-                    error: Some("no credentials configured".into()),
-                };
+                let resp = crate::schema::GatewayResponse::from_write_outcome(
+                    req_id.clone(),
+                    crate::schema::WriteOutcome::Rejected {
+                        code: "not_configured".into(),
+                        message: "no credentials configured".into(),
+                        retry_after_ms: None,
+                    },
+                );
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
                 }
@@ -405,14 +405,14 @@ impl GoogleChatAdapter {
         // Empty message: short-circuit, send failure ack and skip API call
         if chunks.is_empty() {
             if let Some(ref req_id) = reply.request_id {
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success: false,
-                    thread_id: None,
-                    message_id: None,
-                    error: Some("empty message".into()),
-                };
+                let resp = crate::schema::GatewayResponse::from_write_outcome(
+                    req_id.clone(),
+                    crate::schema::WriteOutcome::Rejected {
+                        code: "invalid_request".into(),
+                        message: "empty message".into(),
+                        retry_after_ms: None,
+                    },
+                );
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
                 }
@@ -432,18 +432,20 @@ impl GoogleChatAdapter {
             .await;
 
             if let Some(ref req_id) = reply.request_id {
-                let (success, message_id, error) = match result {
-                    Ok(name) => (true, Some(name), None),
-                    Err(e) => (false, None, Some(e)),
+                let outcome = match result {
+                    Ok(name) => crate::schema::WriteOutcome::Delivered {
+                        message_id: Some(name),
+                    },
+                    Err(message) => crate::schema::WriteOutcome::Rejected {
+                        code: "send_failed".into(),
+                        message,
+                        retry_after_ms: None,
+                    },
                 };
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success,
-                    thread_id: None,
-                    message_id,
-                    error,
-                };
+                let resp = crate::schema::GatewayResponse::from_write_outcome(
+                    req_id.clone(),
+                    outcome,
+                );
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
                 }
@@ -475,13 +477,29 @@ impl GoogleChatAdapter {
                 }
             }
             if let Some(ref req_id) = reply.request_id {
-                let resp = crate::schema::GatewayResponse {
-                    schema: "openab.gateway.response.v1".into(),
-                    request_id: req_id.clone(),
-                    success: first_msg_name.is_some() && first_error.is_none(),
-                    thread_id: None,
-                    message_id: first_msg_name,
-                    error: first_error,
+                let resp = match (first_msg_name, first_error) {
+                    (Some(message_id), None) => {
+                        crate::schema::GatewayResponse::from_write_outcome(
+                            req_id.clone(),
+                            crate::schema::WriteOutcome::Delivered {
+                                message_id: Some(message_id),
+                            },
+                        )
+                    }
+                    (message_id, error) => {
+                        let mut response = crate::schema::GatewayResponse::from_write_outcome(
+                            req_id.clone(),
+                            crate::schema::WriteOutcome::Rejected {
+                                code: "partial_delivery".into(),
+                                message: error.unwrap_or_else(|| "no message delivered".into()),
+                                retry_after_ms: None,
+                            },
+                        );
+                        // Preserve the first successful ID for legacy diagnostics;
+                        // the structured outcome remains rejected and is not retried.
+                        response.message_id = message_id;
+                        response
+                    }
                 };
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
@@ -2060,6 +2078,7 @@ mod tests {
         let resp: GatewayResponse = serde_json::from_str(&received.unwrap()).unwrap();
         assert_eq!(resp.request_id, "req_123");
         assert!(resp.success);
+        assert_eq!(resp.outcome, Some(crate::schema::WriteOutcomeKind::Delivered));
         assert_eq!(resp.message_id, Some("spaces/TEST/messages/msg_abc".into()));
     }
 
@@ -2104,6 +2123,8 @@ mod tests {
         let resp: GatewayResponse = serde_json::from_str(&received.unwrap()).unwrap();
         assert_eq!(resp.request_id, "req_fail");
         assert!(!resp.success);
+        assert_eq!(resp.outcome, Some(crate::schema::WriteOutcomeKind::Rejected));
+        assert_eq!(resp.error_code.as_deref(), Some("send_failed"));
         assert!(resp.message_id.is_none());
         let err = resp.error.expect("error should be set on send failure");
         assert!(err.contains("500"), "error should include status code, got: {}", err);

--- a/crates/openab-gateway/src/adapters/teams.rs
+++ b/crates/openab-gateway/src/adapters/teams.rs
@@ -5,7 +5,7 @@ use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde::Deserialize;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 // --- Bot Framework activity types ---
 
@@ -572,12 +572,18 @@ pub async fn handle_reply(
     service_urls: &tokio::sync::Mutex<
         std::collections::HashMap<String, (String, std::time::Instant)>,
     >,
-) {
-    // Reactions are not supported on Teams — silently ignore
-    if reply.command.as_deref() == Some("add_reaction")
-        || reply.command.as_deref() == Some("remove_reaction")
-    {
-        return;
+) -> anyhow::Result<Option<String>> {
+    // Fail closed for commands the Teams adapter does not implement. Falling
+    // through to `send_activity` would turn edit/delete/topic commands into new
+    // messages, producing duplicate or misleading output. Reaction commands
+    // remain an intentional no-op until a Teams status backend is implemented.
+    match reply.command.as_deref() {
+        None => {}
+        Some("add_reaction" | "remove_reaction") => {
+            debug!(command = ?reply.command.as_deref(), "teams: ignoring unsupported reaction command");
+            return Ok(None);
+        }
+        Some(command) => anyhow::bail!("unsupported Teams command: {command}"),
     }
 
     let service_url = {
@@ -588,10 +594,10 @@ pub async fn handle_reply(
                 *ts = std::time::Instant::now();
                 url.clone()
             }
-            None => {
-                error!(conversation = %reply.channel.id, "teams: no service_url for conversation");
-                return;
-            }
+            None => anyhow::bail!(
+                "no Teams service_url for conversation {}",
+                reply.channel.id
+            ),
         }
     };
 
@@ -602,23 +608,25 @@ pub async fn handle_reply(
     };
 
     info!(conversation = %reply.channel.id, "gateway → teams");
-    match teams
+    let id = teams
         .send_activity(
             &service_url,
             &reply.channel.id,
             &reply.content.text,
             reply_to_id,
         )
-        .await
-    {
-        Ok(id) => debug!(activity_id = %id, "teams activity sent"),
-        Err(e) => error!(error = %e, "teams send error"),
-    }
+        .await?;
+    debug!(activity_id = %id, "teams activity sent");
+    Ok(Some(id))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::{
+        matchers::{method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
 
     // --- ensure_trailing_slash ---
 
@@ -662,6 +670,26 @@ mod tests {
             teams: Some(TeamsAdapter::new(make_config(vec![]))),
             ..crate::AppState::test_default(event_tx)
         })
+    }
+
+    fn make_reply(command: Option<&str>) -> GatewayReply {
+        GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: "evt-1".into(),
+            platform: "teams".into(),
+            channel: ReplyChannel {
+                id: "conversation-1".into(),
+                thread_id: None,
+            },
+            content: Content {
+                content_type: "text".into(),
+                text: "reply text".into(),
+                attachments: vec![],
+            },
+            command: command.map(str::to_owned),
+            request_id: None,
+            quote_message_id: None,
+        }
     }
 
     fn make_activity_with_tenant(tenant_id: Option<&str>) -> Activity {
@@ -857,6 +885,83 @@ mod tests {
     fn deserialize_invalid_json_fails() {
         let result = serde_json::from_str::<Activity>("not json");
         assert!(result.is_err());
+    }
+
+    // --- reply command dispatch ---
+
+    #[tokio::test]
+    async fn unsupported_commands_never_fall_through_to_send_activity() {
+        let server = MockServer::start().await;
+        let _no_post = Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount_as_scoped(&server)
+            .await;
+
+        let mut config = make_config(vec![]);
+        config.oauth_endpoint = format!("{}/token", server.uri());
+        let adapter = TeamsAdapter::new(config);
+        let service_urls = tokio::sync::Mutex::new(std::collections::HashMap::from([(
+            "conversation-1".to_string(),
+            (server.uri(), std::time::Instant::now()),
+        )]));
+
+        for command in ["add_reaction", "remove_reaction"] {
+            let outcome = handle_reply(&make_reply(Some(command)), &adapter, &service_urls)
+                .await
+                .unwrap();
+            assert_eq!(outcome, None, "reaction command {command} should be a no-op");
+        }
+
+        for command in [
+            "create_topic",
+            "edit_message",
+            "delete_message",
+            "future_unknown_command",
+        ] {
+            let error = handle_reply(&make_reply(Some(command)), &adapter, &service_urls)
+                .await
+                .unwrap_err();
+            assert!(
+                error.to_string().contains(command),
+                "error should identify unsupported command {command}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn commandless_reply_still_sends_one_activity() {
+        let server = MockServer::start().await;
+        let _token = Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "test-token",
+                "expires_in": 3600
+            })))
+            .expect(1)
+            .mount_as_scoped(&server)
+            .await;
+        let _activity = Mock::given(method("POST"))
+            .and(path("/v3/conversations/conversation-1/activities"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"id": "activity-1"})),
+            )
+            .expect(1)
+            .mount_as_scoped(&server)
+            .await;
+
+        let mut config = make_config(vec![]);
+        config.oauth_endpoint = format!("{}/token", server.uri());
+        let adapter = TeamsAdapter::new(config);
+        let service_urls = tokio::sync::Mutex::new(std::collections::HashMap::from([(
+            "conversation-1".to_string(),
+            (server.uri(), std::time::Instant::now()),
+        )]));
+
+        let message_id = handle_reply(&make_reply(None), &adapter, &service_urls)
+            .await
+            .unwrap();
+        assert_eq!(message_id.as_deref(), Some("activity-1"));
     }
 
     // --- TeamsConfig::from_env ---

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -435,6 +435,9 @@ pub async fn handle_reply(
                         thread_id: tid,
                         message_id: None,
                         error: None,
+                        outcome: Some(crate::schema::WriteOutcomeKind::Delivered),
+                        error_code: None,
+                        retry_after_ms: None,
                     }
                 } else {
                     let err = body["description"]
@@ -449,6 +452,9 @@ pub async fn handle_reply(
                         thread_id: None,
                         message_id: None,
                         error: Some(err),
+                        outcome: Some(crate::schema::WriteOutcomeKind::Rejected),
+                        error_code: Some("platform_rejected".into()),
+                        retry_after_ms: None,
                     }
                 }
             }
@@ -459,6 +465,9 @@ pub async fn handle_reply(
                 thread_id: None,
                 message_id: None,
                 error: Some(e.to_string()),
+                outcome: Some(crate::schema::WriteOutcomeKind::Unknown),
+                error_code: Some("transport_error".into()),
+                retry_after_ms: None,
             },
         };
         let json = serde_json::to_string(&gw_resp).unwrap();

--- a/crates/openab-gateway/src/adapters/wecom.rs
+++ b/crates/openab-gateway/src/adapters/wecom.rs
@@ -466,6 +466,9 @@ impl WecomAdapter {
                     thread_id: None,
                     message_id: placeholder_id,
                     error: None,
+                    outcome: None,
+                    error_code: None,
+                    retry_after_ms: None,
                 };
                 if let Ok(json) = serde_json::to_string(&resp) {
                     let _ = event_tx.send(json);
@@ -502,6 +505,9 @@ impl WecomAdapter {
                         thread_id: None,
                         message_id: None,
                         error: None,
+                        outcome: None,
+                        error_code: None,
+                        retry_after_ms: None,
                     };
                     if let Ok(json) = serde_json::to_string(&resp) {
                         let _ = event_tx.send(json);
@@ -536,6 +542,9 @@ impl WecomAdapter {
                 thread_id: None,
                 message_id: msg_id,
                 error: None,
+                outcome: None,
+                error_code: None,
+                retry_after_ms: None,
             };
             if let Ok(json) = serde_json::to_string(&resp) {
                 let _ = event_tx.send(json);

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -1245,12 +1245,19 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
                             #[cfg(feature = "teams")]
                             "teams" => {
                                 if let Some(ref teams) = state_for_recv.teams {
-                                    adapters::teams::handle_reply(
+                                    if let Err(e) = adapters::teams::handle_reply(
                                         &reply,
                                         teams,
                                         &state_for_recv.teams_service_urls,
                                     )
-                                    .await;
+                                    .await
+                                    {
+                                        tracing::error!(
+                                            error = %e,
+                                            command = ?reply.command.as_deref(),
+                                            "teams reply rejected"
+                                        );
+                                    }
                                 } else {
                                     warn!("reply for teams but adapter not configured");
                                 }

--- a/crates/openab-gateway/src/lib.rs
+++ b/crates/openab-gateway/src/lib.rs
@@ -4,6 +4,7 @@ pub mod schema;
 pub mod store;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::{broadcast, Mutex, Semaphore};
@@ -85,6 +86,9 @@ pub struct AppState {
     pub lineworks: Option<Arc<adapters::lineworks::LineWorksAdapter>>,
     pub ws_token: Option<String>,
     pub event_tx: broadcast::Sender<String>,
+    /// Number of active OAB WebSocket consumers. M0 supports one; additional
+    /// consumers are admitted for compatibility but marked unsupported.
+    pub active_oab_consumers: Arc<AtomicUsize>,
     pub reply_token_cache: ReplyTokenCache,
     pub line_webhook_semaphore: Arc<Semaphore>,
     /// Bounds post-ack LINE WORKS webhook processing (mention gate + attachment download).
@@ -96,7 +100,6 @@ pub struct AppState {
     pub trust_probe: Option<IngressTrustProbe>,
     pub client: reqwest::Client,
 }
-
 
 impl AppState {
     /// Create a minimal AppState for testing. Only requires an `event_tx` sender;
@@ -139,11 +142,14 @@ impl AppState {
             lineworks: None,
             ws_token: None,
             event_tx,
+            active_oab_consumers: Arc::new(AtomicUsize::new(0)),
             reply_token_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             line_webhook_semaphore: Arc::new(Semaphore::new(LINE_WEBHOOK_CONCURRENCY_MAX)),
-        lineworks_webhook_semaphore: Arc::new(Semaphore::new(LINEWORKS_WEBHOOK_CONCURRENCY_MAX)),
-        lineworks_ingress_queue: Arc::new(Semaphore::new(LINEWORKS_INGRESS_QUEUE_MAX)),
-        trust_probe: None,
+            lineworks_webhook_semaphore: Arc::new(Semaphore::new(
+                LINEWORKS_WEBHOOK_CONCURRENCY_MAX,
+            )),
+            lineworks_ingress_queue: Arc::new(Semaphore::new(LINEWORKS_INGRESS_QUEUE_MAX)),
+            trust_probe: None,
             client: reqwest::Client::new(),
         }
     }
@@ -261,6 +267,7 @@ impl AppState {
             lineworks,
             ws_token,
             event_tx,
+            active_oab_consumers: Arc::new(AtomicUsize::new(0)),
             reply_token_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             line_webhook_semaphore: Arc::new(Semaphore::new(LINE_WEBHOOK_CONCURRENCY_MAX)),
         lineworks_webhook_semaphore: Arc::new(Semaphore::new(LINEWORKS_WEBHOOK_CONCURRENCY_MAX)),
@@ -268,6 +275,122 @@ impl AppState {
         trust_probe: None,
             client,
         }
+    }
+
+    /// Capabilities advertised to a new Core during the optional WebSocket
+    /// hello exchange. Only configured adapters are included, and operation ACK
+    /// flags are conservative: a platform is advertised only when its current
+    /// handler emits a GatewayResponse for that operation.
+    pub fn gateway_capabilities(&self) -> HashMap<String, schema::AdapterCapabilities> {
+        use schema::{AdapterCapabilities, MessageLimit, StatusBackend, StreamingMode};
+
+        let mut capabilities = HashMap::new();
+        let mut insert = |platform: &str, value: AdapterCapabilities| {
+            capabilities.insert(platform.to_string(), value);
+        };
+        let characters = |max| MessageLimit::Characters { max };
+
+        if self.telegram_bot_token.is_some() {
+            insert(
+                "telegram",
+                AdapterCapabilities {
+                    can_edit: self.telegram_rich_messages,
+                    streaming_mode: if self.telegram_rich_messages {
+                        StreamingMode::Edit
+                    } else {
+                        StreamingMode::Disabled
+                    },
+                    show_streaming_placeholder: !self.telegram_rich_messages,
+                    message_limit: characters(4096),
+                    status_backend: StatusBackend::Reactions,
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        if self.line_access_token.is_some() {
+            insert(
+                "line",
+                AdapterCapabilities {
+                    message_limit: characters(4096),
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        #[cfg(feature = "teams")]
+        if self.teams.is_some() {
+            insert(
+                "teams",
+                AdapterCapabilities {
+                    show_streaming_placeholder: true,
+                    message_limit: characters(4096),
+                    status_backend: StatusBackend::None,
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        #[cfg(feature = "feishu")]
+        if self.feishu.is_some() {
+            insert(
+                "feishu",
+                AdapterCapabilities {
+                    send_ack: true,
+                    edit_ack: true,
+                    delete_ack: true,
+                    can_edit: true,
+                    can_delete: true,
+                    streaming_mode: StreamingMode::Edit,
+                    message_limit: characters(4096),
+                    status_backend: StatusBackend::Reactions,
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        #[cfg(feature = "googlechat")]
+        if self.google_chat.is_some() {
+            insert(
+                "googlechat",
+                AdapterCapabilities {
+                    send_ack: true,
+                    can_edit: true,
+                    streaming_mode: StreamingMode::Edit,
+                    message_limit: characters(4096),
+                    status_backend: StatusBackend::Reactions,
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        #[cfg(feature = "wecom")]
+        if self.wecom.is_some() {
+            insert(
+                "wecom",
+                AdapterCapabilities {
+                    message_limit: characters(2048),
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        #[cfg(feature = "lineworks")]
+        if self.lineworks.is_some() {
+            insert(
+                "lineworks",
+                AdapterCapabilities {
+                    message_limit: characters(2000),
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        #[cfg(feature = "acp")]
+        if self.acp.is_some() {
+            insert(
+                "acp",
+                AdapterCapabilities {
+                    message_limit: MessageLimit::Unlimited,
+                    show_streaming_placeholder: false,
+                    ..AdapterCapabilities::default()
+                },
+            );
+        }
+        capabilities
     }
 
     /// Phase 1 L1 audit (#1356): warn loudly for each **active** webhook
@@ -843,6 +966,7 @@ pub async fn serve(config: ServeConfig) -> anyhow::Result<()> {
         lineworks,
         ws_token,
         event_tx,
+        active_oab_consumers: Arc::new(AtomicUsize::new(0)),
         reply_token_cache,
         line_webhook_semaphore: Arc::new(Semaphore::new(LINE_WEBHOOK_CONCURRENCY_MAX)),
         lineworks_webhook_semaphore: Arc::new(Semaphore::new(LINEWORKS_WEBHOOK_CONCURRENCY_MAX)),
@@ -954,22 +1078,90 @@ async fn ws_handler(
     ws.on_upgrade(move |socket| handle_oab_connection(state, socket))
 }
 
+struct ActiveConsumerGuard {
+    counter: Arc<AtomicUsize>,
+}
+
+impl ActiveConsumerGuard {
+    fn enter(counter: Arc<AtomicUsize>) -> (Self, usize) {
+        let active = counter.fetch_add(1, Ordering::AcqRel) + 1;
+        (Self { counter }, active)
+    }
+}
+
+impl Drop for ActiveConsumerGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+fn build_gateway_hello(
+    state: &AppState,
+    client_hello: &schema::GatewayClientHello,
+) -> schema::GatewayHello {
+    let mut capabilities = state.gateway_capabilities();
+    if !client_hello.requested_platforms.is_empty() {
+        capabilities.retain(|platform, _| {
+            client_hello
+                .requested_platforms
+                .iter()
+                .any(|requested| requested == platform)
+        });
+    }
+    let active_consumers = state.active_oab_consumers.load(Ordering::Acquire);
+    schema::GatewayHello {
+        schema: schema::GATEWAY_HELLO_SCHEMA.into(),
+        protocol_version: schema::GATEWAY_PROTOCOL_VERSION,
+        capabilities,
+        topology: schema::GatewayTopology {
+            active_consumers,
+            supported: active_consumers == 1,
+            delivery_mode: "best_effort_broadcast".into(),
+        },
+    }
+}
+
 async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::WebSocket) {
     use axum::extract::ws::Message;
     use futures_util::{SinkExt, StreamExt};
-    use tracing::{info, warn};
+    use tracing::{error, info, warn};
+
+    let (_consumer_guard, active_consumers) =
+        ActiveConsumerGuard::enter(state.active_oab_consumers.clone());
+    if active_consumers > 1 {
+        error!(
+            active_consumers,
+            topology_supported = false,
+            "multiple active OAB consumers detected; M0 broadcast topology is unsupported and may duplicate events"
+        );
+    }
 
     let (mut ws_tx, mut ws_rx) = socket.split();
     let mut event_rx = state.event_tx.subscribe();
+    let (control_tx, mut control_rx) = tokio::sync::mpsc::channel::<String>(4);
 
-    info!("OAB client connected via WebSocket");
+    info!(active_consumers, "OAB client connected via WebSocket");
 
-    let send_task = tokio::spawn(async move {
+    let mut send_task = tokio::spawn(async move {
         loop {
             tokio::select! {
-                Ok(event_json) = event_rx.recv() => {
-                    if ws_tx.send(Message::Text(event_json.into())).await.is_err() {
+                biased;
+                Some(control_json) = control_rx.recv() => {
+                    if ws_tx.send(Message::Text(control_json.into())).await.is_err() {
                         break;
+                    }
+                }
+                event = event_rx.recv() => {
+                    match event {
+                        Ok(event_json) => {
+                            if ws_tx.send(Message::Text(event_json.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            warn!(skipped, "OAB consumer lagged gateway broadcast; events were lost");
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                     }
                 }
             }
@@ -979,10 +1171,37 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
     let state_for_recv = state.clone();
     let reaction_state: Arc<Mutex<HashMap<String, Vec<String>>>> =
         Arc::new(Mutex::new(HashMap::new()));
-    let recv_task = tokio::spawn(async move {
+    let mut recv_task = tokio::spawn(async move {
         let client = reqwest::Client::new();
         while let Some(Ok(msg)) = ws_rx.next().await {
             if let Message::Text(text) = msg {
+                if let Ok(envelope) = serde_json::from_str::<schema::GatewayEnvelope>(&text) {
+                    if envelope.schema == schema::CLIENT_HELLO_SCHEMA {
+                        match serde_json::from_str::<schema::GatewayClientHello>(&text) {
+                            Ok(client_hello) => {
+                                if client_hello.protocol_version != schema::GATEWAY_PROTOCOL_VERSION {
+                                    warn!(
+                                        client_version = client_hello.protocol_version,
+                                        gateway_version = schema::GATEWAY_PROTOCOL_VERSION,
+                                        "gateway protocol version differs; responding with supported version"
+                                    );
+                                }
+                                let hello = build_gateway_hello(&state_for_recv, &client_hello);
+                                if let Ok(json) = serde_json::to_string(&hello) {
+                                    if control_tx.send(json).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                continue;
+                            }
+                            Err(error) => {
+                                warn!(error = %error, "invalid gateway client hello");
+                                continue;
+                            }
+                        }
+                    }
+                }
+
                 match serde_json::from_str::<schema::GatewayReply>(&text) {
                     Ok(reply) => {
                         info!(
@@ -1101,8 +1320,8 @@ async fn handle_oab_connection(state: Arc<AppState>, socket: axum::extract::ws::
     });
 
     tokio::select! {
-        _ = send_task => {},
-        _ = recv_task => {},
+        _ = &mut send_task => recv_task.abort(),
+        _ = &mut recv_task => send_task.abort(),
     }
     info!("OAB client disconnected");
 }
@@ -1191,7 +1410,11 @@ mod l1_audit_tests {
             pairs: pairs.clone(),
         });
         assert!(s.feishu.is_some());
-        let cfg = &s.feishu.as_ref().unwrap().config;
+        let cfg = &s
+            .feishu
+            .as_ref()
+            .expect("complete Feishu credentials should build an adapter")
+            .config;
         assert_eq!(cfg.app_id, "cli_x");
         assert!(matches!(
             cfg.connection_mode,
@@ -1201,6 +1424,14 @@ mod l1_audit_tests {
         // Config-supplied encrypt_key satisfies the L1 startup check
         // when the webhook route is exposed.
         assert!(s.unenforceable_l1(true).is_empty());
+        let capabilities = s.gateway_capabilities();
+        let feishu = capabilities
+            .get("feishu")
+            .expect("configured Feishu adapter should advertise capabilities");
+        assert!(feishu.send_ack);
+        assert!(feishu.edit_ack);
+        assert!(feishu.delete_ack);
+        assert_eq!(feishu.streaming_mode, super::schema::StreamingMode::Edit);
 
         // Missing secret → adapter disabled.
         pairs.remove("FEISHU_APP_SECRET");
@@ -1224,6 +1455,15 @@ mod l1_audit_tests {
         });
         assert!(s.teams.is_some());
         assert_eq!(s.teams_webhook_path, "/hook/teams");
+        let capabilities = s.gateway_capabilities();
+        let teams = capabilities
+            .get("teams")
+            .expect("configured Teams adapter should advertise capabilities");
+        assert!(!teams.send_ack);
+        assert!(!teams.can_edit);
+        assert_eq!(teams.streaming_mode, super::schema::StreamingMode::Disabled);
+        assert!(teams.show_streaming_placeholder);
+        assert_eq!(teams.status_backend, super::schema::StatusBackend::None);
 
         // Missing secret → adapter disabled (same as env-only semantics).
         s.apply_teams_config(GatewayTeamsConfig {
@@ -1297,6 +1537,151 @@ mod l1_audit_tests {
         assert_eq!(s.line_webhook_path, "/hook/line");
         // Config-supplied secret satisfies the L1 startup check.
         assert!(flagged(&s).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod gateway_protocol_tests {
+    use super::*;
+    use anyhow::Context as _;
+    use axum::{routing::get, Router};
+    use futures_util::{SinkExt, StreamExt};
+    use tokio::time::{sleep, timeout, Duration};
+    use tokio_tungstenite::tungstenite::Message;
+
+    type TestSocket = tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >;
+
+    async fn start_server(
+        state: AppState,
+    ) -> anyhow::Result<(
+        std::net::SocketAddr,
+        Arc<AppState>,
+        tokio::task::JoinHandle<()>,
+    )> {
+        let state = Arc::new(state);
+        let app = Router::new()
+            .route("/ws", get(ws_handler))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("loopback test server should run");
+        });
+        Ok((addr, state, task))
+    }
+
+    async fn wait_for_consumers(state: &AppState, expected: usize) -> anyhow::Result<()> {
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if state.active_oab_consumers.load(Ordering::Acquire) == expected {
+                    return;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await?;
+        Ok(())
+    }
+
+    async fn next_text(socket: &mut TestSocket) -> anyhow::Result<String> {
+        let message = timeout(Duration::from_secs(1), socket.next())
+            .await?
+            .context("test WebSocket closed before a frame arrived")??;
+        Ok(message.into_text()?)
+    }
+
+    #[tokio::test]
+    async fn hello_advertises_requested_capabilities_and_topology() -> anyhow::Result<()> {
+        let (event_tx, _event_rx) = broadcast::channel(8);
+        let mut app_state = AppState::test_default(event_tx);
+        app_state.telegram_bot_token = Some("bot-token".into());
+        app_state.telegram_rich_messages = true;
+        app_state.line_access_token = Some("line-token".into());
+        let (addr, state, server) = start_server(app_state).await?;
+        let url = format!("ws://{addr}/ws");
+
+        let (mut first, _) = tokio_tungstenite::connect_async(&url).await?;
+        let client_hello = schema::GatewayClientHello {
+            schema: schema::CLIENT_HELLO_SCHEMA.into(),
+            protocol_version: schema::GATEWAY_PROTOCOL_VERSION,
+            client_name: Some("test-core".into()),
+            requested_platforms: vec!["telegram".into()],
+        };
+        first
+            .send(Message::Text(serde_json::to_string(&client_hello)?))
+            .await?;
+        let text = next_text(&mut first).await?;
+        let hello: schema::GatewayHello = serde_json::from_str(&text)?;
+        assert_eq!(hello.protocol_version, schema::GATEWAY_PROTOCOL_VERSION);
+        assert_eq!(hello.capabilities.len(), 1);
+        let telegram = hello
+            .capabilities
+            .get("telegram")
+            .context("telegram capability should be advertised")?;
+        assert_eq!(telegram.streaming_mode, schema::StreamingMode::Edit);
+        assert!(!telegram.show_streaming_placeholder);
+        assert!(hello.topology.supported);
+        assert_eq!(hello.topology.active_consumers, 1);
+
+        let (mut second, _) = tokio_tungstenite::connect_async(&url).await?;
+        second
+            .send(Message::Text(serde_json::to_string(&client_hello)?))
+            .await?;
+        let text = next_text(&mut second).await?;
+        let hello: schema::GatewayHello = serde_json::from_str(&text)?;
+        assert!(!hello.topology.supported);
+        assert_eq!(hello.topology.active_consumers, 2);
+        assert_eq!(hello.topology.delivery_mode, "best_effort_broadcast");
+
+        second.close(None).await?;
+        wait_for_consumers(&state, 1).await?;
+        first.close(None).await?;
+        wait_for_consumers(&state, 0).await?;
+        server.abort();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_client_can_send_reply_without_hello() -> anyhow::Result<()> {
+        let (event_tx, _event_rx) = broadcast::channel(8);
+        let app_state = AppState::test_default(event_tx);
+        let (addr, state, server) = start_server(app_state).await?;
+        let url = format!("ws://{addr}/ws");
+        let (mut socket, _) = tokio_tungstenite::connect_async(&url).await?;
+        wait_for_consumers(&state, 1).await?;
+
+        let legacy_reply = schema::GatewayReply {
+            schema: "openab.gateway.reply.v1".into(),
+            reply_to: "evt-1".into(),
+            platform: "unknown".into(),
+            channel: schema::ReplyChannel {
+                id: "channel-1".into(),
+                thread_id: None,
+            },
+            content: schema::Content {
+                content_type: "text".into(),
+                text: "hello".into(),
+                attachments: Vec::new(),
+            },
+            command: None,
+            request_id: None,
+            quote_message_id: None,
+        };
+        socket
+            .send(Message::Text(serde_json::to_string(&legacy_reply)?))
+            .await?;
+
+        state.event_tx.send("legacy-event".into())?;
+        assert_eq!(next_text(&mut socket).await?, "legacy-event");
+
+        socket.close(None).await?;
+        wait_for_consumers(&state, 0).await?;
+        server.abort();
+        Ok(())
     }
 }
 

--- a/crates/openab-gateway/src/schema.rs
+++ b/crates/openab-gateway/src/schema.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 // --- Event schema (ADR openab.gateway.event.v1) ---
 
@@ -98,6 +99,107 @@ impl Attachment {
     }
 }
 
+// --- Gateway protocol negotiation and capability schema ---
+
+pub const CLIENT_HELLO_SCHEMA: &str = "openab.gateway.client_hello.v1";
+pub const GATEWAY_HELLO_SCHEMA: &str = "openab.gateway.hello.v1";
+pub const GATEWAY_PROTOCOL_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GatewayEnvelope {
+    pub schema: String,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamingMode {
+    #[default]
+    Disabled,
+    Edit,
+    Native,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "unit", rename_all = "snake_case")]
+pub enum MessageLimit {
+    Characters { max: usize },
+    Bytes { max: usize },
+    Utf16Bytes { max: usize },
+    Unlimited,
+}
+
+impl Default for MessageLimit {
+    fn default() -> Self {
+        Self::Characters { max: 4096 }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusBackend {
+    #[default]
+    None,
+    Reactions,
+    Assistant,
+    Typing,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AdapterCapabilities {
+    pub send_ack: bool,
+    pub edit_ack: bool,
+    pub delete_ack: bool,
+    pub can_edit: bool,
+    pub can_delete: bool,
+    pub streaming_mode: StreamingMode,
+    pub show_streaming_placeholder: bool,
+    pub message_limit: MessageLimit,
+    pub status_backend: StatusBackend,
+}
+
+impl Default for AdapterCapabilities {
+    fn default() -> Self {
+        Self {
+            send_ack: false,
+            edit_ack: false,
+            delete_ack: false,
+            can_edit: false,
+            can_delete: false,
+            streaming_mode: StreamingMode::Disabled,
+            show_streaming_placeholder: true,
+            message_limit: MessageLimit::default(),
+            status_backend: StatusBackend::None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GatewayClientHello {
+    pub schema: String,
+    pub protocol_version: u32,
+    #[serde(default)]
+    pub client_name: Option<String>,
+    #[serde(default)]
+    pub requested_platforms: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GatewayHello {
+    pub schema: String,
+    pub protocol_version: u32,
+    #[serde(default)]
+    pub capabilities: HashMap<String, AdapterCapabilities>,
+    pub topology: GatewayTopology,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GatewayTopology {
+    pub active_consumers: usize,
+    pub supported: bool,
+    pub delivery_mode: String,
+}
+
 // --- Reply schema (ADR openab.gateway.reply.v1) ---
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -125,7 +227,36 @@ pub struct ReplyChannel {
     pub thread_id: Option<String>,
 }
 
-/// Response from gateway back to OAB for commands (e.g. create_topic)
+/// Stable wire discriminator for additive write-outcome fields.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WriteOutcomeKind {
+    Delivered,
+    Rejected,
+    Unknown,
+}
+
+/// Internal result of a platform write. `Unknown` prevents unsafe retries when
+/// a timed-out POST may already have reached the platform.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WriteOutcome {
+    Delivered {
+        message_id: Option<String>,
+    },
+    Rejected {
+        code: String,
+        message: String,
+        retry_after_ms: Option<u64>,
+    },
+    Unknown {
+        code: String,
+        message: String,
+    },
+}
+
+/// Response from gateway back to OAB for commands and acknowledged writes.
+/// The legacy fields remain required; outcome metadata is additive so old peers
+/// can ignore it and new peers can distinguish rejection from uncertainty.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GatewayResponse {
     pub schema: String,
@@ -134,6 +265,91 @@ pub struct GatewayResponse {
     pub thread_id: Option<String>,
     pub message_id: Option<String>,
     pub error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outcome: Option<WriteOutcomeKind>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after_ms: Option<u64>,
+}
+
+impl GatewayResponse {
+    pub fn from_write_outcome(request_id: impl Into<String>, outcome: WriteOutcome) -> Self {
+        let request_id = request_id.into();
+        match outcome {
+            WriteOutcome::Delivered { message_id } => Self {
+                schema: "openab.gateway.response.v1".into(),
+                request_id,
+                success: true,
+                thread_id: None,
+                message_id,
+                error: None,
+                outcome: Some(WriteOutcomeKind::Delivered),
+                error_code: None,
+                retry_after_ms: None,
+            },
+            WriteOutcome::Rejected {
+                code,
+                message,
+                retry_after_ms,
+            } => Self {
+                schema: "openab.gateway.response.v1".into(),
+                request_id,
+                success: false,
+                thread_id: None,
+                message_id: None,
+                error: Some(message),
+                outcome: Some(WriteOutcomeKind::Rejected),
+                error_code: Some(code),
+                retry_after_ms,
+            },
+            WriteOutcome::Unknown { code, message } => Self {
+                schema: "openab.gateway.response.v1".into(),
+                request_id,
+                success: false,
+                thread_id: None,
+                message_id: None,
+                error: Some(message),
+                outcome: Some(WriteOutcomeKind::Unknown),
+                error_code: Some(code),
+                retry_after_ms: None,
+            },
+        }
+    }
+
+    pub fn write_outcome(&self) -> WriteOutcome {
+        match self.outcome {
+            Some(WriteOutcomeKind::Delivered) => WriteOutcome::Delivered {
+                message_id: self.message_id.clone(),
+            },
+            Some(WriteOutcomeKind::Rejected) => WriteOutcome::Rejected {
+                code: self.error_code.clone().unwrap_or_else(|| "rejected".into()),
+                message: self
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "gateway rejected write".into()),
+                retry_after_ms: self.retry_after_ms,
+            },
+            Some(WriteOutcomeKind::Unknown) => WriteOutcome::Unknown {
+                code: self.error_code.clone().unwrap_or_else(|| "unknown".into()),
+                message: self
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "gateway write outcome is unknown".into()),
+            },
+            None if self.success => WriteOutcome::Delivered {
+                message_id: self.message_id.clone(),
+            },
+            None => WriteOutcome::Rejected {
+                code: "legacy_failure".into(),
+                message: self
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "gateway reported failure".into()),
+                retry_after_ms: None,
+            },
+        }
+    }
 }
 
 impl GatewayEvent {
@@ -161,5 +377,103 @@ impl GatewayEvent {
             mentions,
             message_id: message_id.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+
+    #[test]
+    fn legacy_response_deserializes_without_outcome_fields() {
+        let response: GatewayResponse = serde_json::from_value(serde_json::json!({
+            "schema": "openab.gateway.response.v1",
+            "request_id": "req-1",
+            "success": true,
+            "thread_id": null,
+            "message_id": "activity-1",
+            "error": null
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.write_outcome(),
+            WriteOutcome::Delivered {
+                message_id: Some("activity-1".into())
+            }
+        );
+        let encoded = serde_json::to_value(response).unwrap();
+        assert!(encoded.get("outcome").is_none());
+        assert!(encoded.get("error_code").is_none());
+        assert!(encoded.get("retry_after_ms").is_none());
+    }
+
+    #[test]
+    fn structured_write_outcomes_round_trip() {
+        let outcomes = [
+            WriteOutcome::Delivered {
+                message_id: Some("activity-2".into()),
+            },
+            WriteOutcome::Rejected {
+                code: "rate_limited".into(),
+                message: "retry later".into(),
+                retry_after_ms: Some(750),
+            },
+            WriteOutcome::Unknown {
+                code: "request_timeout".into(),
+                message: "delivery may have completed".into(),
+            },
+        ];
+
+        for (index, expected) in outcomes.into_iter().enumerate() {
+            let response =
+                GatewayResponse::from_write_outcome(format!("req-{index}"), expected.clone());
+            let json = serde_json::to_string(&response).unwrap();
+            let decoded: GatewayResponse = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded.write_outcome(), expected);
+        }
+    }
+
+    #[test]
+    fn structured_response_remains_decodable_by_legacy_peer() {
+        #[derive(serde::Deserialize)]
+        struct LegacyResponse {
+            schema: String,
+            request_id: String,
+            success: bool,
+            message_id: Option<String>,
+            error: Option<String>,
+        }
+
+        let response = GatewayResponse::from_write_outcome(
+            "req-legacy",
+            WriteOutcome::Unknown {
+                code: "request_timeout".into(),
+                message: "delivery may have completed".into(),
+            },
+        );
+        let legacy: LegacyResponse =
+            serde_json::from_str(&serde_json::to_string(&response).unwrap()).unwrap();
+        assert_eq!(legacy.schema, "openab.gateway.response.v1");
+        assert_eq!(legacy.request_id, "req-legacy");
+        assert!(!legacy.success);
+        assert!(legacy.message_id.is_none());
+        assert_eq!(legacy.error.as_deref(), Some("delivery may have completed"));
+    }
+
+    #[test]
+    fn missing_capability_fields_default_fail_closed() {
+        let capabilities: AdapterCapabilities = serde_json::from_str("{}").unwrap();
+        assert!(!capabilities.send_ack);
+        assert!(!capabilities.edit_ack);
+        assert!(!capabilities.delete_ack);
+        assert!(!capabilities.can_edit);
+        assert!(!capabilities.can_delete);
+        assert_eq!(capabilities.streaming_mode, StreamingMode::Disabled);
+        assert_eq!(capabilities.status_backend, StatusBackend::None);
+        assert_eq!(
+            capabilities.message_limit,
+            MessageLimit::Characters { max: 4096 }
+        );
     }
 }

--- a/docs/adr/custom-gateway.md
+++ b/docs/adr/custom-gateway.md
@@ -6,12 +6,14 @@
 - **Supersedes:** Sections of [ADR: LINE Adapter](./line-adapter.md) (v2 Target Architecture)
 - **Superseded by:** [ADR: Separate Binaries with Opt-In Unified Build](./unified-binary.md)
 
-> **⚠️ This ADR is partially superseded by the unified binary architecture.**
-> OpenAB now supports a single unified binary mode for simplified deployment
-> (see [ADR: Separate Binaries with Opt-In Unified Build](./unified-binary.md)).
-> While the unified binary is the recommended path for standard setups, the
-> standalone gateway architecture remains fully supported for deployments
-> requiring strict outbound-only network isolation for the OpenAB core.
+> **Standing: historical reference only.** This ADR records the original
+> standalone-gateway proposal and is not operative implementation instruction.
+> Unified mode is the standard deployment path; standalone Gateway remains
+> supported when Core must stay outbound-only. For operative protocol and delivery
+> requirements, use [Separate Binaries with Opt-In Unified Build](./unified-binary.md)
+> and [Gateway Capabilities and Delivery Semantics](gateway-capabilities-and-delivery-semantics.md).
+> Every requirement, rollout step, and compliance statement below describes this
+> superseded proposal unless a non-superseded ADR explicitly adopts it.
 
 ---
 
@@ -22,6 +24,7 @@ As an OpenAB operator, I want to connect webhook-based platforms (LINE, Telegram
 As a platform integrator, I want to write a plugin/adapter for my platform and register it with the gateway, so that any webhook source can drive an OAB agent session without upstream code changes.
 
 Requirements:
+
 - OAB core must remain outbound-only — no inbound ports, no TLS, no K8s Service
 - The gateway is a separate, independently deployable service
 - Adding a new webhook platform requires only a gateway plugin, zero OAB changes
@@ -101,7 +104,7 @@ Outbound (OAB → platform):
 
 ---
 
-## 3. Internal Event Schema
+## 3. Historical Internal Event Schema
 
 The contract between the gateway and OAB. All platform-specific details are normalized away before crossing this boundary.
 
@@ -136,6 +139,7 @@ The contract between the gateway and OAB. All platform-specific details are norm
 ```
 
 Key fields in the base schema:
+
 - **`channel.thread_id`**: thread identifier for platforms that support threads (Discord thread ID, Slack `thread_ts`). `null` for platforms without threads (LINE). OAB uses this for session key construction — without it, per-thread session isolation cannot work through the gateway.
 - **`mentions`**: array of mentioned entity IDs (users, bots). Required for @mention gating — the gateway adapter parses platform-specific mention formats and normalizes them here. Without it, OAB cannot determine whether the bot was mentioned, breaking the primary mitigation for LINE group chat noise and Discord/Slack trigger logic.
 
@@ -157,7 +161,10 @@ Key fields in the base schema:
 ```
 
 Key fields in the outbound reply:
-- **`reply_to`**: the `event_id` of the inbound `GatewayEvent` that triggered this reply. The gateway can use this for reply correlation — e.g., looking up a cached LINE reply token to prefer the free Reply API over the quota-consuming Push API. Empty string if the reply is not associated with a specific inbound event (e.g., cron-triggered messages).
+
+- **`reply_to`**: the `event_id` of the inbound `GatewayEvent` that triggered this reply. The gateway can use this for reply correlation — e.g., looking up a cached LINE reply token to prefer the free Reply API over the quota-consuming Push API. Empty string if the reply is not associated with a specific inbound event (e.g., cron-triggered messages). Legacy command peers may still overload it with a platform target.
+- **`quote_message_id`**: optional platform message selected for visual reply/quote behavior; it is distinct from origin correlation.
+- **`target_message_id`**: additive optional target for edit/delete/reaction commands. Core uses it only when the negotiated capability advertises support; otherwise it copies the target into legacy `reply_to`.
 
 ### Design Principles for the Schema
 
@@ -178,9 +185,11 @@ The following fields/concepts are known to be needed but are not fully defined i
 | `reply_context` | Reply token, quote target, original message reference — not all platforms only need `channel.id` to deliver a reply |
 | `tenant` / `gateway_instance` | Multi-tenancy routing if a shared gateway serves multiple OAB instances |
 
+The capability and delivery-result portion is resolved by [Gateway Capabilities and Delivery Semantics](gateway-capabilities-and-delivery-semantics.md). Teams process-local route and duplicate-suppression behavior is resolved by [Teams Ephemeral Ingress Route and Duplicate Suppression](teams-ephemeral-ingress-state.md), its event correlation plus real send ACK by [Teams Real Send Acknowledgement and Reply Correlation](teams-real-send-acknowledgement.md), and its explicit command target plus ownership enforcement by [Teams Bot-Owned Message Mutations](teams-owned-message-mutations.md). The other rows remain deferred.
+
 ---
 
-## 4. Gateway Adapter Interface
+## 4. Historical Gateway Adapter Interface
 
 Each platform adapter implements a common interface:
 
@@ -305,7 +314,7 @@ GitHub shows the gateway handling a non-chat event. The adapter maps repo → ch
 
 ---
 
-## 7. Open Design Questions
+## 7. Historical Open Design Questions
 
 | Question | Options | Impact |
 |---|---|---|
@@ -317,11 +326,11 @@ GitHub shows the gateway handling a non-chat event. The adapter maps repo → ch
 
 ---
 
-## 8. Rollout Plan
+## 8. Historical Rollout Plan
 
 | Phase | Scope | Deliverable |
 |---|---|---|
-| **v1 (now)** | LINE adapter inside OAB | PR #521 — unblocks LINE users |
+| **v1 (2026-04-22 baseline)** | LINE adapter inside OAB | PR #521 — unblocks LINE users |
 | **v2** | Standalone gateway + OAB generic gateway adapter + LINE migrated out | Gateway service, LINE adapter, internal event schema, OAB connects via WebSocket |
 | **v3** | Multi-platform gateway | Telegram, GitHub, custom adapters |
 | **v4** | Plugin / distribution model | Third-party adapters without forking gateway |
@@ -386,10 +395,13 @@ The gateway holding all platform credentials is the correct architectural choice
 
 ---
 
-## Compliance
+## Historical Compliance Proposal
+
+These clauses governed the superseded proposal; non-superseded ADRs named in the
+standing notice above take precedence.
 
 1. **OAB outbound-only**: after adoption of the custom gateway architecture, new platform integrations must not add inbound platform-traffic handling to OAB core unless explicitly approved by a superseding ADR.
-2. **Event schema stability**: the `openab.gateway.event.v1` schema is currently a draft envelope for v2 development. The protocol spec must finalize all required fields (including deferred concerns in Section 3) before the schema is declared stable. Once declared stable, breaking changes require a version bump (`v2`) and a migration path.
+2. **Event schema stability**: at ADR version 0.2 (2026-06-29), `openab.gateway.event.v1` was a draft envelope for v2 development. Current wire stability is defined by the implementation and [Gateway Capabilities and Delivery Semantics](gateway-capabilities-and-delivery-semantics.md); this historical clause has no independent authority.
 3. **Credential isolation**: platform credentials (tokens, secrets) must reside in the gateway, not in OAB. OAB must not hold or access platform-specific authentication material.
 4. **Adapter interface compliance**: all gateway adapters must implement `validate`, `parse`, `send`, and `health`. Adapters that skip signature validation must be explicitly flagged as insecure.
 5. **Webhook correctness**: all adapters must validate signatures against exact raw request body bytes, per the constraints defined in [ADR: LINE Adapter](./line-adapter.md) Compliance #1.

--- a/docs/adr/gateway-capabilities-and-delivery-semantics.md
+++ b/docs/adr/gateway-capabilities-and-delivery-semantics.md
@@ -1,0 +1,241 @@
+# ADR: Gateway Capabilities and Delivery Semantics
+
+- **Status:** Proposed
+- **Date:** 2026-08-06
+- **Author:** @NeoHsu
+- **Related:**
+  - [Custom Gateway](custom-gateway.md)
+  - [Unified Binary](unified-binary.md)
+  - [Multi-Platform Adapters](multi-platform-adapters.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+  - [Teams message reactions preview](teams-message-reactions-preview.md)
+
+---
+
+## Context
+
+OpenAB has two paths for webhook-based chat platforms:
+
+1. **Unified:** platform adapters and Core run in one process.
+2. **Standalone:** Core connects to `openab-gateway` through `/ws`.
+
+Before this decision, Core inferred behavior from adapter-wide methods and platform-name allowlists. That caused three classes of error:
+
+- a shared Unified adapter could apply Telegram streaming settings to Teams;
+- Standalone Core could not know whether a Gateway acknowledged send, edit, or delete operations;
+- a transport timeout could not be distinguished from an explicit platform rejection.
+
+The Standalone event channel is a bounded in-process broadcast channel. It has no durable inbox, replay, shared deduplication store, or consumer-group semantics. Multiple Core consumers therefore receive duplicate events rather than distributed work.
+
+## Decision
+
+### 1. Proposed baseline product decisions
+
+The following decisions define this proposed single-process baseline:
+
+| ID | Decision |
+| --- | --- |
+| D1 | The baseline supports one process replica and one active Standalone Core consumer per platform. Ingress after local enqueue is best-effort; there is no crash replay or exactly-once claim. A second consumer is warned at high severity and reported as unsupported, but is not rejected in this backward-compatible release. |
+| D2 | Standalone uses an optional, client-initiated capability handshake. A peer that does not complete a supported handshake remains in legacy mode; missing ACKs are not delivery failures in legacy mode. |
+| D3 | `GatewayEvent.event_id` is correlation metadata, never a platform activity ID. New↔new create/send returns the real platform message ID. Teams client presentation is outside transport acknowledgement semantics. |
+| D4 | Teams supports Microsoft commercial public cloud only. Sovereign-cloud and custom-proxy endpoints require an explicit future cloud profile. |
+| D5 | User-visible status and content streaming are independent capabilities. Teams processing status must not reuse a streaming placeholder implicitly. |
+
+### 2. Platform-aware capability contract
+
+Each adapter exposes capabilities for the actual `ChannelRef.platform`:
+
+```rust
+struct AdapterCapabilities {
+    send_ack: bool,
+    edit_ack: bool,
+    delete_ack: bool,
+    supports_target_message_id: bool,
+    supports_reactions: bool,
+    can_edit: bool,
+    can_delete: bool,
+    streaming_mode: StreamingMode,
+    show_streaming_placeholder: bool,
+    message_limit: MessageLimit,
+    status_backend: StatusBackend,
+}
+```
+
+Capability defaults fail closed:
+
+- no required ACK;
+- no additive command-target field or native reaction support;
+- no edit or delete support;
+- streaming disabled;
+- status side effects disabled;
+- a conservative 4,096-character message limit.
+
+Direct adapters derive a backward-compatible capability view from their existing methods. Unified and Standalone shared adapters override it by platform.
+
+A valid negotiated hello is authoritative. If a platform is omitted from a valid hello, Core uses fail-closed defaults rather than optimistic legacy behavior. Legacy behavior is used only before a supported hello is accepted.
+
+### 3. Optional Standalone hello exchange
+
+Core sends this additive control frame immediately after connecting:
+
+```json
+{
+  "schema": "openab.gateway.client_hello.v1",
+  "protocol_version": 1,
+  "client_name": "openab-core/<version>",
+  "requested_platforms": ["teams"]
+}
+```
+
+A new Gateway responds:
+
+```json
+{
+  "schema": "openab.gateway.hello.v1",
+  "protocol_version": 1,
+  "capabilities": {
+    "teams": {
+      "send_ack": true,
+      "edit_ack": true,
+      "delete_ack": true,
+      "supports_target_message_id": true,
+      "supports_reactions": false,
+      "can_edit": true,
+      "can_delete": true,
+      "streaming_mode": "disabled",
+      "show_streaming_placeholder": true,
+      "message_limit": { "unit": "characters", "max": 4096 },
+      "status_backend": "none"
+    }
+  },
+  "topology": {
+    "active_consumers": 1,
+    "supported": true,
+    "delivery_mode": "best_effort_broadcast"
+  }
+}
+```
+
+Rules:
+
+- unknown JSON fields are additive and may be ignored;
+- an empty `requested_platforms` list requests all configured adapters; the stock Core uses this because one Standalone socket can carry events from several platforms;
+- protocol version mismatch, malformed hello, or no hello keeps Core in legacy mode;
+- Gateway continues to accept `openab.gateway.reply.v1` as the first frame, so an old Core works with a new Gateway;
+- a new Core may send `client_hello` to an old Gateway; the old Gateway may log it as an invalid reply but must keep the connection usable;
+- operations emitted before a valid hello is processed use legacy semantics;
+- control frames are prioritized over broadcast events once received.
+
+Recommended Standalone rollout order remains Gateway first, then Core, but either side may be upgraded first.
+
+### 4. Structured write outcome
+
+Gateway keeps the existing `openab.gateway.response.v1` fields and adds optional fields:
+
+- `outcome`: `delivered`, `rejected`, or `unknown`;
+- `error_code`;
+- `retry_after_ms`.
+
+The internal result is:
+
+```rust
+enum WriteOutcome {
+    Delivered { message_id: Option<String> },
+    Rejected {
+        code: String,
+        message: String,
+        retry_after_ms: Option<u64>,
+    },
+    Unknown { code: String, message: String },
+}
+```
+
+Semantics:
+
+- create/send delivery requires a non-empty real message ID when that operation advertises required ACK support;
+- edit/delete delivery does not require a message ID in its ACK;
+- explicit platform refusal is `Rejected`;
+- an ambiguous POST timeout or disconnect is `Unknown` and must not be retried blindly;
+- legacy responses without `outcome` map from the existing `success`, `message_id`, and `error` fields;
+- Core waits only for an operation whose capability advertises the corresponding ACK;
+- Teams advertises `send_ack = true` only after its event-route send path emits a terminal structured response with a non-empty Bot Framework activity ID on delivery;
+- Teams advertises edit/delete ACK and `supports_target_message_id` only after bot-owned mutation enforcement emits a terminal response on every command path;
+- Teams advertises `supports_reactions = true` and `status_backend = reactions` only under the explicit public-preview `reactions_enabled` opt-in; the default remains false/`none`;
+- `supports_reactions` is independent from the selected progress backend so permanent batch receipts can coexist with a processing message; new Core normalizes an old peer's `status_backend = reactions` to reaction support;
+- configured Teams processing messages are selected Core-side only after a valid hello advertises required send/edit/delete ACKs, additive command targets, and bot-owned edit/delete; no valid hello means no message status;
+- negotiated required ACK timeout defaults to 12 seconds and is configurable as `[gateway].gateway_ack_timeout_secs`;
+- configuration rejects zero, a budget at or above `pool.prompt_hard_timeout_secs`, and a Teams budget at or below the 10-second Connector timeout;
+- legacy response waits preserve their previous best-effort behavior.
+
+The 12-second Gateway budget must remain greater than the Teams Bot Connector request timeout (10 seconds) and less than the ACP turn hard timeout.
+
+### 5. Topology guardrail
+
+Each Gateway process counts active `/ws` Core consumers:
+
+- one consumer: `topology.supported = true`;
+- more than one: emit an error-level log and return `topology.supported = false` with `delivery_mode = "best_effort_broadcast"`;
+- disconnect decrements the count through a drop guard, including task cancellation paths.
+
+This detects unsupported fan-out inside one Gateway process. It cannot detect multiple independent Gateway replicas because the baseline deliberately has no shared state. The Helm deployments therefore remain fixed at `replicas: 1` with `Recreate` strategy. External deployments must follow the same constraint.
+
+Rejecting the second consumer would be a breaking change and is deferred.
+
+## Compatibility Matrix
+
+| Core | Gateway | Behavior |
+| --- | --- | --- |
+| old | old | Existing protocol and fire-and-forget behavior. |
+| old | new | Gateway accepts a reply without hello; additive response fields are ignored. |
+| new | old | Core sends optional hello, receives none, and stays in legacy mode; missing ACK is not failure. |
+| new | new | Valid hello enables platform-aware capabilities, operation-specific required ACKs, structured outcomes, and topology reporting. |
+
+## Security and Reliability Boundaries
+
+- Capability negotiation is not authentication or authorization. Existing WebSocket token, platform webhook authentication, tenant checks, L2 scope, and L3 identity gates remain authoritative.
+- Hello frames contain no platform credentials, service URLs, route records, or user identifiers.
+- Advertising a capability does not make an operation safe by itself; the adapter must emit the corresponding ACK on every terminal path before the flag is enabled.
+- `Unknown` preserves ambiguity instead of creating duplicates through automatic retry.
+- This baseline does not claim durable enqueue, replay, duplicate-safe multi-consumer operation, or exactly-once delivery.
+
+## Consequences
+
+### Positive
+
+- Teams no longer inherits generic Gateway or Telegram streaming/status behavior; reaction availability, processing-message selection, and progressive content each require their own explicit opt-in and capability gate.
+- Core no longer needs write-path platform allowlists such as `EDIT_RESPONSE_PLATFORMS`.
+- New platform features can be introduced additively without forcing a lockstep Core/Gateway deployment.
+- Operators and Core can identify unsupported multi-consumer topology.
+- Delivery uncertainty is represented explicitly and can be handled without unsafe retry.
+
+### Negative
+
+- Capability DTOs are mirrored in Core and Gateway and require wire-compatibility tests.
+- The first operation may use legacy behavior if it races ahead of hello processing.
+- Existing adapters that cannot return a stable message ID must advertise conservative send-once behavior until their delivery path is upgraded.
+- Cross-replica topology remains undetectable without a shared coordination system.
+
+## Alternatives Rejected
+
+1. **Platform-name allowlists in Core.** Rejected because they drift whenever an adapter changes behavior and cannot represent deployment-specific support.
+2. **Mandatory hello before accepting replies.** Rejected because it breaks old Core deployments during rolling upgrade.
+3. **Treat every timeout as rejection.** Rejected because the platform may have committed an ambiguous POST.
+4. **Retry ambiguous POST automatically.** Rejected because it can duplicate user-visible activities.
+5. **Reject the second consumer immediately.** Deferred because this is a breaking operational change.
+6. **Claim HA from multiple broadcast consumers.** Rejected because broadcast fan-out is not work distribution and has no shared idempotency state.
+
+## Verification
+
+Automated verification must cover:
+
+- capability DTO defaults and wire round trips;
+- all three structured outcomes plus legacy response decoding;
+- old Core→new Gateway reply without hello;
+- new Core→old Gateway legacy fallback;
+- new↔new capability selection;
+- requested-platform filtering;
+- second-consumer unsupported topology and disconnect decrement;
+- Unified Teams isolation from Telegram streaming settings;
+- additive reaction-support decoding and processing-message fail-closed capability selection;
+- Teams progressive-response selection only under explicit opt-in plus every required write primitive, in Standalone and Unified modes;
+- configurable 12-second ACK default.

--- a/docs/adr/teams-attachment-ingress.md
+++ b/docs/adr/teams-attachment-ingress.md
@@ -1,0 +1,305 @@
+# ADR: Teams Metadata-First Attachment Ingress
+
+- **Status:** Proposed
+- **Date:** 2026-08-09
+- **Author:** @NeoHsu
+- **Related:**
+  - [Inbound attachments](../inbound-attachments.md)
+  - [Custom Gateway](custom-gateway.md)
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Teams typed scope and mention routing](teams-typed-scope-and-mention-routing.md)
+  - [Microsoft: Send and receive files](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bots-filesv4)
+
+---
+
+## Context
+
+Teams message activities can carry inline images and, in Personal chats with a
+separate `supportsFiles = true` manifest profile,
+`application/vnd.microsoft.teams.file.download.info` attachments. Microsoft
+states that file-consent APIs support Personal context only; wider file support
+requires Microsoft Graph. This proposal remains Graph-free, so it supports only
+inline images and Personal image or UTF-8 text files.
+
+The existing Gateway attachment envelope can carry base64 bytes or a local
+path. Neither existing delivery mode is sufficient as the Teams security
+contract:
+
+- Gateway receives Microsoft credentials and download URLs, but it does not own
+  Core's configured L2 scope and L3 identity decision.
+- Core owns the authoritative trust gate, but Microsoft credentials and URLs
+  must not cross into Core or the ACP child.
+- A Gateway-local path is invalid when Standalone Gateway and Core use separate
+  filesystems.
+- Downloading before the Core gate would let an authenticated but untrusted
+  sender consume network, memory, and image-processing resources.
+
+The attachment-ingress design therefore needs a two-phase contract that works
+identically in Unified and Standalone deployments while preserving default-off behavior and
+rolling compatibility.
+
+## Decision
+
+### Choose metadata-first materialization
+
+Use metadata-first materialization: Gateway publishes bounded attachment
+metadata plus an opaque reference, and Core asks Gateway to materialize that
+reference only after the shared trust gate returns Allow.
+
+Do not copy Core trust configuration into Gateway. A duplicated evaluator would
+create two policy authorities and could drift across rolling upgrades. The
+existing Core gate remains the sole L2/L3 decision point.
+
+The flow is:
+
+```text
+Microsoft activity
+  -> Gateway validates JWT, tenant, route fields, and service URL
+  -> Gateway stores URL/auth metadata only in the bounded process-local route
+  -> GatewayEvent carries filename/MIME/declared size + opaque reference
+  -> Core runs structural filter, typed L2, and shared L3
+  -> Deny: no materialization command and no download
+  -> Allow: Core requests each reference sequentially
+  -> Gateway validates event/route/reference ownership, then downloads
+  -> Gateway returns bounded normalized attachment bytes or rejected metadata
+  -> Core converts the result to ACP ContentBlocks before dispatcher admission
+```
+
+No ACP session, processing indicator, streaming placeholder, or proactive
+promotion begins before materialization completes.
+
+### Additive v1 wire fields and capability
+
+Keep the existing schema and protocol version. Add only optional fields:
+
+- `Attachment.reference`: opaque Gateway-generated materialization reference;
+- `GatewayReply.attachment_ref`: requested opaque reference;
+- `GatewayResponse.attachment`: one normalized attachment result; and
+- `AdapterCapabilities.supports_attachment_materialization`: fail-closed
+  operation capability.
+
+The operation is `command = "materialize_attachment"`. It always carries a
+non-empty `request_id`; Core sends it only after a valid hello explicitly
+advertises the capability. Unknown or legacy peers are never probed
+optimistically.
+
+`reply_to` remains the authenticated Gateway event correlation, and
+`channel.id` remains the conversation correlation. Gateway must validate both
+against the process-local route before resolving `attachment_ref`. A reference
+is random, contains no URL or platform ID, is scoped to one event, and expires
+with that event's route. It is not promoted to proactive state and does not
+survive restart or replica changes.
+
+Core makes at most one materialization request per reference in a turn and does
+not automatically retry timeout, disconnect, malformed response, or rejection.
+A download is read-only at Microsoft, but unbounded retry would still amplify
+attacker-controlled resource use.
+
+### One bounded base64 response for both deployment modes
+
+Both Standalone and Unified return normalized bytes in
+`GatewayResponse.attachment.data` as bounded base64. Unified deliberately uses
+the same logical transport instead of a Gateway-local path so both modes share
+validation, limits, failure behavior, and tests.
+
+Existing `Attachment.path` remains available to other colocated adapters; Teams
+attachment ingress neither emits nor accepts a path. This prevents a Standalone
+Gateway path from being interpreted in the Core container.
+
+The materialized response must fit the explicit internal WebSocket frame cap.
+Core rejects an oversized response before JSON or base64 processing. The URL,
+query, OAuth token, and raw Microsoft attachment object never enter the event,
+response, Core log, agent prompt, or ACP child environment.
+
+### Explicit opt-in
+
+Add one first-class Teams setting:
+
+```toml
+[teams]
+inbound_attachments = false
+```
+
+The environment fallback is `TEAMS_INBOUND_ATTACHMENTS`. Only `true`, `false`,
+`1`, and `0` are accepted; malformed values fail closed to `false`. The default
+remains disabled.
+
+When disabled, Teams text behavior is unchanged and attachment metadata is
+ignored. An attachment-only activity creates no Core turn. Enabling the setting
+still requires the negotiated materialization capability.
+
+### Supported Microsoft attachment forms
+
+This proposal supports:
+
+1. **Inline images in Personal, groupChat, and channel scopes**
+   - declared MIME must be `image/*`;
+   - `contentUrl` remains Gateway-local;
+   - downloaded bytes must decode as an accepted image;
+   - images are resized to at most 1200 pixels on the longest side and encoded
+     as JPEG, except bounded GIF passthrough.
+
+2. **Personal `file.download.info` attachments**
+   - conversation type must be Personal;
+   - the app uses a separate manifest profile with `supportsFiles = true`;
+   - image extensions use the image pipeline;
+   - the existing text-extension whitelist is accepted only with strict UTF-8;
+   - the preauthenticated `downloadUrl` is fetched without the Bot bearer
+     token.
+
+3. **Attachment-only events**
+   - empty text is accepted only when at least one bounded attachment metadata
+     entry exists;
+   - the turn proceeds only if materialization produces a usable content block
+     or a rejected-attachment system block.
+
+Adaptive Cards, file-info cards sent by the bot, audio, video, PDF, archives,
+Office binaries, non-UTF-8 text, and channel/groupChat paperclip files are not
+materialized. They become `Attachment::rejected` metadata after trust, rather
+than being silently reclassified or downloaded.
+
+### URL, redirect, and credential policy
+
+Every attachment request uses a dedicated manual-redirect downloader:
+
+- HTTPS only in production, port 443, no userinfo or fragment;
+- URL query is permitted because Microsoft download URLs can be
+  preauthenticated, but it is always redacted;
+- IP literals, loopback, link-local, private destinations, and arbitrary
+  operator-provided hosts are rejected;
+- inline-image `contentUrl` is bound to the validated Bot Connector public-cloud
+  origin;
+- Personal file URLs and every redirect hop must match the compiled Microsoft
+  commercial-cloud file-host profile;
+- each redirect is resolved and revalidated before the next request;
+- the Bot bearer token is attached only to an inline-image request and is never
+  forwarded across an origin change;
+- Personal `downloadUrl` requests never receive the Bot bearer token; and
+- error messages contain operation class and rejection category, never URL,
+  query, token, tenant, conversation, activity, or opaque-reference values.
+
+The commercial public-cloud profile does not add a user-configurable host
+allowlist. New Microsoft cloud profiles or observed official hosts require a
+reviewed policy update.
+
+### Resource limits
+
+| Control | Limit |
+| --- | ---: |
+| Metadata entries examined | 10 per activity |
+| Opaque references retained | 10 per accepted route |
+| Inline image raw download | 10 MiB |
+| Personal text file | 512 KiB |
+| Aggregate raw download budget | 20 MiB per event |
+| GIF passthrough | 5 MiB |
+| Materialized response / WS text frame | 8 MiB |
+| Redirect hops | 4 |
+| Individual HTTP request | existing Teams request timeout |
+| Whole materialization batch | 45 seconds |
+| Filename after sanitization | 200 Unicode scalars |
+
+`Content-Length`, when present, is checked before reading but never trusted as
+the only bound. Bodies are streamed and stopped before appending bytes past the
+remaining per-file or per-event budget. Declared size, actual raw size, output
+size, MIME, image decoding, text extension, and UTF-8 are validated
+independently.
+
+Materialization is sequential per event. Existing per-event route capacity,
+TTL, dedupe, and one-consumer topology remain in force.
+
+### Rejection behavior
+
+A metadata or materialization failure returns `Attachment::rejected` with a
+stable category and sanitized detail:
+
+- `size exceeded`;
+- `unsupported format`;
+- `download failed`;
+- `processing failed`;
+- `invalid content`;
+- `security rejected`; or
+- `configuration error`.
+
+A rejected attachment has empty `data`, no `path`, and no reusable reference.
+Core surfaces the rejected metadata as a system content block only after Allow.
+One failed attachment does not discard usable text or another valid attachment.
+
+Protocol-level failures such as missing capability, unknown reference, expired
+route, cross-conversation request, oversized frame, or malformed base64 also
+fail closed and never trigger a second download.
+
+### Rolling compatibility
+
+| Core | Gateway | Result when configured |
+| --- | --- | --- |
+| old | new | Text behavior unchanged; unknown references are ignored and no download occurs. |
+| new | old or no valid hello | Attachments disabled because materialization capability is absent. |
+| new | new with valid capability | Metadata is materialized only after Core Allow. |
+| Unified | embedded new adapter | Uses the same reference, limits, and normalized response contract. |
+
+A new Gateway may publish metadata references before a client hello because
+this has no external side effect. Only a new, capability-aware Core can issue
+the materialization command. An old Core drops attachment-only metadata and
+continues processing text exactly as before.
+
+## Security and reliability boundaries
+
+- JWT and tenant validation remain L1 at Gateway.
+- Core typed L2 and shared L3 remain authoritative and precede download.
+- Attachment URLs and Microsoft credentials stay Gateway-local.
+- Opaque references are process-local capabilities, not bearer URLs.
+- The internal WebSocket token still authenticates Core-to-Gateway commands.
+- Route expiry, restart, replica change, malformed reference, and conversation
+  mismatch fail closed.
+- No Graph, RSC, delegated token, durable attachment queue, replay, or
+  exactly-once download is introduced.
+- Microsoft commercial public cloud remains the only supported cloud profile.
+
+## Manifest profiles
+
+The base manifest keeps:
+
+```json
+"supportsFiles": false
+```
+
+Operators enabling Personal paperclip files use a separate reviewed profile
+with `supportsFiles = true`. Inline images do not require this manifest opt-in.
+The profile adds no Microsoft Graph or RSC permission.
+
+## Acceptance criteria
+
+Automated verification must prove:
+
+- default off and malformed environment fail closed;
+- no download command before structural, L2, and L3 Allow;
+- denied text-plus-attachment and attachment-only events cause zero download;
+- missing capability and old peers cause zero download;
+- opaque reference event/conversation/TTL enforcement;
+- URL and every redirect hop are validated without leaking URL or token;
+- strict streamed limits, image decode, text extension, and UTF-8;
+- unsupported and failed attachments become sanitized rejected metadata;
+- attachment-only dispatch after one successful or rejected materialization;
+- Standalone and Unified produce equivalent content blocks;
+- response and WebSocket frame ceilings; and
+- no path crosses a non-shared deployment boundary.
+
+## Consequences
+
+### Positive
+
+- Trust-before-fetch is enforced by one authoritative Core policy.
+- Gateway retains Microsoft credentials and sensitive URLs.
+- Standalone no longer depends on an accidental shared filesystem.
+- Additive capability negotiation keeps rolling upgrades fail closed.
+- Unified and Standalone share observable behavior and limits.
+
+### Negative
+
+- Materialization adds one internal request/response per attachment.
+- Base64 adds bounded memory and approximately one-third encoding overhead.
+- Attachment-only turns wait for materialization before showing progress.
+- Route-local references are intentionally lost on restart or expiry.
+- Strict Microsoft host policy may reject a newly introduced official host until
+  the profile is reviewed and updated.

--- a/docs/adr/teams-ephemeral-ingress-state.md
+++ b/docs/adr/teams-ephemeral-ingress-state.md
@@ -1,0 +1,151 @@
+# ADR: Teams Ephemeral Ingress Route and Duplicate Suppression
+
+- **Status:** Proposed
+- **Date:** 2026-08-07
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Custom Gateway](custom-gateway.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+
+---
+
+## Context
+
+Bot Framework may retry the same webhook activity. Before this decision, the
+Teams adapter published every authenticated retry, keyed reply routing only by
+conversation ID, accepted messages with missing routing identifiers, and
+ignored the result of the local Gateway broadcast. An HTTP 200 could therefore
+mean that no Core consumer received the event.
+
+The proposed delivery boundary remains deliberately narrow:
+
+- one Gateway process replica;
+- one supported Standalone Core consumer;
+- process-local state only;
+- no crash replay, durable inbox, shared idempotency store, or exactly-once
+  claim.
+
+## Decision
+
+### Required message fields
+
+A message activity proceeds only when it contains non-empty values for:
+
+- Bot Framework channel ID;
+- tenant ID;
+- conversation ID;
+- activity ID;
+- sender ID;
+- service URL.
+
+Structural presence is checked before JWT key lookup; route and dedupe state are
+created only after JWT and tenant authorization. The service URL must also pass
+the Microsoft commercial public-cloud endpoint policy. Invalid or missing
+fields return HTTP 400 and do not create route or dedupe state. Non-message and
+structurally valid empty-text activities retain their existing HTTP 200 ignore
+behavior.
+
+The adapter also parses optional Bot Framework `replyToId`, Team ID, and channel
+ID into gateway-local route state. These values are not sent to the agent.
+
+### Composite identity
+
+Both route correlation and duplicate suppression use the composite identity:
+
+```text
+(app_id, tenant_id, conversation_id, activity_id)
+```
+
+This prevents an activity ID collision from crossing applications, tenants, or
+conversations. A generated `GatewayEvent.event_id` is a separate correlation
+index for the future outbound route lookup. It is never a Bot Framework
+activity ID.
+
+### Publication state machine
+
+Each composite key follows:
+
+```text
+Vacant -> Publishing -> Accepted
+             |
+             +-> local publish failure -> Vacant
+```
+
+The first request owns publication. A concurrent duplicate that observes
+`Publishing` waits on the same in-process completion signal. It returns HTTP
+200 only if the owner reaches `Accepted`; otherwise it returns HTTP 503.
+
+An `Accepted` duplicate returns HTTP 200 without publishing another
+`GatewayEvent`. A failed local broadcast removes the publishing entry before
+returning HTTP 503, so a later Bot Framework retry may publish again.
+
+The Gateway checks the result of `broadcast::Sender::send` rather than a
+separate receiver-count preflight, avoiding a check-then-send race. A successful
+local broadcast is the process-local acknowledgement boundary; it does not prove ACP or
+outbound completion.
+
+### Bounded process-local state
+
+Three positive settings control state:
+
+| Setting | Default | Purpose |
+| --- | ---: | --- |
+| `teams.dedupe_ttl_secs` | 600 | Accepted duplicate suppression window |
+| `teams.route_ttl_secs` | 3600 | Authenticated ephemeral route lifetime |
+| `teams.max_route_entries` | 10000 | Independent capacity bound for route and dedupe maps; bot-owned mutation state uses the same independent bound |
+
+Equivalent Standalone environment variables are
+`TEAMS_DEDUPE_TTL_SECS`, `TEAMS_ROUTE_TTL_SECS`, and
+`TEAMS_MAX_ROUTE_ENTRIES`.
+
+Expired entries are removed during reservation and by a shared background
+sweeper used in both Standalone and Unified mode. At capacity, the oldest
+accepted dedupe entry or route may be evicted with a warning. Active
+`Publishing` entries are never evicted to admit another key; saturation returns
+HTTP 503. A stale publishing owner is failed after a bounded internal timeout so
+waiters cannot remain blocked indefinitely.
+
+The initial route implementation retained the legacy conversation-to-service-URL
+cache for the existing outbound path. The real-send implementation removed that
+compatibility cache: outbound sends
+now resolve the authenticated route directly by `event_id` and verify the
+reply's conversation before using its gateway-local service URL.
+
+## Security and privacy
+
+- Service URLs remain gateway-local and are excluded from Gateway wire events,
+  agent prompts, response payloads, and logs.
+- Endpoint validation happens before route persistence.
+- Logs may include tenant, conversation, sender, and validated service host,
+  but never the full service URL or app secret.
+- Route state is not promoted to a proactive conversation reference.
+- Duplicate suppression occurs only after JWT and tenant checks; unauthenticated
+  input cannot poison the cache.
+
+## Compatibility
+
+This is a correctness change for malformed or undeliverable Teams webhooks:
+
+| Condition | Previous behavior | New behavior |
+| --- | --- | --- |
+| Missing required route field | Often HTTP 200 | HTTP 400 |
+| Accepted duplicate | Published again | HTTP 200 without republish |
+| No local event consumer | HTTP 200 | HTTP 503, no tombstone |
+| Local publish succeeds | HTTP 200 | HTTP 200 and route accepted |
+
+No Gateway wire field is removed or made mandatory. Unified and Standalone use
+the same adapter state machine. Existing configuration remains valid through
+the documented defaults.
+
+
+## Consequences
+
+- Duplicate suppression does not survive restart and does not span replicas.
+- Capacity eviction may shorten the effective dedupe window under sustained
+  overload; warnings make this visible.
+- A successful broadcast can still be lost after process failure or consumer
+  lag. Durable delivery requires a later inbox/outbox design.
+- [Real send acknowledgement](teams-real-send-acknowledgement.md) uses this
+  route for real activity IDs and outbound correlation.

--- a/docs/adr/teams-formatting-and-long-messages.md
+++ b/docs/adr/teams-formatting-and-long-messages.md
@@ -1,0 +1,284 @@
+# ADR: Teams Budget-Aware Formatting and Ordered Long Messages
+
+- **Status:** Proposed
+- **Date:** 2026-08-10
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams progressive edit response](teams-progressive-response.md)
+  - [Multi-platform adapters](multi-platform-adapters.md)
+
+---
+
+## Context
+
+At the initial long-message design baseline, OpenAB advertised Teams with a conservative
+4,096-character message limit. Core converted every negotiated non-character
+`MessageLimit` into an even smaller character count before calling
+`format::split_message`. This was a safe
+compatibility default, but it does not model the Teams platform contract:
+
+- Microsoft documents an approximate 100 KB agent-message limit;
+- the size includes message text, image links, mentions, and reactions encoded
+  as UTF-16, but excludes base64-encoded images;
+- Microsoft recommends keeping the message itself within 80 KB for reliable
+  delivery; and
+- an oversized message returns HTTP 413 with `MessageSizeTooBig`.
+
+The existing capability schema already has additive `characters`, `bytes`,
+`utf16_bytes`, and `unlimited` variants. The missing work is exact budget-aware
+splitting and a Teams capability value that reflects the documented unit.
+
+Teams receives OpenAB content as text-only Bot Framework activities with
+`textFormat = markdown`. Microsoft documents only a subset of Markdown and
+states that text-only messages do not support tables. Rich cards likewise do
+not add Markdown-table support. OpenAB already has a table pre-pass whose default `code` mode converts a
+Markdown table to an aligned fenced block before message splitting, but at that
+baseline the Teams setup guide recommended bypassing the fallback with
+`tables = "off"`.
+
+Long-message delivery also has two different safety levels. Structured Teams
+progressive finalization already waits for each required ACK, sends overflow in
+order, and stops on the first rejected or unknown write. The ordinary
+send-once branch awaits each `Result`, but continues with later chunks after an
+earlier failure. That can show a suffix without the missing middle and does not
+report a precise partial-delivery boundary.
+
+## Decision
+
+### 1. Teams advertises an exact UTF-16 byte budget
+
+The Teams capability in both Standalone Gateway hello and Unified mode will be:
+
+```text
+MessageLimit::Utf16Bytes { max: 80_000 }
+```
+
+`80_000` is deliberately decimal, not `80 * 1024`. It follows Microsoft's
+recommended 80 KB implementation target rather than treating the approximate
+100 KB rejection threshold as a guaranteed text allowance.
+
+For this limit, Core measures a string as:
+
+```text
+utf16_bytes(text) = 2 * text.encode_utf16().count()
+```
+
+A BMP scalar therefore costs two bytes and a supplementary-plane scalar costs
+four. The limit is not a Unicode-scalar, grapheme, UTF-8-byte, or display-column
+count. Table rendering and final display composition happen before the budget
+is applied, so their expanded output is included.
+
+OpenAB's current Teams content activity does not emit outbound mention entities,
+cards, or inline base64 images. If those fields are added later, their encoded
+size must receive an explicit reserve or a lower text budget before they share
+this capability. This proposal does not infer authenticated mentions from plain
+text.
+
+### 2. Core gains one budget-aware splitter
+
+Keep `format::split_message(text, character_limit)` as the compatibility wrapper
+for existing direct callers. Add an internal splitter driven by the negotiated
+`MessageLimit` with these unit definitions:
+
+| Limit | Measurement |
+| --- | --- |
+| `characters` | Unicode scalar count, preserving current behavior |
+| `bytes` | UTF-8 byte length |
+| `utf16_bytes` | UTF-16 code units multiplied by two |
+| `unlimited` | One unchanged chunk |
+
+The splitter must preserve the existing structural behavior:
+
+- prefer newline boundaries, then whitespace boundaries;
+- preserve valid UTF-8;
+- keep an extended grapheme cluster together whenever that cluster fits in an
+  empty chunk;
+- if one grapheme is larger than the budget, fall back only to Unicode-scalar
+  boundaries; and
+- fail before any final-content write if even one scalar cannot fit the
+  advertised non-zero budget.
+
+Fenced code blocks remain balanced independently in every chunk. The complete
+opener, including its language tag, is repeated after a split; synthetic close
+and reopen markers are included in the selected unit's budget. A zero limit or
+an otherwise unsplittable non-empty value is an error, not an infinite loop,
+truncation, invalid UTF-8, or oversized final-content write. A streaming turn
+may already own its acknowledged placeholder; that existing activity follows
+the [progressive-response failure lifecycle](teams-progressive-response.md) and
+is never converted into a blind fresh send.
+
+The 1.5-second cosmetic Teams edit path may retain its existing conservative
+character preview. Authoritative final PUT/POST chunks use the exact negotiated
+budget. This keeps intermediate writes safely below the limit without widening
+this proposal into a streaming-preview redesign.
+
+### 3. Markdown remains text-only and tables use the existing fallback
+
+Teams outbound activities continue to set `textFormat = markdown`. This
+proposal does not create Adaptive Cards or rich cards.
+
+OpenAB preserves the agent's Markdown source except for the existing configured
+table conversion:
+
+- `tables = "code"` remains the default and recommended Teams setting;
+- `tables = "bullets"` remains an accessibility-oriented fallback;
+- `tables = "off"` remains an explicit operator bypass, but raw Markdown tables
+  are not claimed to render as tables in Teams; and
+- Teams continues to report `renders_native_tables = false` in both deployment
+  modes.
+
+The Teams setup documentation will stop recommending `tables = "off"`.
+Mention-looking text and Markdown links are not rewritten, dropped, or copied
+into later chunks; an individual token longer than the whole budget may still
+be split at a valid Unicode boundary. Existing Discord mention-footer
+propagation is unchanged and is not applied to Teams. Headings, lists,
+strikethrough, and other Markdown remain subject to Microsoft's published
+desktop/iOS/Android support differences. This proposal does not rewrite them
+into a new rich-message schema or claim identical presentation across clients.
+
+### 4. Required-ACK chunk delivery is sequential and terminal
+
+Core builds the complete final chunk list before the first platform write. When
+the resolved capability requires send ACKs, every POST is delivered through an
+outcome-preserving method and the sequence obeys:
+
+1. Send chunk `N` only after chunk `N - 1` is `Delivered`.
+2. A delivered POST requires a non-empty real activity ID.
+3. Stop at the first `Rejected` or `Unknown`; never skip it and send a suffix.
+4. Never retry a rejected or unknown POST in Core. In particular, the existing
+   Teams rule that records a 429 `Retry-After` without retrying POST remains
+   unchanged.
+5. An `Unknown` terminal outcome suppresses retry, fresh-send, cleanup, and the
+   router's warning activity because the selected chunk may have committed.
+6. A `Rejected` terminal outcome may use the existing single warning route,
+   because rejection is explicit, but it does not resume the chunk sequence.
+
+The delivery result records, without message content or activity IDs:
+
+- total chunk count;
+- number known delivered;
+- zero-based failed chunk index; and
+- terminal outcome kind and sanitized code.
+
+If at least one earlier chunk was delivered, the error is explicitly classified
+as partial delivery. Already-delivered activities are not deleted or edited in
+an attempted rollback. Processing status and reaction progress become failed,
+and status is cleared only after every final chunk is delivered.
+
+This rule applies to ordinary send-once, explicit-reply-first, progressive
+overflow, and rejected-placeholder recovery paths when required send ACK is
+available. Existing progressive helpers already implement the ordering and
+ambiguity rules; this proposal unifies the send-once branch with that behavior
+rather than adding a second Teams-specific retry loop.
+
+### 5. Rolling compatibility remains fail closed
+
+| Core | Gateway | Result |
+| --- | --- | --- |
+| old Core without hello | new Gateway | Legacy behavior; Gateway accepts the first reply and sends no unsolicited control requirement. |
+| capability-aware old Core | new Gateway | Decodes the existing `utf16_bytes` variant and uses its conservative quarter-size character bound; still safe, but not exact. |
+| new Core | old Gateway or no valid hello | Existing `characters = 4096` legacy limit and legacy delivery semantics. |
+| new Core | new Gateway | Exact 80,000 UTF-16-byte split plus required-ACK ordered delivery. |
+| new Unified | embedded Teams adapter | Same exact budget and delivery semantics as new↔new Standalone. |
+
+A valid hello remains authoritative. Missing Teams capabilities in a valid hello
+do not fall back optimistically. Protocol version stays v1 because the
+`utf16_bytes` wire variant was already additive before this proposal.
+
+### 6. Observability is content-free
+
+One finalization summary may record platform, total chunks, delivered chunks,
+failed index, outcome kind, and sanitized error code. It must not log message
+content, activity IDs, conversation IDs, request IDs, URLs, tokens, or serialized
+Connector bodies.
+
+A Microsoft HTTP 413 remains `Rejected / message_too_large`. It is evidence that
+the conservative target was insufficient for that activity shape, not a reason
+to retry the same body or silently change the limit during the turn.
+
+## Security and reliability boundaries
+
+- Trust admission, route ownership, tenant/conversation checks, and write
+  serialization are unchanged.
+- No Graph, RSC, delegated token, Adaptive Card permission, or manifest
+  permission is added.
+- POST `Unknown` is never retried or converted into a fresh warning activity.
+- Partial delivery is not transactional; delivered prefix activities may remain
+  when a later chunk fails.
+- The feature does not claim exactly-once delivery, crash replay, durable
+  ownership, or multi-consumer work distribution.
+- Microsoft commercial public cloud remains the only supported Teams profile.
+
+## Acceptance criteria
+
+Automated verification must cover:
+
+- exact character, UTF-8-byte, UTF-16-byte, and unlimited measurements;
+- BMP, CJK, supplementary emoji, combining marks, ZWJ sequences, and mixed text;
+- every emitted chunk fitting its own budget, including synthetic code-fence
+  close/reopen markers and language tags;
+- newline/whitespace preference, order preservation, no truncation, valid UTF-8,
+  and explicit unsplittable-budget failure;
+- Teams Standalone hello and Unified parity advertising
+  `utf16_bytes = 80_000`;
+- new Core→old Gateway/no-hello 4,096-character fallback and decoding by a
+  capability-aware old Core;
+- table conversion before splitting, Teams native-table=false behavior, and the
+  explicit `off` bypass;
+- send-once, explicit reply, progressive overflow, and recovery chunk order;
+- stop-on-first `Rejected` and stop-on-first `Unknown`, with no later chunk;
+- delivered/total/failed-index partial-delivery classification;
+- no warning, delete, retry, or fresh send after an unknown POST;
+- HTTP 413 mapping to `message_too_large`; and
+- no regressions in existing character-based Discord/Slack splitting or Teams
+  progressive ambiguity tests.
+
+## Consequences
+
+### Positive
+
+- Teams uses the platform's documented unit instead of a fictional character
+  limit.
+- ASCII and BMP-heavy long replies require fewer activities while emoji-heavy
+  replies remain correctly bounded.
+- Code fences and table fallbacks are budgeted after rendering.
+- Users never receive a later suffix after a known missing middle chunk.
+- Rolling upgrades remain safe without a protocol bump.
+
+### Negative
+
+- The generic splitter becomes more complex and must carry unit-aware tests.
+- Larger individual activities may take longer to render or edit even though
+  they remain within Microsoft's recommendation.
+- Partial delivery cannot be made atomic with Bot Connector primitives.
+- Cosmetic streaming previews remain more conservative than final messages.
+
+## Alternatives rejected
+
+1. **Keep 4,096 characters permanently.** Safe but knowingly misrepresents the
+   platform, produces unnecessary activities, and leaves the UTF-16 capability
+   unused.
+2. **Advertise 100 KB.** Rejected because Microsoft labels it approximate and
+   recommends an 80 KB implementation target.
+3. **Use 80,000 Unicode scalars.** Rejected because supplementary characters
+   consume twice the UTF-16 bytes of BMP characters.
+4. **Use UTF-8 bytes.** Rejected because it is not the unit Microsoft documents
+   for this limit.
+5. **Split inside Gateway.** Rejected because Core owns final formatting,
+   directive handling, ordered delivery health, and Unified/Standalone parity;
+   Gateway-side splitting would hide per-chunk outcomes from Core.
+6. **Continue after a rejected middle chunk.** Rejected because a suffix without
+   its missing middle is a corrupt user view.
+7. **Retry an unknown POST.** Rejected because it can duplicate an activity that
+   Microsoft already committed.
+8. **Use Adaptive Cards for every answer.** Rejected because cards have different
+   formatting semantics, do not solve Markdown tables, and belong to a later
+   explicitly reviewed feature.
+
+## References
+
+- [Microsoft: Format your agent messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages)
+- [Microsoft: Update and delete messages sent from agent](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages)
+- [OpenAB platform schema: Teams](../platforms/schema/teams.toml)

--- a/docs/adr/teams-message-reactions-preview.md
+++ b/docs/adr/teams-message-reactions-preview.md
@@ -1,0 +1,133 @@
+# ADR: Teams Public-Preview Message Reactions
+
+- **Status:** Proposed
+- **Date:** 2026-08-09
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+
+---
+
+## Context
+
+Microsoft's Teams SDK exposes public-preview add/remove reaction operations on
+the Bot Connector conversation API. They use the authenticated Bot Framework
+`serviceUrl`, conversation ID, activity ID, and bot token already required for
+normal sends. They do not require Microsoft Graph, RSC, a delegated user token,
+or a new manifest permission.
+
+OpenAB previously treated `add_reaction` and `remove_reaction` as successful
+no-ops for Teams. Enabling the preview by default would change existing
+behavior, create new status side effects, and rely on a tenant feature that is
+not yet generally available.
+
+## Decision
+
+### Explicit opt-in
+
+Add this first-class setting:
+
+```toml
+[teams]
+reactions_enabled = false
+```
+
+The environment fallback is `TEAMS_REACTIONS_ENABLED`. Only `true` or `1`
+enables the preview. Missing, false, zero, empty, or invalid values remain
+fail-closed at `false`.
+
+When disabled:
+
+- reaction commands preserve the legacy successful no-op;
+- no route lookup, token request, or Connector write occurs;
+- Teams advertises `status_backend = none` to a negotiated Core.
+
+When enabled, Standalone and Unified advertise `supports_reactions = true`.
+They select `status_backend = reactions` unless Core explicitly selects a
+separate processing-message backend. In that combined mode, reactions provide
+only permanent queued receipts while a turn-local message provides transient
+progress. Streaming remains disabled and reaction support does not enable any
+other Teams capability.
+
+### Bot Connector operations
+
+OpenAB uses the existing Bot Framework token and validated public-cloud
+`serviceUrl`:
+
+```text
+PUT    {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}/reactions/{reactionType}
+DELETE {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}/reactions/{reactionType}
+```
+
+All path values are appended as URL path segments. Empty reaction writes send
+`Content-Length: 0`; the Connector otherwise rejects PUT requests that have
+neither content length nor chunked framing. The
+existing same-origin redirect policy, timeout, bounded error body, token
+redaction, and commercial public-cloud endpoint policy apply unchanged.
+
+Reaction writes share the idempotent PUT/DELETE outcome classifier. HTTP
+success is `Delivered`; explicit 3xx/4xx is `Rejected`; timeout, disconnect, or
+5xx is `Unknown`. An explicit `429` with `Retry-After` no greater than one
+second receives at most one internal retry. A bounded retry emits a warning
+containing only the static operation name and `retry_after_ms`; it does not log
+the Connector URL, conversation, activity ID, or token. There is no
+POST/fresh-send fallback.
+
+### Scope and target trust
+
+A reaction target may be:
+
+- an authenticated inbound activity retained in the process-local route index;
+- the authenticated reply-chain root of the command's origin route; or
+- a confirmed bot-owned activity in the process-local ownership index.
+
+New-field commands require a live origin event route and cannot cross app,
+tenant, or conversation scope. Legacy commands without a separate origin are
+accepted only when app, conversation, and activity resolve to one unique route;
+cross-tenant ambiguity fails closed.
+
+Reaction writes use the same fixed tenant/conversation write shards as sends,
+edits, and deletes, with route state revalidated after lock acquisition.
+
+### Reaction IDs
+
+Core emits Unicode status emoji, while the Connector preview expects Teams
+reaction IDs. OpenAB maps all default status and completion emoji to IDs from
+the Microsoft Teams reactions reference. The generic controller's hard-coded
+soft- and hard-stall states are included: `🥱` maps to
+`1f971_yawningface`, while `😨` maps to the distinct `fearful` ID so a later
+`😱` / `screamingfear` error swap cannot add and remove the same reaction. A
+configured value may also be an ASCII reaction ID containing only letters,
+digits, `_`, or `-`, up to 128 bytes. Unknown Unicode and unsafe identifiers
+are rejected before HTTP.
+
+### Deliberate exclusions
+
+This preview slice does not:
+
+- process inbound `messageReaction` activities;
+- add Graph or RSC permissions;
+- add reaction-specific required ACK negotiation;
+- promise availability outside Microsoft commercial public cloud;
+- make native reactions part of the default processing-indicator contract;
+- persist route evidence across restart or replicas.
+
+
+## Consequences
+
+### Positive
+
+- Operators can test visible Teams reactions without widening Graph authority.
+- Existing deployments remain unchanged until explicit opt-in.
+- Reactions cannot be aimed at arbitrary activity IDs or leak `serviceUrl`.
+- Default OpenAB status emoji work without operator-specific mapping.
+
+### Negative
+
+- Preview availability and rendering remain tenant-dependent.
+- Rapid generic status transitions may encounter the platform's reaction rate
+  limit; bounded retries do not guarantee every cosmetic transition is shown.
+- Inbound user reactions remain ignored until a separate behavior and trust
+  contract is approved.

--- a/docs/adr/teams-operator-cron-delivery.md
+++ b/docs/adr/teams-operator-cron-delivery.md
@@ -1,0 +1,378 @@
+# ADR: Teams Operator Cron over Trusted Persistent Conversations
+
+- **Status:** Proposed
+- **Date:** 2026-08-20
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams trusted persistent conversation registry](teams-trusted-persistent-conversation-registry.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Basic cron scheduler](basic-cronjob.md)
+
+---
+
+## Context
+
+OpenAB's scheduler can dispatch operator-configured prompts through Discord,
+Slack, Telegram, Google Chat, and LINE WORKS adapters. It first posts a visible
+cron trigger, then starts or reuses the ACP session only after that trigger send
+succeeds. Teams is intentionally absent from `VALID_PLATFORMS` and from the cron
+adapter map because ordinary Teams sends require a short-lived inbound event
+route.
+
+The [persistent-registry proposal](teams-trusted-persistent-conversation-registry.md)
+adds an explicit-path, default-off Gateway-local registry. A route enters that
+registry only after Bot Framework authentication plus Core structural,
+typed L2, and L3 admission. The registry retains the complete
+app/tenant/Bot-Framework-channel/conversation identity and validated
+`serviceUrl`, and exposes only active, non-expired records for
+operator-scheduled delivery. Core and ACP never receive the stored reference or `serviceUrl`.
+
+This proposal connects the existing operator scheduler to that registry without
+turning agent-writable usercron into cross-conversation authority. It does not add a new
+scheduler, create Teams conversations, install an app, or implement `/remind`.
+
+## Constraints
+
+- Existing deployments and non-Teams cron behavior remain unchanged by default.
+- A Teams cron job may target only an exact active, non-expired registry record.
+- The complete registry identity must be enforced; conversation ID alone is not
+  a registry key.
+- `serviceUrl`, the stored record, and app credentials remain Gateway-local and
+  never enter Core config, the Gateway wire, ACP input, responses, or logs.
+- Config-defined baseline cron is operator authority. The hot-reloaded
+  `cronjob.toml` is explicitly agent-writable in current OpenAB documentation and
+  is not equivalent authority.
+- Standalone and Unified must apply the same lookup, send, delivery-outcome, and
+  registry-reconciliation rules.
+- Every accepted content POST has a real Bot Framework activity ID. Ambiguous
+  writes are `Unknown` and are never retried blindly.
+- The baseline remains one Gateway writer and one active Standalone Core consumer.
+
+## Current-System Findings
+
+### Scheduler authority and ordering
+
+`[[cron.jobs]]` is immutable process config and is validated at startup. The
+scheduler sends the visible cron trigger before it calls `AdapterRouter`, so a
+failed destination consumes no ACP session or agent work. The scheduler also
+prevents overlap for one job and treats the next matching schedule as a new
+execution rather than retrying a failed tick.
+
+The separate `cronjob.toml` overlay is disabled by default but may be
+hot-reloaded and written by the agent. It can also execute an operator-approved
+local `disable_on_success` command. It therefore cannot safely select an
+arbitrary trusted Teams record without a future user/scope binding design.
+
+### Standalone adapter lifetime
+
+At the design baseline, Unified mode retained one shared adapter for cron.
+Standalone constructed a new `GatewayAdapter` inside each WebSocket connection
+loop and did not expose it to the scheduler. This proposal needs a stable
+reconnect-aware proxy: the
+proxy delegates to the current negotiated connection, clears it on disconnect,
+and never creates a second Gateway WebSocket consumer.
+
+### Microsoft Teams proactive delivery
+
+Microsoft documents scheduled messages as proactive messages. The app must
+already be installed in the destination; a stored conversation ID or
+conversation reference is required, and the incoming `serviceUrl` should be
+retained instead of hardcoding an endpoint. Proactive messaging cannot create a
+new group chat or a new Team channel. A blocked or uninstalled app can return
+HTTP 403 with `MessageWritesBlocked`; Microsoft also documents
+`BotNotInConversationRoster` when the bot is no longer a member of the
+conversation.
+
+### Reviewed prior art
+
+OpenClaw revision
+[`4994f7bacf308269a0770b4a912c44a746cccec7`](https://github.com/openclaw/openclaw/tree/4994f7bacf308269a0770b4a912c44a746cccec7)
+resolves an outbound target through its conversation store, validates the
+stored service endpoint/cloud boundary, reconstructs the SDK reference inside
+the Teams plugin, and sends directly to the stored conversation. OpenAB adopts
+the Gateway-local resolution and endpoint validation, but requires the complete
+registry key and active state rather than a conversation-ID-only lookup.
+
+Hermes Agent revision
+[`00e5a361b60f621ae2246dffdd0a0252895d8493`](https://github.com/NousResearch/hermes-agent/tree/00e5a361b60f621ae2246dffdd0a0252895d8493)
+uses an operator-configured standalone Teams destination and validates its
+service host and conversation identifier. OpenAB adopts explicit operator
+selection but not a static service URL in Core or config; the trusted registry
+remains the only source of the endpoint.
+
+## Decision
+
+### 1. Authority boundary
+
+Only baseline `[[cron.jobs]]` entries may set `platform = "teams"` under this proposal.
+These entries are operator-controlled process configuration and intentionally
+bypass inbound user L2/L3 checks at execution time, as existing operator cron
+does. Their destination is still constrained to a record that previously
+passed those checks and remains active.
+
+The usercron loader rejects every Teams entry with a bounded, identifier-free
+warning. It does not partially execute the job, resolve a registry record, send
+a message, or start ACP. `/remind`, agent-created recurring schedules, and any
+user-facing target selector remain separate follow-ups that must bind the
+initiating user and scope and revalidate them at execution.
+
+### 2. Additive target configuration
+
+A Teams baseline job keeps `channel` as the stored Teams conversation ID and
+adds one required field:
+
+```toml
+[[cron.jobs]]
+enabled = true
+schedule = "0 9 * * 1-5"
+platform = "teams"
+channel = "<conversation-id>"
+teams_tenant_id = "<tenant-id>"
+message = "summarize yesterday's merged work"
+sender_name = "DailyOps"
+timezone = "Asia/Taipei"
+```
+
+For Teams jobs:
+
+- `teams_tenant_id` must be present, non-empty, and bounded;
+- `thread_id` is rejected because the trusted conversation already encodes the
+  Teams Personal, groupChat, or channel route;
+- fields used only by agent-writable usercron remain rejected in baseline config;
+- a Teams-specific field on any other platform is rejected as a configuration
+  error; and
+- `bot_framework_channel_id` is the verified Teams transport constant
+  `msteams`, while `app_id` comes from the configured Gateway credential. Neither
+  is operator-selectable in Core.
+
+Gateway therefore reconstructs and validates the complete registry key:
+
+```text
+(configured_app_id, teams_tenant_id, "msteams", channel)
+```
+
+The raw `configToml`/`configUrl` chart contract remains authoritative; this proposal does
+not restore removed Helm field rendering or create a second cron configuration
+surface.
+
+### 3. Platform-neutral Core route marker
+
+`ChannelRef` gains an optional bounded persistent-conversation target carrying
+only tenant ID, Bot Framework channel ID, and conversation ID. It participates
+in routing equality so two distinct persistent targets cannot alias, but the
+existing session key continues to use the Teams conversation route and does not
+serialize the target into ACP sender context.
+
+All existing reactive and non-Teams `ChannelRef` values set the field to
+`None`. A Teams cron `ChannelRef` sets it before the visible trigger send; clones
+and returned `MessageRef` values preserve it for agent response chunks and
+turn-local bot-owned mutations.
+
+### 4. Additive Gateway capability and wire field
+
+`AdapterCapabilities` gains
+`supports_persistent_conversation_send`, defaulting to `false`. Gateway
+advertises it for Teams only when:
+
+- the trusted persistent registry opened safely;
+- Teams send ACK is supported; and
+- Standalone reports exactly one active Core consumer.
+
+`openab.gateway.reply.v1` gains an optional closed
+`persistent_conversation` object containing the non-secret tenant,
+Bot-Framework-channel, and conversation identity. It never contains app secret,
+OAuth token, `serviceUrl`, message/activity history, or the serialized registry
+record. `reply.channel.id` must equal the target conversation ID and proactive
+frames have no inbound `reply_to` correlation.
+
+New Core does not emit this field unless the exact capability is available.
+Gateway rejects an unnegotiated field, an unsupported topology, malformed or
+mismatched identity, or a non-Teams use before lookup or HTTP. The existing
+registration capability is not reused as an optimistic send capability, so
+registry-only Gateway peers fail closed.
+
+### 5. Exact Gateway-local lookup
+
+Gateway combines the wire target with its configured app ID and validates all
+fields before acquiring the registry lock. It also reapplies the current
+Gateway tenant allowlist. It then obtains a clone only if the exact record is
+active and non-expired.
+
+Missing, expired, disabled, revoked, cross-tenant, cross-conversation, wrong
+Bot-Framework-channel, unsafe-endpoint, unavailable-registry, and ambiguous
+records all return a bounded `Rejected` outcome without OAuth, Connector HTTP,
+filesystem mutation, ACP work, or fallback to the ephemeral route cache.
+Expired records are not refreshed by cron; only a new trusted inbound activity
+can refresh or reactivate them.
+
+### 6. Delivery and turn ordering
+
+For each Teams execution:
+
+1. the scheduler builds the persistent target from operator config;
+2. Gateway performs the exact active lookup and conversation write lock;
+3. Gateway rechecks active state after locking;
+4. the existing outcome-aware Connector path posts one visible cron trigger;
+5. only `Delivered` with a non-empty real activity ID allows session/ACP work;
+6. agent response sends and ordered chunks repeat the active lookup using the
+   preserved target; and
+7. turn-local ownership records permit only the activities created by this
+   process to be edited, deleted, or reacted to.
+
+Teams is added to the scheduler's threadless platforms. It never calls
+`create_thread` or `rename_thread`, and no operator-cron path creates a new Teams
+conversation. Personal, groupChat, and channel behavior comes from the trusted
+stored conversation itself.
+
+### 7. Registry reconciliation
+
+After a Connector write, Gateway updates the exact registry key without holding
+its filesystem mutex across network I/O:
+
+- `Delivered` clears one prior consecutive forbidden-write count;
+- an exact HTTP 403 `MessageWritesBlocked` or
+  `BotNotInConversationRoster` increments the count and disables the active
+  record on the second consecutive result;
+- generic 401/403, 404, 413, 429, other 4xx, 5xx, timeout, disconnect, and every
+  `Unknown` outcome leave state unchanged; and
+- only a later trusted inbound promotion can reactivate a disabled or revoked
+  record.
+
+The 403 classifier parses only bounded structured error bodies and emits a
+bounded internal reason code; it does not log or persist the response body or
+user identity. A registry reconciliation failure is logged count-only and does
+not rewrite the already authoritative Connector outcome. No outcome is retried
+inside the cron execution.
+
+### 8. Reconnect-aware Standalone proxy
+
+Main creates one stable `ChatAdapter` proxy before spawning the existing
+Standalone Gateway connection loop and registers that proxy for Teams cron.
+Each connection generation installs its negotiated concrete adapter; disconnect
+clears only that generation and wakes pending requests. The proxy never opens a
+socket itself.
+
+A call made while disconnected or before the persistent-send capability is
+negotiated is rejected before wire output. A call whose frame was accepted but
+whose ACK is lost remains `Unknown`. After reconnect, later independent cron
+executions use the new adapter and re-resolve the durable record, while an old
+connection cannot clear or satisfy requests owned by the new generation.
+
+### 9. Observability and privacy
+
+Teams cron logs may expose platform, schedule/source class, operation class,
+outcome class, elapsed time, aggregate registry state counts, and bounded reason
+codes. They must not expose the configured prompt, app/tenant/conversation,
+Team/channel/activity/sender IDs, target object, full registry path,
+`serviceUrl`, credentials, or Connector response body.
+
+The scheduled prompt necessarily enters the selected ACP session, but the
+persistent target does not. Tests and validation records use only synthetic values or sanitized counts,
+order, and UI structure.
+
+## Compatibility and Rollout
+
+| Core | Gateway | Behavior |
+| --- | --- | --- |
+| old | old | Teams cron remains unsupported. |
+| old | new | No persistent target is emitted; reactive registry behavior is unchanged. |
+| new | registry-only Gateway | Capability defaults false; Teams cron stops before wire/ACP. |
+| new | new, registry off | Capability false; Teams cron stops before wire/ACP. |
+| new | new, registry on | Exact active lookup, required ACK, and reconciliation are enabled. |
+
+Existing non-Teams cron jobs retain their defaults and routing. A recommended
+Standalone rollout is Core first with no imminently firing Teams job, verify the
+old Gateway fail-closed path, then upgrade Gateway, verify the negotiated
+capability, and only then enable a Teams baseline job. Gateway rollback leaves
+the registry file untouched; a new Core paired with the rolled-back Gateway simply
+cannot fire Teams cron.
+
+## Acceptance criteria
+
+Automated coverage must include:
+
+1. additive config parsing/defaults plus Teams tenant, field-bound, thread, and
+   cross-platform validation;
+2. baseline Teams acceptance and unconditional usercron Teams rejection;
+3. `VALID_PLATFORMS`, threadless behavior, configured-platform detection, and
+   exactly one selected cron adapter in Unified and Standalone modes;
+4. stable Standalone proxy behavior before connect, after hello, during ACK,
+   after disconnect, and after a new connection generation;
+5. additive capability and target wire round trips, missing-field defaults, old
+   peers, unsupported topology, and no pre-negotiation send;
+6. exact complete-key lookup with current tenant allowlist and no HTTP for
+   missing/expired/disabled/revoked/mismatched targets;
+7. one real-ID trigger before session/ACP work, no synthetic Teams thread, and
+   target preservation through content chunks and turn-local ownership;
+8. `Delivered`, `Rejected`, and `Unknown` propagation with no blind retry;
+9. exact blocked/not-in-roster parsing, two-result disable, successful reset,
+   generic-403/429/5xx/timeout no-state-change, and reconciliation-write failure;
+10. same-conversation serialization without cross-conversation head-of-line
+    blocking;
+11. Unified/Standalone parity and Core-first/new-old rolling combinations;
+12. serialization/logging guards proving that persistent records, target IDs,
+    response bodies, `serviceUrl`, credentials, and prompts do not leak to ACP,
+    responses, or logs; and
+13. targeted Core/Gateway/Unified/platform-schema tests, config documentation,
+    changed-line formatting, shipping-target Clippy, LSP, links, secret scans,
+    and `git diff --check`.
+
+
+## Consequences
+
+### Positive
+
+- Teams scheduled delivery reuses the trust already proven by PR 11.
+- The first platform write gates agent cost and every write retains structured
+  delivery semantics.
+- Core selects a complete logical target without receiving `serviceUrl` or the
+  stored reference.
+- Explicit capability negotiation preserves rolling fail-closed behavior.
+- Usercron cannot turn agent filesystem access into arbitrary Teams proactive
+  authority.
+
+### Negative
+
+- Operators must copy a tenant ID and conversation ID into baseline config.
+- `ChannelRef`, capability DTOs, and the mirrored Gateway reply schema gain one
+  more additive routing concept.
+- Standalone needs a reconnect-aware adapter proxy shared with the scheduler.
+- Each proactive write performs a registry lookup and may perform an atomic
+  state reconciliation.
+- A blocked installation is disabled only after two exact outcomes.
+
+## Alternatives Rejected
+
+1. **Allow `platform = "teams"` in usercron.** The documented agent-writable file
+   has no initiating-user/scope binding and would grant arbitrary registry
+   selection.
+2. **Lookup by conversation ID alone.** PR 11 explicitly requires the complete
+   app/tenant/Bot-Framework-channel/conversation identity.
+3. **Put `serviceUrl` in `[[cron.jobs]]` or Core.** This bypasses registry state,
+   refresh, revocation, endpoint validation, and the established secret boundary.
+4. **Reuse `supports_conversation_registry` as send support.** A PR 11 Gateway
+   can register but cannot proactively resolve and send; optimistic reuse would
+   break rolling compatibility.
+5. **Create a second Standalone WebSocket for cron.** Broadcast fan-out would
+   create an unsupported second Core consumer and duplicate inbound events.
+6. **Create a new Teams conversation at fire time.** It requires different
+   authority and platform semantics, cannot create group chats/channels, and
+   bypasses the trusted stored route.
+7. **Treat every 403 as uninstall evidence.** Authentication/config failures and
+   unrelated forbidden operations must not disable a trusted route.
+8. **Retry timeout, disconnect, or 5xx automatically.** A POST may already have
+   committed, so retry can duplicate a user-visible scheduled activity.
+9. **Apply Discord thread creation to Teams.** The persistent conversation
+   already represents the Teams routing surface; a synthetic child thread is
+   neither portable nor authorized.
+
+## References
+
+- [Microsoft: Send proactive messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages)
+- [Microsoft: Send and receive targeted messages](https://learn.microsoft.com/en-us/microsoftteams/platform/agents-in-teams/targeted-messages)
+- [Microsoft: Conversation events and installation updates](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events)
+- [Microsoft: Bot Connector authentication](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0)
+- [OpenClaw Teams proactive send at reviewed revision](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/sdk-proactive.ts)
+- [OpenClaw Teams send-context resolution at reviewed revision](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/send-context.ts)
+- [Hermes Teams adapter at reviewed revision](https://github.com/NousResearch/hermes-agent/blob/00e5a361b60f621ae2246dffdd0a0252895d8493/plugins/platforms/teams/adapter.py)

--- a/docs/adr/teams-owned-message-mutations.md
+++ b/docs/adr/teams-owned-message-mutations.md
@@ -1,0 +1,229 @@
+# ADR: Teams Bot-Owned Message Mutations
+
+- **Status:** Proposed
+- **Date:** 2026-08-09
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams public-preview message reactions](teams-message-reactions-preview.md)
+
+---
+
+## Context
+
+The [real-send decision](teams-real-send-acknowledgement.md) returns the Bot
+Framework activity ID for every confirmed Teams send.
+That ID is required for Bot Connector update and delete APIs, but accepting an
+arbitrary activity ID from Core would allow OpenAB to attempt mutation of an
+inbound user message or a bot message from another tenant or conversation.
+
+The existing `GatewayReply.reply_to` field is overloaded by older command
+paths: normal sends use it as the origin OpenAB event ID, while edit and delete
+commands historically place the platform message target in it. Keeping that
+overload for new peers would again risk passing an OpenAB event ID to a Bot
+Connector activity URL.
+
+The reliability boundary remains single-process and process-local. It does not
+provide durable ownership, cross-replica coordination, or mutation of messages
+created before restart.
+
+## Decision
+
+### Additive command target
+
+`openab.gateway.reply.v1` gains an optional `target_message_id` field. The
+capability contract gains a fail-closed `supports_target_message_id` flag.
+
+For a negotiated peer that advertises support, Core sends command replies as:
+
+```json
+{
+  "reply_to": "evt_origin",
+  "target_message_id": "platform_activity_id",
+  "command": "edit_message"
+}
+```
+
+`reply_to` remains origin event correlation. `target_message_id` is the
+platform activity targeted by edit, delete, or an opt-in reaction command.
+Normal sends never interpret `reply_to` as a command target.
+
+Compatibility behavior is:
+
+- new Core + new Gateway: preserve the origin event and send the explicit
+  target field;
+- new Core + old Gateway, or an operation before hello completes: omit the new
+  field and copy the command target into legacy `reply_to`;
+- old Core + new Gateway: when the field is absent, treat `reply_to` as the
+  legacy command target;
+- Unified: use the explicit field for Teams and legacy form for adapters that
+  do not advertise support.
+
+Missing capability fields default to false. The protocol version remains v1
+because both capability and reply fields are additive and covered by
+old-peer decoding tests.
+
+### Process-local ownership index
+
+After a Teams create/send returns `Delivered` with a non-empty activity ID, the
+Gateway records:
+
+```text
+(app_id, tenant_id, conversation_id, activity_id)
+    -> authenticated route + ownership_created_at
+```
+
+The ownership index:
+
+- is process-local;
+- uses `teams.route_ttl_secs` as its lifetime;
+- has an independent `teams.max_route_entries` capacity bound;
+- evicts its oldest entry at capacity with an operator warning;
+- is swept by the existing Teams ingress cleanup task;
+- stores the already validated gateway-local service URL and never exposes it
+  to Core, the agent, ACK payloads, or logs.
+
+Inbound activity IDs are not inserted. Only a confirmed outbound activity can
+be edited or deleted.
+
+A new-field command must still have a live origin event route. The route fixes
+the app, tenant, and conversation scope before ownership lookup. A missing or
+expired origin returns `target_origin_not_found`; a channel mismatch returns
+`target_scope_mismatch`; a target outside that exact scope returns
+`message_not_owned`.
+
+A legacy command has no separate origin event. Gateway may use a unique owned
+entry matching the configured app, command conversation, and target activity.
+If the same legacy tuple exists in more than one tenant, it fails closed with
+`target_scope_ambiguous`.
+
+### Bot Connector operations
+
+Owned edits call:
+
+```text
+PUT {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}
+```
+
+Owned deletes call:
+
+```text
+DELETE {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}
+```
+
+Conversation and activity IDs continue to use URL path-segment encoding and the
+commercial-public-cloud endpoint policy. OAuth acquisition, same-origin
+redirect policy, 5-second connect timeout, 10-second request timeout, 4 KiB
+error body cap, and redaction rules are unchanged.
+
+Mutation outcomes are classified as follows:
+
+- HTTP success: `Delivered` without a required message ID;
+- explicit `3xx` or `4xx`: `Rejected`;
+- `429`: `Rejected` with parsed `retry_after_ms` unless the bounded internal
+  retry succeeds;
+- `5xx`, request timeout, disconnect, or transport failure: `Unknown`;
+- route, ownership, target, or command validation failure before HTTP:
+  `Rejected`.
+
+POST sends are never retried. PUT and DELETE perform at most one internal retry
+only after an explicit `429` response proves that attempt was rejected, and
+only when `Retry-After` is present and no greater than one second. A second
+`429`, a longer delay, a timeout, disconnect, or `5xx` is returned immediately.
+Core does not retry a terminal `Rejected` or `Unknown` outcome.
+
+A delivered delete removes the ownership entry. A rejected delete retains it
+for a later corrected attempt; an unknown delete retains it because the Gateway
+cannot safely infer whether Teams applied the operation. Delivered edits retain
+the original ownership timestamp rather than turning active mutation into
+unbounded retention.
+
+### Operation-specific acknowledgement
+
+A configured Teams adapter advertises:
+
+```text
+send_ack = true
+edit_ack = true
+delete_ack = true
+supports_target_message_id = true
+can_edit = true
+can_delete = true
+streaming_mode = disabled
+```
+
+New Standalone peers wait for the existing configured Gateway ACK timeout on
+edit and delete. Delivered edit/delete ACKs do not require a message ID.
+Rejected and unknown outcomes propagate as errors and are not converted to
+fire-and-forget success.
+
+Legacy peers retain their previous missing-ACK semantics. Unified returns the
+same outcome directly and overrides native delete instead of falling back to an
+edit-to-zero-width operation.
+
+Enabling edit/delete capability does not enable progressive response. Teams
+`streaming_mode` remains disabled; progressive response owns its policy and
+lifecycle separately.
+
+### Same-conversation ordering
+
+Every Teams send, edit, and delete acquires a fixed process-local write shard
+computed from tenant and conversation ID. There are 64 shards:
+
+- writes in the same tenant/conversation are serialized;
+- different conversations normally proceed independently;
+- a hash collision may conservatively serialize unrelated conversations;
+- the fixed array prevents an attacker or busy tenant from growing a lock map
+  without bound.
+
+Ownership and route state are revalidated after lock acquisition. This prevents
+a queued edit from running after a preceding delete removed ownership.
+
+## Compatibility matrix
+
+| Core | Gateway | Command targeting and ACK behavior |
+| --- | --- | --- |
+| old | old | Legacy `reply_to` wire shape; Teams edit/delete remain unsupported and fail closed in a legacy Gateway without bot-owned mutation support. |
+| old | new | Legacy target fallback is accepted only if it resolves to a unique bot-owned activity; missing ACK remains non-fatal to old Core. |
+| new | old | No target-field capability is advertised, so Core copies the target into legacy `reply_to`; missing required ACK is not enabled. |
+| new | new | Origin and target remain separate; ownership is enforced; edit/delete receive operation-specific structured ACKs. |
+| Unified | embedded | Teams uses the explicit target and returns the structured mutation outcome directly. |
+
+## Security and reliability boundaries
+
+- Inbound user activities cannot enter the ownership index and therefore cannot
+  be edited or deleted.
+- New-field mutation cannot cross app, tenant, or conversation scope.
+- Ambiguous legacy scope fails closed.
+- Service URLs and credentials remain Gateway-local.
+- Ownership disappears on restart and is not shared across replicas.
+- A successful write ACK is not a durable event log or exactly-once guarantee.
+- External deletion, app uninstall, or platform-side retention can make a
+  locally owned ID invalid; the Connector response remains authoritative.
+- This decision does not add proactive references, persistent ownership, or
+  multi-consumer coordination.
+
+
+## Consequences
+
+### Positive
+
+- OpenAB can update and delete only activities it confirmed creating.
+- Event correlation and platform command targets are no longer overloaded for
+  new peers.
+- Edit/delete uncertainty is explicit and cannot trigger blind fresh sends.
+- Same-conversation writes cannot overtake one another within a process.
+- Rolling upgrades remain non-lockstep.
+
+### Negative
+
+- Restart, TTL expiry, or capacity eviction makes older bot messages immutable
+  through OpenAB.
+- New-field commands require their origin route to remain live even if ownership
+  was recorded slightly later.
+- Fixed lock-shard collisions can reduce concurrency.
+- The one-second `429` retry bound may return a retryable rejection to Core
+  instead of waiting for a longer platform delay.
+- Connector mutation behavior and availability remain controlled by Microsoft.

--- a/docs/adr/teams-processing-indicator.md
+++ b/docs/adr/teams-processing-indicator.md
@@ -1,0 +1,201 @@
+# ADR: Teams Processing-Message Indicator
+
+- **Status:** Proposed
+- **Date:** 2026-08-07
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+  - [Teams public-preview message reactions](teams-message-reactions-preview.md)
+  - [Teams progressive edit response](teams-progressive-response.md)
+  - [Turn-boundary message batching](turn-boundary-batching.md)
+
+---
+
+## Context
+
+Teams has no generally available native status API equivalent to Slack
+`assistant.threads.setStatus`. Bot Connector typing activities are transient and
+not part of a generally available processing-status guarantee. The implemented
+Teams reaction backend is Microsoft public preview, explicitly opt-in, and therefore cannot be the
+default processing-indicator contract.
+
+This proposal needs a visible, Graph-free processing lifecycle without enabling
+content streaming or weakening the existing route and bot-ownership checks. It must
+also preserve the batching contract: every event may keep its permanent queued
+receipt when reaction preview is enabled, while only the final event in a batch
+anchors transient progress.
+
+## Decision
+
+### Explicit opt-in
+
+Add one first-class Teams setting:
+
+```toml
+[teams]
+processing_indicator = "off" # off | message
+```
+
+The environment fallback is `TEAMS_PROCESSING_INDICATOR`. Missing or malformed
+environment values resolve to `off`; malformed TOML enum values fail config
+parsing. The default is `off`, preserving existing deployments.
+
+`processing_indicator = "message"` selects a processing **message** lifecycle.
+It does not enable streaming, reactions, typing activities, Graph, RSC, or any
+new manifest permission.
+
+### Capability selection and rolling upgrades
+
+Core gains an internal `StatusBackend::Message` value. The processing message
+uses only the existing commandless send plus bot-owned edit/delete operations;
+no new Gateway command or protocol-version bump is introduced.
+
+Standalone Core selects the message backend only after a valid Gateway hello
+advertises all required primitives for Teams:
+
+- required send, edit, and delete acknowledgements;
+- `supports_target_message_id`;
+- bot-owned edit and delete support.
+
+Before a valid hello, or when any required primitive is absent, configured
+message status fails closed to `StatusBackend::None`. Final answer delivery is
+unaffected. Unified mode selects the backend only when the in-process Teams
+adapter provides the same primitives.
+
+Reaction availability and progress-backend choice are independent. Add an
+additive `supports_reactions` capability bit. A peer that advertises the older
+`status_backend = reactions` shape is normalized to reaction support for
+rolling compatibility; old Core ignores the new bit.
+
+When both opt-ins are active:
+
+- `supports_reactions = true` keeps permanent queued receipts on every event in
+  the batch; and
+- `status_backend = message` drives transient thinking/tool progress only on the
+  final event.
+
+When `processing_indicator = "off"`, the existing reaction-preview behavior is
+unchanged.
+
+### One turn-local status activity
+
+Each admitted dispatch turn creates one turn-local processing controller. Its
+identity is the controller instance plus the real Bot Connector activity ID
+returned by the initial status send. The controller is constructed from the
+final event's `ChannelRef`, including its authenticated `origin_event_id`, so
+successive turns never share a status target.
+
+For a batched turn, Core creates exactly one controller from
+`batch.last().trigger_msg`. It never creates one status message per queued
+receipt.
+
+The controller emits at most one new status activity:
+
+| Transition | Visible text | Transport |
+| --- | --- | --- |
+| start / thinking | `⏳ Processing…` | commandless POST |
+| tool start | `🛠️ Using <tool>…` | PUT same activity |
+| tool done / thinking | `⏳ Processing…` | PUT same activity |
+| successful terminal | `✅ Completed` | PUT same activity |
+| agent error | `❌ Failed` | PUT same activity |
+| hard timeout | `⏱️ Timed out` | PUT same activity |
+| final delivery failure | `❌ Delivery failed` | PUT same activity |
+| clear after delivered final content | — | DELETE same activity |
+
+Tool labels are broker-generated metadata, not user prompt text. Normalize line
+breaks and backticks and cap the rendered label before sending it to Teams.
+Duplicate states are no-ops.
+
+### Terminal-before-final ordering
+
+Status and content streaming remain separate lifecycles:
+
+1. mark the processing activity terminal before the first final-content write;
+2. deliver every final-content chunk through the normal send path;
+3. after complete delivery, delete the terminal status activity;
+4. if final delivery is incomplete, change the status to
+   `❌ Delivery failed` and leave it visible.
+
+This ordering prevents a failed delete from leaving an apparently active
+`Processing…` message. If terminal edit succeeds but delete is rejected or
+unknown, the recognizable terminal text remains. Ambiguous POST, PUT, or DELETE
+outcomes never trigger a fresh status send or blind retry.
+
+Status writes are cosmetic: a status failure is logged and must not suppress,
+duplicate, or fresh-send the final answer.
+
+### Receipt and progress separation
+
+`docs/adr/turn-boundary-batching.md` §6.7 remains authoritative:
+
+- each batch event receives its permanent queued receipt sequentially when the
+  adapter explicitly supports reactions and global reactions are enabled;
+- the turn-local processing controller anchors only on the final event; and
+- the controller never removes queued receipts.
+
+Teams with reaction preview disabled has no native queued-receipt side effect;
+it still creates at most one opt-in processing message for the turn.
+
+## Failure boundaries
+
+- Initial status POST `Rejected` or `Unknown`: disable message status for that
+  turn; do not fresh-send another status.
+- Status PUT `Rejected` or `Unknown`: keep the known activity handle for final
+  terminal/delete cleanup; do not blind retry.
+- Terminal PUT succeeds but DELETE fails: leave terminal text visible.
+- Final answer delivery fails: report the existing delivery error and leave a
+  delivery-failed terminal status when possible.
+- Gateway/Core restart or ownership/route expiry may prevent terminal cleanup.
+  Status state is intentionally process-local, matching existing route and
+  ownership boundaries; this proposal does not add crash replay or durable
+  cleanup.
+
+## Security boundaries
+
+- L1 tenant/JWT, typed L2 scope, structured mention, and L3 identity gates run
+  before status creation.
+- The initial POST resolves only through the authenticated origin event route.
+- PUT/DELETE target only the returned bot-owned activity ID and reuse existing
+  tenant/conversation ownership validation and write serialization.
+- Status text contains no prompt, service URL, token, tenant ID, conversation
+  ID, activity ID, or attachment URL.
+- No Graph, RSC, delegated token, proactive registry, or new permission is
+  introduced.
+
+## Acceptance criteria
+
+Automated tests must cover:
+
+- config/TOML/environment resolution and fail-closed defaults;
+- additive `supports_reactions` old/new capability decoding;
+- configured message status remaining disabled before hello or when one
+  required primitive is absent;
+- Standalone and Unified selecting identical Teams backend semantics;
+- one POST followed only by PUTs against its real returned activity ID;
+- thinking, tool, success, error, timeout, delivery-failure, and clear order;
+- terminal PUT before final content and DELETE only after complete delivery;
+- POST/PUT/DELETE rejection or unknown outcomes without fresh-send fallback;
+- one status activity per batch, anchored to the final event;
+- permanent queued receipts surviving when reaction preview and processing
+  message are both enabled; and
+- no status side effect before trust gates pass.
+
+## Consequences
+
+### Positive
+
+- Teams gains a visible processing lifecycle without Graph or preview APIs.
+- One real activity ID gives deterministic, turn-local mutation ownership.
+- Processing messages and queued reaction receipts can coexist without
+  conflating their lifecycles.
+- Existing deployments remain unchanged by default.
+
+### Negative
+
+- Each enabled turn adds one POST, several bounded PUTs, and normally one
+  DELETE to the conversation write stream.
+- A process restart can orphan a processing message because status state is
+  process-local and not durable.
+- Tool-heavy turns need transition coalescing to avoid cosmetic write pressure.

--- a/docs/adr/teams-progressive-response.md
+++ b/docs/adr/teams-progressive-response.md
@@ -1,0 +1,220 @@
+# ADR: Teams Progressive Edit Response
+
+- **Status:** Proposed
+- **Date:** 2026-08-08
+- **Author:** @NeoHsu
+- **Related:**
+  - [Gateway capabilities and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+  - [Teams processing-message indicator](teams-processing-indicator.md)
+  - [Turn-boundary message batching](turn-boundary-batching.md)
+
+---
+
+## Context
+
+OpenAB already has a platform-neutral post-and-edit streaming path. Teams could
+not safely use it before
+[real-send acknowledgement](teams-real-send-acknowledgement.md) and
+[bot-owned mutations](teams-owned-message-mutations.md), because a placeholder
+POST did not return a real Bot Connector activity ID and later PUT/DELETE operations had no
+operation-specific acknowledgement or bot-ownership boundary.
+
+The linked real-send and mutation decisions supply those primitives. This
+proposal may opt Teams into progressive content, but it must not reintroduce synthetic IDs, fixed best-effort waits, blind retries, or a
+fresh final message after an ambiguous write. It must also preserve the
+capability separation rule: the [processing message](teams-processing-indicator.md) and content placeholder are
+independent activities and lifecycles.
+
+## Decision
+
+### Explicit, default-off setting
+
+Add one first-class Teams setting:
+
+```toml
+[teams]
+streaming = false
+```
+
+The environment fallback is `TEAMS_STREAMING`. Missing or malformed environment
+values resolve to `false`; malformed TOML values fail config parsing. The
+existing generic `[gateway].streaming` setting must not implicitly enable Teams.
+Existing deployments therefore remain send-once.
+
+Streaming does not enable reactions, processing messages, attachments, Graph,
+RSC, delegated tokens, or new manifest permissions.
+
+### Capability selection and rolling upgrades
+
+Teams progressive response requires all of these primitives:
+
+- a valid Gateway hello;
+- required send, edit, and delete acknowledgements;
+- `supports_target_message_id`;
+- bot-owned edit and delete support; and
+- `show_streaming_placeholder = true`.
+
+When configured and all primitives are present, new Core selects internal
+`StreamingMode::Edit`. Otherwise it fails closed to `StreamingMode::Disabled`.
+Unified selects the same mode only when its in-process Teams adapter provides
+the same primitives.
+
+The Gateway hello continues to advertise Teams `streaming_mode = disabled` so
+an old Core with an unrelated generic gateway streaming switch cannot begin
+streaming merely because Gateway was upgraded first. New Core derives the
+opt-in mode from the explicit Teams setting plus the existing primitive flags;
+no protocol version or new command is required.
+
+Compatibility behavior is:
+
+| Core | Gateway | Configured Teams result |
+| --- | --- | --- |
+| old | new | Send-once; new Gateway does not advertise selected Teams streaming. |
+| new | old without valid hello | Send-once, fail closed. |
+| new | valid hello with every required primitive | Edit streaming may be selected. |
+| new | hello missing any primitive | Send-once, fail closed. |
+| Unified | embedded Teams adapter | Edit streaming only under the explicit Teams opt-in. |
+
+### One real placeholder per turn
+
+After L1/L2/L3 admission and successful ACP prompt start, Core creates at most
+one content placeholder for the turn through the authenticated event route.
+Required send ACK must return a non-empty real activity ID. That ID is the only
+placeholder target the turn may edit or delete.
+
+A batched turn still runs one ACP turn and therefore creates one placeholder,
+anchored to the final event's authenticated `origin_event_id`. Concurrent or
+successive turns never share placeholder state. Multi-bot participation keeps
+the existing per-turn streaming disable and falls back to send-once.
+
+Placeholder POST outcomes are handled as follows:
+
+- `Delivered` with a real ID: begin progressive edits;
+- `Rejected`: no activity was created, so complete the ACP turn and safely use
+  the normal send-once final path;
+- `Unknown`, required-ACK timeout, or closed ACK channel: do not create another
+  placeholder or fresh-send the final answer, because the first POST may have
+  committed without returning its ID.
+
+### Coalesced cosmetic edits
+
+The existing edit loop remains the common implementation:
+
+- publish only changed display content;
+- coalesce at a minimum 1.5-second interval;
+- wait for the negotiated edit ACK budget, never the legacy Feishu 800 ms
+  observation window;
+- let Gateway perform only its existing explicit short `429 Retry-After`
+  bounded retry;
+- never retry the same content after a rejected or unknown PUT; a later edit is
+  allowed only when newer content supersedes it; and
+- stop cosmetic edits after three consecutive failed changed-content writes.
+
+All Teams POST, PUT, DELETE, and reaction writes continue to share the existing
+per-conversation write shard. Core aborts and joins the cosmetic edit task before
+the authoritative final write so a stale edit cannot overtake finalization.
+
+### Outcome-aware finalization
+
+The first final chunk is authoritative. Core must retain the structured outcome
+instead of flattening it to an undifferentiated error.
+
+| Final operation | Required behavior |
+| --- | --- |
+| Placeholder PUT `Delivered` | Send overflow chunks sequentially. |
+| Placeholder PUT `Rejected` | Attempt one placeholder DELETE, then use one fresh POST recovery unless DELETE is `Unknown`. |
+| Placeholder PUT `Unknown` | Do not DELETE, retry PUT, or fresh-send. Mark delivery ambiguous. |
+| Recovery DELETE `Delivered` | Fresh-send the first final chunk once. |
+| Recovery DELETE `Rejected` | Fresh-send once; the rejected delete may leave partial placeholder overlap, but no full final activity exists. |
+| Recovery DELETE `Unknown` | Do not fresh-send because deletion may have committed. |
+| Recovery POST `Rejected` or `Unknown` | Do not retry. |
+
+An explicit `[[reply_to:...]]` directive remains a deliberate new-message path:
+Core sends the quoted final activity first and deletes the placeholder only
+after that send is `Delivered`. An unknown quoted POST is not retried and does
+not trigger placeholder deletion.
+
+Overflow chunks are sent in order only after the first final chunk is known to
+be delivered. Core stops at the first rejected or unknown overflow POST; every
+chunk contributes to delivery health. It never skips a failed chunk and sends a
+later one.
+
+An ambiguous progressive write returns a delivery error that suppresses the
+router's usual fresh warning message. Reactions or a separate processing status
+may still show failure, but Core must not turn ambiguity into another Teams
+activity.
+
+### Processing-status coexistence
+
+`processing_indicator = "message"` and `streaming = true` may coexist. They
+produce two distinct activities:
+
+1. the processing status follows its thinking/tool/terminal lifecycle; and
+2. the streaming placeholder contains progressively rendered answer content.
+
+Core marks the processing activity terminal before the authoritative final
+content write and clears it only after every final chunk is delivered. A final
+delivery failure leaves or updates the separate status to a recognizable
+failure state when possible. Neither controller edits or deletes the other's
+activity ID.
+
+Reaction preview remains independent. When enabled, queued `👀` receipts stay
+permanent while content progress uses the placeholder.
+
+## Security and reliability boundaries
+
+- Trust gates run before placeholder creation.
+- Placeholder POST uses only the authenticated process-local event route.
+- PUT/DELETE reuse bot-owned activity validation, tenant/conversation matching,
+  TTL bounds, and write serialization.
+- No placeholder ID survives restart, route expiry, or replica changes.
+- `Unknown` is never reclassified as rejection and never causes blind retry or
+  fresh-send.
+- This proposal does not claim exactly-once delivery, crash cleanup, replay,
+  durable ownership, or multi-consumer work distribution.
+- Microsoft commercial public cloud remains the only supported cloud profile.
+
+## Acceptance criteria
+
+Automated verification must cover:
+
+- config, environment fallback, malformed-value fail-closed behavior, and the
+  default-off invariant;
+- Teams not inheriting generic Gateway or Telegram streaming settings;
+- valid-hello and every-required-primitive capability gating in Standalone;
+- identical Unified capability selection;
+- one placeholder POST returning and reusing one real activity ID;
+- coalescing, changed-content-only writes, three-failure cutoff, and edit-loop
+  abort/join before finalization;
+- required ACK timeout rather than the legacy 800 ms path;
+- final PUT `Delivered`, `Rejected`, and `Unknown` branches;
+- recovery DELETE `Delivered`, `Rejected`, and `Unknown` branches;
+- no fresh-send or warning activity after ambiguous POST, PUT, or DELETE;
+- explicit-reply finalization;
+- ordered overflow delivery stopping on first failure;
+- processing-message and permanent receipt coexistence; and
+- no placeholder side effect before trust admission.
+
+## Consequences
+
+### Positive
+
+- Teams gains progressive answer content using already-authenticated Connector
+  writes and real activity IDs.
+- Explicit outcome handling preserves duplicate safety during transport
+  ambiguity.
+- Rolling upgrades cannot accidentally enable streaming in an old Core.
+- Status, receipts, and content progress remain independently configurable.
+
+### Negative
+
+- Enabled turns add repeated acknowledged PUTs and can increase Connector write
+  pressure.
+- An ambiguous write may leave a partial placeholder and intentionally suppress
+  a fresh final answer.
+- Recovery after an explicitly rejected DELETE may show partial placeholder
+  overlap beside the complete fresh answer.
+- Process restart can orphan a placeholder because state remains intentionally
+  non-durable.

--- a/docs/adr/teams-real-send-acknowledgement.md
+++ b/docs/adr/teams-real-send-acknowledgement.md
@@ -1,0 +1,205 @@
+# ADR: Teams Real Send Acknowledgement and Reply Correlation
+
+- **Status:** Proposed
+- **Date:** 2026-08-08
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Custom Gateway](custom-gateway.md)
+  - [Teams bot-owned message mutations](teams-owned-message-mutations.md)
+
+---
+
+## Context
+
+The [ephemeral-ingress decision](teams-ephemeral-ingress-state.md) introduced an
+authenticated, bounded, gateway-local route for each Teams message activity. Before this decision, outbound Teams delivery still used a
+conversation-only service URL cache, copied the OpenAB `event_id` into Bot
+Connector `replyToId`, and discarded the activity ID returned by Teams in
+Unified mode. Standalone Core could not require a send acknowledgement because
+the Teams capability advertised `send_ack = false`.
+
+Those behaviors violated the identifier contract:
+
+- `GatewayEvent.event_id` is OpenAB correlation metadata, not a Bot Framework
+  activity ID;
+- a successful create/send must return the real platform activity ID;
+- a timed-out or disconnected POST may already have completed and must not be
+  represented as a safe rejection or retried blindly.
+
+Teams controls channel-root, channel-reply, Personal, and group-chat
+presentation; HTTP transport tests cannot define or guarantee that UX.
+
+## Decision
+
+### Route resolution
+
+A commandless outbound reply resolves `GatewayReply.reply_to` exclusively as an
+OpenAB `event_id` in the bounded ingress registry. The resolved route supplies:
+
+- bot app and tenant scope;
+- conversation ID and type;
+- inbound activity and reply-chain identifiers;
+- the validated gateway-local service URL;
+- optional Team and channel identifiers.
+
+The outbound `GatewayReply.channel.id` must equal the route's conversation ID.
+A missing, expired, or capacity-evicted event route returns
+`route_not_found`; a conversation mismatch returns `route_mismatch`. Both are
+`Rejected` outcomes and occur before OAuth or Bot Connector I/O.
+
+The conversation-only compatibility service URL map is removed. Service URLs
+remain inside authenticated route state and are never sent to Core or the
+agent.
+
+### Normal send and explicit quote
+
+Normal responses do not infer a Bot Connector `replyToId` from `event_id` or
+from the triggering inbound activity. They use the Bot Connector
+`SendToConversation` endpoint:
+
+```text
+POST {serviceUrl}/v3/conversations/{conversationId}/activities
+```
+
+Only `GatewayReply.quote_message_id` expresses an explicit quote request. The
+adapter uses the Bot Connector `ReplyToActivity` endpoint and also carries the
+target as `Activity.replyToId`, but only when the target is known in the same
+app, tenant, and conversation scope:
+
+```text
+POST {serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}
+```
+
+Known targets include:
+
+- the current authenticated inbound activity;
+- its authenticated `replyToId` reply-chain root;
+- another activity still present in the same bounded ingress route index.
+
+An empty or unknown target falls back to a plain send. It is never looked up in
+another tenant or conversation and never causes `event_id` to reach a Bot
+Connector activity URL or body field. This endpoint distinction follows
+Microsoft's [Bot Connector API reference](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0#reply-to-activity),
+which directs replies to a specific activity through `ReplyToActivity` rather
+than `SendToConversation`.
+
+### Structured send outcomes
+
+Teams sends produce one of the existing protocol outcomes:
+
+| Condition | Outcome | Code / data |
+| --- | --- | --- |
+| HTTP success with non-empty activity ID | `Delivered` | real `message_id` |
+| Invalid or missing route | `Rejected` | `invalid_route`, `route_not_found`, or `route_mismatch` |
+| OAuth acquisition fails before Connector POST | `Rejected` | `connector_auth_failed` |
+| Connector `3xx` or `4xx` response | `Rejected` | stable rejection code |
+| Connector `429` | `Rejected` | `rate_limited` plus bounded `retry_after_ms` |
+| Connector `5xx` | `Unknown` | `connector_server_error` |
+| POST timeout, disconnect, or transport error | `Unknown` | `request_timeout` or `transport_error` |
+| Success response is malformed or omits activity ID | `Unknown` | `invalid_success_response` or `missing_activity_id` |
+
+A success response without a usable activity ID is `Unknown`, not `Rejected`,
+because Teams may already have created the message. OpenAB does not
+fresh-send or automatically retry `Rejected` or `Unknown` results on this path.
+Error body size, redaction, endpoint validation, redirect policy, and request
+timeouts remain governed by the Bot Connector transport-hardening decision.
+
+`Retry-After` accepts either delta seconds or an HTTP date and is converted to a
+bounded millisecond value. Recording it does not introduce an automatic retry.
+
+### Standalone acknowledgement
+
+A configured Teams adapter now advertises:
+
+```text
+send_ack = true
+edit_ack = false
+delete_ack = false
+```
+
+After a valid new↔new hello negotiation, Core includes a request ID and waits for
+the operation-specific send ACK. Gateway emits
+`openab.gateway.response.v1` with additive structured outcome fields on every
+terminal commandless-send path. `Delivered` must contain a non-empty real
+Bot Framework activity ID; Core rejects an otherwise successful ACK without
+one.
+
+A legacy Core may omit the request ID or include one for its existing
+best-effort streaming correlation. New Gateway emits no unsolicited frame when
+the ID is absent. When it is present, the response keeps the legacy fields and
+adds outcome metadata that old peers can ignore; a missing response remains
+non-fatal under legacy Core semantics. New Core connected to an old Gateway
+receives no supported hello and likewise retains legacy missing-ACK behavior.
+
+### Unified acknowledgement
+
+Unified mode calls the same Teams route and Connector implementation in
+process. `ChatAdapter::send_message` and `send_message_with_reply` return a
+`MessageRef` containing the real Bot Framework activity ID. `Rejected` and
+`Unknown` outcomes become errors; Unified no longer fabricates a synthetic ID
+for Teams delivery.
+
+Other Unified platforms retain their existing behavior. At this decision's
+boundary, Teams capabilities report required send acknowledgement while edit,
+delete, streaming, and status remain disabled. The later
+[bot-owned mutation decision](teams-owned-message-mutations.md) enables guarded
+edit/delete without enabling streaming.
+
+### Activity DTO
+
+The inbound DTO parses the route and presentation fields, including
+`activity.id`, `activity.replyToId`, `conversation.id`, `conversation.conversationType`,
+`channelData.team.id`, `channelData.channel.id`, and `recipient.id`.
+Parsing these fields does not define or guarantee Teams presentation behavior.
+
+## Compatibility
+
+| Core | Gateway | Send behavior |
+| --- | --- | --- |
+| old | old | Existing legacy fire-and-forget behavior. |
+| old | new | Event route is used; no request ID means no response frame, while a legacy request ID receives a backward-compatible response. Missing ACK remains non-fatal to old Core. |
+| new | old | No valid hello; Core keeps legacy missing-ACK semantics. |
+| new | new | Teams advertises required send ACK and returns a structured terminal outcome with the real activity ID on delivery. |
+| Unified | embedded | The same outcome is returned directly without a WebSocket ACK frame. |
+
+Operations emitted before a valid hello is processed continue to use legacy
+Core semantics. The Gateway still classifies the internal result, but does not
+send an unsolicited response when the reply has no request ID.
+
+## Security and reliability boundaries
+
+- Route lookup is process-local, bounded, and TTL-limited.
+- Service URLs never cross the Gateway boundary or appear in outcome messages.
+- Quote targets cannot cross app, tenant, or conversation scope.
+- Unsupported commands are rejected before route lookup and network I/O;
+  reactions remain an intentional no-op until a Teams status backend exists.
+- A Gateway broadcast ACK is not a durable record and does not provide crash
+  replay.
+- This decision does not claim exactly-once delivery, multi-consumer work
+  distribution, proactive-send support, or restart-persistent message
+  ownership.
+
+
+## Consequences
+
+### Positive
+
+- OpenAB correlation IDs can no longer leak into Bot Connector activity fields.
+- New Standalone and Unified sends expose the real Teams activity ID.
+- Rejection and ambiguous delivery are distinct, preventing blind duplicate
+  sends after POST uncertainty.
+- The temporary conversation-only service URL cache is eliminated.
+- Explicit quote targets fail safely to plain send when route evidence is
+  missing.
+
+### Negative
+
+- Replies fail after route expiry, capacity eviction, or process restart.
+- A successful Teams write with a malformed response is reported as unknown
+  even though a message may be visible to the user.
+- Teams clients control scope-specific thread and quote presentation; successful
+  transport correlation does not guarantee visible quote chrome.
+- Required ACKs make Connector latency visible to new Core peers and consume
+  the configured 12-second Gateway ACK budget.

--- a/docs/adr/teams-text-command-parity.md
+++ b/docs/adr/teams-text-command-parity.md
@@ -1,0 +1,323 @@
+# ADR: Teams Text Command Parity
+
+- **Status:** Proposed
+- **Date:** 2026-08-13
+- **Author:** @NeoHsu
+- **Related:**
+  - [Slash commands](../slash-commands.md)
+  - [Teams typed scope and mention routing](teams-typed-scope-and-mention-routing.md)
+  - [Multi-platform adapters](multi-platform-adapters.md)
+
+---
+
+## Context
+
+Teams bot command menus do not create a Discord-style interaction callback.
+The stable Teams app-manifest `bots[].commandLists[]` surface inserts configured
+text into the compose box, and the user sends it as an ordinary authenticated
+`message` activity. OpenAB must therefore parse commands only after the normal
+Bot Framework validation, typed scope, identity, and structured-mention gates.
+
+The first parity set is:
+
+- `/models`
+- `/agents`
+- `/cancel`
+- `/reset`
+- `/cancel-all`
+- `/usage`
+
+At the reviewed design baseline, the implementation was split across platform entry points:
+
+| Command | Discord native interaction | Gateway text path |
+| --- | --- | --- |
+| `/models` | Ephemeral select menu | Numbered text list through `/models` and `/model …` |
+| `/agents` | Ephemeral select menu | Numbered text list through `/agents` and `/agent …` |
+| `/cancel` | Implemented | Implemented in both Standalone and Unified loops |
+| `/reset` | Implemented | Implemented in both Standalone and Unified loops |
+| `/cancel-all` | Implemented | Missing |
+| `/usage` | Ephemeral, Kiro-specific ACP query | Missing |
+
+The two Gateway paths also duplicated command dispatch. At that baseline, the
+Standalone path executed inside the WebSocket reader and used an unacknowledged
+fire-and-forget response to avoid waiting for a reply that only the same reader
+could dispatch. That was incompatible with Teams required send acknowledgements.
+
+`/usage` has an additional privacy boundary. Discord responses are ephemeral,
+but an ordinary Teams reply in a group chat or Team channel is visible to the
+conversation. Account plan, limit, and overage information must not be exposed
+there merely because the command text is valid.
+
+## Prior Art
+
+### OpenClaw
+
+OpenClaw separates a shared command registry and parser from native-platform
+fast paths. Definitions describe native names, text aliases, scope, arguments,
+and tiers, while authorization is resolved before command execution. Unknown or
+colliding prefixes are not accidentally consumed.
+
+- [Shared command registry](https://github.com/openclaw/openclaw/blob/7179d21d977aacd0b07c0d5b12c31d1be251df7d/src/auto-reply/commands-registry.shared.ts)
+- [Boundary-aware text parser](https://github.com/openclaw/openclaw/blob/7179d21d977aacd0b07c0d5b12c31d1be251df7d/src/auto-reply/reply/commands-slash-parse.ts)
+- [Native command fast path](https://github.com/openclaw/openclaw/blob/7179d21d977aacd0b07c0d5b12c31d1be251df7d/src/auto-reply/reply/get-reply-native-slash-fast-path.ts)
+
+### Hermes Agent
+
+Hermes exposes a central messaging command surface, applies a separate
+per-platform and per-scope command-access policy, and declares native command
+manifests independently from command execution. Relay interactions normalize
+back into the same command dispatcher rather than creating a second handler.
+
+- [Messaging command handlers](https://github.com/NousResearch/hermes-agent/blob/a871948d8d4b0f774d4ec40467bab1078a9f28d5/gateway/slash_commands.py)
+- [Per-platform command access](https://github.com/NousResearch/hermes-agent/blob/a871948d8d4b0f774d4ec40467bab1078a9f28d5/gateway/slash_access.py)
+- [Relay command manifest](https://github.com/NousResearch/hermes-agent/blob/a871948d8d4b0f774d4ec40467bab1078a9f28d5/gateway/relay/command_manifest.py)
+
+OpenAB does not need either project's full registry or permission-tier system.
+The useful common pattern is a small semantic command service with separate
+ingress admission and platform rendering.
+
+## Decision
+
+### 1. Add one platform-neutral command service
+
+Core will own a small command module used by Discord native interactions,
+Standalone Gateway events, and Unified Gateway events. It will contain:
+
+- an exact parser for the six canonical commands and the existing Gateway
+  `/model …` and `/agent …` compatibility forms;
+- command execution against `SessionPool` and `Dispatcher`;
+- structured, platform-neutral results for config options, session-control
+  acknowledgements, usage data, validation errors, and unavailable operations;
+- bounded user-facing error classes rather than raw backend errors; and
+- shared config-option selection validation.
+
+The command service will not depend on Serenity, Gateway wire types, Teams Bot
+Framework types, Adaptive Cards, or any platform SDK. Platform adapters retain
+presentation responsibilities:
+
+- Discord renders ephemeral messages, selects, pagination controls, and the
+  existing usage colour/footer embed.
+- Teams and other approved text surfaces render bounded Markdown/plain text.
+
+### 2. Parse only standalone, boundary-valid commands
+
+Outer whitespace is ignored. Canonical command names are lowercase ASCII and
+must end at the input boundary because the first set takes no arguments.
+Recognized compatibility forms retain their current syntax:
+
+```text
+/model
+/model list
+/model set <number or exact name>
+/agent
+/agent list
+/agent set <number or exact name>
+```
+
+A known command with unsupported trailing arguments returns a bounded usage
+message. Prefix collisions such as `/reset-now`, `/usage-report`, or
+`/cancel-all-now` are not commands and continue through the ordinary agent
+prompt path. Unknown slash-prefixed text also continues to the ACP backend so
+agent-native commands such as `/compact` remain usable.
+
+Command interception occurs after structural, L2 scope, L3 identity, and Teams
+recipient-mention handling, but before attachment materialization and dispatcher
+submission. A recognized command does not create a session, consume an agent
+turn, add queued/progress reactions, create a placeholder, or download an
+attachment.
+
+### 3. Keep one logical-thread command key
+
+Commands use the same session key as normal dispatch:
+
+```text
+{platform}:{thread_id-or-channel_id}
+```
+
+`/reset` and `/cancel-all` clear all dispatcher handles whose key belongs to the
+same `(platform, logical_thread_id)`, including every per-sender lane. They do
+not affect another platform or conversation with a coincidentally equal native
+ID.
+
+### 4. Define the six command semantics
+
+| Command | Core behavior |
+| --- | --- |
+| `/models` | Require existing session config options; return model options with current selection. Discord keeps its paginated select UI. Text rendering is current-first, displays at most 25 entries, and reports the omitted count. Existing `/model set …` searches the full option set. |
+| `/agents` | Same as `/models`, accepting both `agent` and `mode` ACP categories. Existing `/agent set …` searches the full option set. |
+| `/cancel` | Send one lock-free ACP `session/cancel` notification for the logical session. Do not clear buffered messages. |
+| `/cancel-all` | Remove and abort all buffered dispatcher lanes for the logical thread, then send the same ACP cancel notification when a session exists. Report only whether buffering was cleared, not a race-prone exact count. |
+| `/reset` | Remove and abort all buffered lanes, issue best-effort ACP cancellation, purge active/suspended/persisted session state through `SessionPool::reset_session`, and let the next ordinary message create a fresh session. |
+| `/usage` | Require an active session, a backend that supports the existing usage extension, and a response surface proven private. Return the existing plan, breakdown, overage, currency, and reset information without logging it. |
+
+Config mutations validate the requested `config_id` and value against the
+current active session options before calling `session/set_config_option`.
+Discord component payloads and text set commands use the same validation.
+
+No command retries an ACP control notification or a platform response. A
+platform write that is `Rejected` or `Unknown` remains terminal for that
+response.
+
+### 5. Preserve privacy and trust before execution
+
+All command entry points must pass their normal platform admission before the
+service is called.
+
+For Teams:
+
+1. JWT, tenant, required route fields, and public-cloud service URL are already
+   validated by Gateway.
+2. Structural bot/mention filtering runs.
+3. Typed L2 scope and L3 identity admission runs.
+4. Only an authenticated recipient mention entity is removed.
+5. The remaining text is parsed as a command.
+
+Plain-text `@OpenAB`, an unbound `<at>OpenAB</at>`, malformed typed scope, a
+disallowed surface, or a denied identity cannot invoke a command.
+
+Discord native interactions will be routed through the existing adapter-level
+DM/channel/user policy and shared L3 identity gate before a shared command is
+executed. Denial is acknowledged ephemerally and does not disclose another
+user's or session's state.
+
+`/usage` executes only when the response is private by construction:
+
+- Discord native interaction: ephemeral response;
+- Teams: authenticated typed `personal` scope with `is_dm = true`.
+
+A Team channel, group chat, or old Teams event without typed privacy proof gets
+a generic private-chat-only response and does not call the ACP usage extension.
+No account values are logged or included in that rejection.
+
+### 6. Keep Standalone and Unified execution equivalent
+
+Both Gateway paths will call the same post-gate command helper. The duplicated
+`/reset`, `/cancel`, and config-command blocks are removed.
+
+The Standalone WebSocket reader must never await a command response whose
+required Gateway ACK is dispatched by that same reader. It spawns bounded
+command execution/delivery work, continues reading frames, and uses the normal
+outcome-aware `ChatAdapter` send path from the spawned task. Unified uses the
+same command service and renderer without a wire hop.
+
+Command response delivery therefore follows negotiated Teams semantics:
+
+- valid new-peer hello: required real-ID send ACK;
+- old Gateway or no valid hello: existing legacy send behavior;
+- first `Rejected` or `Unknown`: stop without retry or a second warning send.
+
+No Gateway protocol version or capability field is added.
+
+### 7. Add a conservative Teams manifest command menu
+
+The documented manifest v1.25 profile will add classic
+`bots[].commandLists[]`. Titles contain the exact text command, including the
+leading slash.
+
+The Personal list advertises all six commands. The Team/group-chat list omits
+`/usage` and advertises the other five. This is discoverability only; selecting
+an item still produces an ordinary message and all runtime trust/mention gates
+remain authoritative.
+
+This proposal does **not** enable the newer `supportsTargetedMessages` plus
+`commandLists[].triggers = ["slash"]` agent surface. Microsoft's current agent
+slash-command guidance says that surface switches group conversations into
+private targeted-message mode. OpenAB does not negotiate, route, or support that privacy model, and manifest
+v1.25 does not define those fields.
+
+Changing an installed app manifest remains an operator-controlled package
+upgrade. Runtime deployment does not silently mutate a tenant app package.
+
+### 8. Keep observability content-free
+
+One command completion record may include platform, canonical command name,
+semantic outcome class, and response write outcome. It must not include command
+arguments, option values, usage values, sender/conversation/activity IDs,
+serialized responses, tokens, or URLs.
+
+## Rolling Compatibility
+
+| Core | Gateway / surface | Result |
+| --- | --- | --- |
+| old Core | new Gateway or unchanged manifest | Existing partial text-command behavior; new Gateway does not execute commands. |
+| new Core | old Gateway / no valid hello | Ordinary event decoding remains compatible; non-sensitive commands use legacy response delivery. `/usage` fails closed without authenticated typed privacy proof. |
+| new Core | new Gateway | Shared service plus negotiated response ACKs. |
+| new Unified | embedded Teams adapter | Same parser, execution, privacy, and result semantics without WebSocket transport. |
+| any runtime | old installed manifest | Commands remain manually typeable; no menu is required for correctness. |
+| any runtime | updated command-list manifest | Menu selection sends ordinary text; runtime gates remain authoritative. |
+
+## Acceptance criteria
+
+Automated verification must cover:
+
+- exact command boundaries, outer whitespace, known invalid arguments, and
+  unknown slash text passing through to ACP;
+- all six semantic command results plus existing `/model` and `/agent`
+  compatibility forms;
+- current-first 25-entry text rendering with deterministic truncation count;
+- full-option validation for config selection and rejection of stale or forged
+  IDs/values before ACP mutation;
+- `/cancel` preserving buffers, `/cancel-all` clearing every lane, and `/reset`
+  clearing every lane plus session state without cross-thread/platform effects;
+- active, absent, unsupported, malformed, over-limit, and no-cap usage reports;
+- `/usage` denied before backend access on public or unproven-private surfaces;
+- Teams structural → typed L2 → L3 → mention cleanup → command ordering in both
+  Standalone and Unified paths;
+- recognized command events skipping attachments, dispatcher submission,
+  reactions, processing status, and progressive placeholders;
+- Standalone command execution not blocking the WebSocket response reader;
+- required-ACK response `Delivered`, `Rejected`, `Unknown`, and timeout behavior
+  without retry or duplicate response;
+- new Core ↔ old Gateway/no-hello behavior and Unified parity;
+- Discord interaction admission, ephemeral presentation, config pagination, and
+  existing `/models`, `/agents`, `/cancel`, `/cancel-all`, `/reset`, and `/usage`
+  regressions;
+- manifest v1.25 schema validation, command-list scope separation, command count,
+  and absence of targeted-message, Graph, RSC, delegated, or Adaptive Card
+  permissions; and
+- platform-schema conformance plus existing Core/Gateway/Unified tests.
+
+
+## Consequences
+
+### Positive
+
+- Command semantics stop drifting between Discord, Standalone, and Unified.
+- Teams gains the missing control and usage commands without a new protocol or
+  permission.
+- Usage data cannot be accidentally published to a group or channel.
+- Required ACKs can be used without blocking the Standalone WebSocket reader.
+- Manifest discovery remains independent from runtime authorization.
+
+### Negative
+
+- The shared service introduces structured semantic results and platform
+  renderers instead of a single string-returning helper.
+- Discord native command admission must be made explicit during the refactor.
+- Teams text menus cannot match Discord's interactive select controls without
+  the deferred Adaptive Card work.
+- Operators must install a revised app package before command-menu entries
+  appear.
+
+## Alternatives Rejected
+
+1. **Copy Discord handlers into Teams.** This preserves drift and imports
+   platform-specific interaction assumptions into ordinary messages.
+2. **Forward every command to the agent.** Session control and account usage are
+   broker responsibilities and must work without consuming an agent turn.
+3. **Keep the duplicated Gateway blocks.** `/cancel-all` and `/usage` would still
+   diverge, and Standalone response ACKs would remain unsafe.
+4. **Publish `/usage` in all scopes.** Teams ordinary replies are not ephemeral
+   and could expose account information.
+5. **Enable targeted messages now.** The newer manifest surface changes group
+   privacy and delivery semantics that OpenAB has not modeled or validated.
+6. **Use Adaptive Cards for parity.** Cards add a separate callback trust path
+   and are explicitly deferred.
+7. **Add a new Gateway command protocol.** Commands already arrive as ordinary
+   authenticated events; a protocol change adds rolling risk without need.
+
+## References
+
+- [Microsoft: expose slash commands from agents and apps](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-commands-menu)
+- [Microsoft Teams manifest v1.25 schema](https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json)
+- [Microsoft classic bot command-menu source at reviewed commit](https://github.com/MicrosoftDocs/msteams-docs/blob/c4611ef2586b/msteams-platform/bots/how-to/create-a-bot-commands-menu.md)

--- a/docs/adr/teams-trusted-persistent-conversation-registry.md
+++ b/docs/adr/teams-trusted-persistent-conversation-registry.md
@@ -1,0 +1,375 @@
+# ADR: Teams Trusted Persistent Conversation Registry
+
+- **Status:** Proposed
+- **Date:** 2026-08-19
+- **Author:** @NeoHsu
+- **Related:**
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+  - [Teams typed scope and mention routing](teams-typed-scope-and-mention-routing.md)
+  - [Gateway capability and delivery semantics](gateway-capabilities-and-delivery-semantics.md)
+  - [Teams real send acknowledgement](teams-real-send-acknowledgement.md)
+  - [Basic cron scheduler](basic-cronjob.md)
+
+---
+
+## Context
+
+OpenAB can reply to an authenticated Teams activity only while its bounded
+Gateway-local `TeamsIngressRoute` remains available. That route contains the
+validated Bot Framework `serviceUrl` and is indexed by an OpenAB event ID. It is
+deliberately process-local, expires after `route_ttl_secs`, and disappears when
+the Gateway restarts.
+
+Operator-scheduled delivery needs a trustworthy Teams destination after the
+original turn and ephemeral route have ended. Persisting every JWT-valid
+webhook is unsafe because Teams L2 scope and L3 sender identity are decided in
+Core, after Gateway publication. Persisting only after an agent reply is also
+incorrect: a trusted conversation remains a valid destination when a command
+short-circuits, an attachment is rejected, the ACP backend fails, or the turn is
+cancelled.
+
+The trust and secret boundary is therefore split:
+
+- Gateway alone validates Bot Framework JWT, tenant, endpoint, and route fields
+  and retains `serviceUrl`;
+- Core alone has the authoritative shared L2/L3 Allow decision; and
+- neither Core nor an ACP child may receive a persistent conversation
+  reference or `serviceUrl`.
+
+This proposal creates the registry and post-trust promotion handshake. It does
+not send proactive messages or schedule work.
+
+## Constraints
+
+- Existing deployments must remain behaviorally unchanged unless an operator
+  configures a registry path.
+- A denied, malformed, unauthenticated, cross-tenant, or expired route must
+  never create or refresh a persistent record.
+- The registry is routing authority and must be treated as sensitive state even
+  though it contains no bot credential or message body.
+- `serviceUrl` remains Gateway-local and must not appear in Gateway wire events,
+  ACP input, command responses, or application logs.
+- Standalone and Unified mode must apply the same promotion and storage rules.
+- The baseline supports one Gateway process and one direct Core consumer; this
+  is not a distributed registry or durable inbox.
+
+## Prior Art and Industry Research
+
+Research was performed against immutable source revisions on 2026-08-19.
+
+### Microsoft Teams and Bot Framework
+
+Microsoft requires a bot to retain a `conversationId` or
+`conversationReference` for out-of-context delivery and recommends using the
+`serviceUrl` from the incoming activity. The app must already be installed in
+the target scope. A blocked or uninstalled bot may receive HTTP 403 with
+`MessageWritesBlocked`; Teams also emits authenticated `installationUpdate`
+activities with `action = add` or `remove`.
+
+OpenAB adopts the incoming-reference and uninstall-signal model, but adds its
+own shared L2/L3 promotion gate because JWT validation alone is not OpenAB user
+or scope authorization. This proposal does not use Microsoft Graph to install the app
+or discover new conversations.
+
+### OpenClaw
+
+Reviewed revision:
+[`4994f7bacf308269a0770b4a912c44a746cccec7`](https://github.com/openclaw/openclaw/tree/4994f7bacf308269a0770b4a912c44a746cccec7).
+
+OpenClaw's Teams plugin stores conversation references in keyed SQLite state,
+hashes the conversation ID for its storage key, bounds retained conversations,
+uses a one-year TTL, merges sparse refreshes, and validates stored
+`serviceUrl` hosts before proactive use:
+
+- [`conversation-store-state.ts`](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/conversation-store-state.ts)
+- [`conversation-store-helpers.ts`](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/conversation-store-helpers.ts)
+- [`bot-framework-service-url.ts`](https://github.com/openclaw/openclaw/blob/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src/bot-framework-service-url.ts)
+
+Its normal admitted-message path asynchronously upserts the reference after
+access checks, although its pairing path intentionally stores a reference for a
+not-yet-allowlisted DM. OpenAB adopts bounded versioned storage, sparse-field
+refresh, and endpoint revalidation. It diverges by prohibiting pairing or any
+other denied activity from promotion, keying by app plus tenant plus Bot
+Framework channel plus conversation, and recording disabled/revoked state
+rather than exposing every stored route as immediately usable.
+
+### Hermes Agent
+
+Reviewed revision:
+[`00e5a361b60f621ae2246dffdd0a0252895d8493`](https://github.com/NousResearch/hermes-agent/tree/00e5a361b60f621ae2246dffdd0a0252895d8493).
+
+Hermes keeps Teams `ConversationReference` objects in an in-memory `chat_id`
+map for cards and captures them before its shared `handle_message` admission.
+The map disappears on restart. Separate-process cron instead requires an
+operator-configured home conversation, tenant, and service URL; that path
+allowlists service hosts and validates conversation IDs:
+
+- [`plugins/platforms/teams/adapter.py`](https://github.com/NousResearch/hermes-agent/blob/00e5a361b60f621ae2246dffdd0a0252895d8493/plugins/platforms/teams/adapter.py)
+
+OpenAB adopts the explicit endpoint and identifier validation but not the
+pre-admission cache or static global home route. Those approaches cannot prove
+that a dynamically observed conversation passed OpenAB's shared L2/L3 gate and
+do not provide restart-safe per-conversation authority.
+
+## Decision
+
+### Opt-in configuration
+
+Persistence is disabled when `teams.conversation_registry_path` is absent or
+empty. This preserves all existing route and filesystem behavior.
+
+When configured, the registry resolves:
+
+| Setting | Default when enabled | Purpose |
+| --- | ---: | --- |
+| `conversation_registry_path` | none | Registry JSON file; absence disables the feature |
+| `conversation_registry_max_entries` | `1000` | Independent persistent-record cap |
+| `conversation_registry_ttl_secs` | `31536000` | One-year active/disabled retention window |
+
+Standalone environment fallbacks are
+`TEAMS_CONVERSATION_REGISTRY_PATH`,
+`TEAMS_CONVERSATION_REGISTRY_MAX_ENTRIES`, and
+`TEAMS_CONVERSATION_REGISTRY_TTL_SECS`.
+
+A relative path resolves beneath `$HOME/.openab/`; an absolute path is accepted
+as an explicit operator choice. Empty components, `.`/`..`, NUL, and any
+existing symlink component are rejected. Helm does not silently create a new
+Gateway PVC: Standalone operators must mount durable storage explicitly, while
+Unified deployments may place the file on their existing HOME volume.
+
+### Versioned record
+
+The file has a closed top-level schema and records a generation number plus a
+bounded list of entries. Each entry contains only:
+
+- schema version;
+- bot app ID;
+- tenant ID;
+- Bot Framework channel ID;
+- conversation ID and canonical type;
+- validated `serviceUrl`;
+- optional Team and Teams channel IDs;
+- `last_validated_at` and `updated_at` wall-clock timestamps;
+- `active`, `disabled`, or `revoked` state;
+- a bounded reason code and consecutive forbidden-write count.
+
+No sender ID, user display name, message/activity ID, message text, attachment,
+credential, OAuth token, or agent/session identifier is persisted. Configuration
+accepts `1..=10000` entries; the serialized file is independently capped at 16
+MiB. App, tenant, Bot Framework channel, conversation type, and reason fields
+are capped at 256 UTF-8 bytes; conversation, Team, and Teams channel IDs at
+2048 bytes; and the already endpoint-validated service URL at 4096 bytes.
+
+The composite identity is:
+
+```text
+(app_id, tenant_id, bot_framework_channel_id, conversation_id)
+```
+
+Lookup always requires the complete identity. Conversation IDs alone are never
+global keys.
+
+### Trust-confirmed promotion
+
+Gateway advertises an additive Teams capability only when the registry is
+configured, safely opened, and the supported single-consumer topology is in
+use. New Core treats an absent capability as persistence unavailable and sends
+no new command. Old Core and old Gateway combinations retain process-local
+behavior.
+
+After structural admission and shared L2/L3 `Allow`, Core submits a bounded
+`register_conversation` Gateway command before command, attachment, session, or
+agent work can determine the turn outcome. The command carries only the
+existing origin event ID and logical channel correlation. It never carries a
+`serviceUrl` or serialized reference.
+
+Gateway resolves the origin event ID back to the still-valid authenticated
+`TeamsIngressRoute`, verifies the reply channel and single-consumer topology,
+and atomically upserts that route into the persistent registry. Missing,
+expired, evicted, cross-conversation, or capability-mismatched routes are
+rejected before filesystem mutation.
+
+Standalone registration runs in a tracked bounded task outside the WebSocket
+reader because its correlated response can only be dispatched by that reader.
+Unified invokes the same Gateway method in process. Registration is independent
+from ACP success and is allowed for trusted recognized commands, ordinary
+turns, and trusted turns that later become empty after mention cleanup.
+
+A storage failure does not retroactively reject the already authenticated
+inbound message or prevent its current reactive turn. It returns a correlated
+`Rejected` or `Unknown` registration outcome, leaves no new usable record, and
+is never blindly retried. A later independently authenticated inbound activity
+may safely attempt a fresh upsert.
+
+### Refresh and state transitions
+
+Only a newly authenticated ephemeral route plus a new shared L2/L3 Allow may
+refresh address fields or `last_validated_at`:
+
+```text
+Absent   -- trusted inbound + committed write --> Active
+Active   -- trusted inbound + committed write --> Active (refreshed)
+Disabled -- trusted inbound + committed write --> Active (re-enabled)
+Revoked  -- trusted inbound + committed write --> Active (re-installed proof)
+```
+
+Gateway-local delivery reconciliation exposes transitions for
+operator-scheduled delivery:
+
+- two consecutive explicit blocked/not-in-roster 403 outcomes disable an active
+  record;
+- a successful proactive write clears the consecutive forbidden count;
+- 429, 5xx, timeout, disconnect, and ambiguous outcomes do not disable or
+  refresh a record; and
+- an authenticated, tenant-allowed `installationUpdate` with `remove` or
+  `remove-upgrade` marks an existing matching record revoked without creating a
+  new record.
+
+An `installationUpdate add` does not activate a route by itself because it has
+not passed user L3 admission. A subsequent trusted inbound activity may
+reactivate the record. This proposal records and tests these transitions;
+operator-scheduled delivery is the first caller of reconciliation.
+
+### Filesystem transaction and recovery
+
+All mutations are serialized by one registry lock and follow
+clone → validate → write temporary file → flush → atomic rename → parent
+flush → publish in-memory state. Readers never observe a candidate state before
+its durable commit.
+
+On Unix, newly created directories are mode `0700` and the registry and
+temporary files are mode `0600`. Existing registry permissions are tightened
+before use. The final file, temporary file, and every existing path component
+must be regular/non-symlink objects of the expected type. Record fields, entry
+count, and total JSON bytes are bounded before allocation or replacement.
+
+Malformed JSON, an unknown schema version, an oversized file, unsafe path, or
+permission failure makes the persistent capability unavailable and does not
+replace the existing file. Reactive Teams messaging continues with the current
+process-local route contract, while health/logging reports a content-free
+registry initialization error.
+
+A crash before rename leaves the prior generation authoritative. Startup
+ignores and safely removes only this registry's own validated temporary-file
+pattern; unrelated files are never touched. No automatic migration from an
+unknown future schema is attempted.
+
+### Capacity and retention
+
+Expired active or disabled entries are removed during load and mutation.
+Revoked tombstones are retained within the same hard cap so a restart does not
+silently erase the last known platform revocation before fresh trusted evidence
+arrives. At capacity, the oldest expired, then disabled, then active record may
+be evicted deterministically. Revoked records are not evicted to admit a new
+key; saturation rejects the new promotion and emits a count-only warning.
+
+This registry is not shared between replicas. Two Gateway processes must not
+write the same path. The registry performs no cross-process locking and advertises no
+persistent capability when the existing topology report is unsupported.
+
+### Observability and privacy
+
+Logs and tests may expose schema/generation, aggregate entry/state counts,
+operation class, result class, elapsed time, and bounded reason codes. They must
+not expose app, tenant, conversation, Team/channel, activity, sender, full path,
+or service URL values. Filesystem tests use synthetic identifiers only.
+
+The registry is never mounted into or passed through the agent subprocess
+environment. Core and ACP observe only registration capability and the
+correlated outcome.
+
+## Compatibility and rollout
+
+- Missing configuration means no disk read/write and no advertised capability.
+- New Gateway with old Core never receives promotion and remains process-local.
+- New Core with old or unavailable Gateway sees capability false and sends no
+  unsupported command.
+- Registry state is Gateway-local; rolling Core replacement does not require a
+  file migration.
+- A Gateway rollback leaves the versioned file untouched. The old binary does
+  not know its path unless separately configured.
+- Enabling Standalone persistence requires an operator-owned durable mount and
+  a rollback backup. It does not recreate Core or change the Teams app
+  manifest.
+
+## Acceptance criteria
+
+Automated coverage must include:
+
+1. versioned round-trip, stable composite keys, sparse refresh, and complete
+   record-field bounds;
+2. absent-path no-op defaults and config/env/Unified/Standalone equivalence;
+3. `0600`/`0700`, traversal and symlink rejection, temporary-file isolation,
+   corrupt/unknown/oversized file fail-closed behavior, and old-or-new recovery
+   across an interrupted write;
+4. deterministic TTL/capacity behavior and revoked-tombstone saturation;
+5. no promotion for structural, tenant, typed L2, L3, malformed-scope, expired
+   route, cross-conversation, or unsupported-topology rejection;
+6. promotion before command/attachment/session/agent side effects and
+   independence from ACP failure;
+7. correlated Standalone response without WebSocket reader deadlock, timeout
+   retry, or unsolicited old-peer response;
+8. Unified and Standalone promotion parity;
+9. refresh/reactivation, consecutive blocked-403 disable, successful-write
+   reset, ambiguous-outcome no-disable, and authenticated uninstall revocation;
+10. serialization/logging guards proving that route identifiers, `serviceUrl`,
+    messages, and credentials do not cross into Core, ACP, or logs; and
+11. changed-line formatting, targeted Core/Gateway/platform-schema tests,
+    Clippy, config documentation, relative links, secret scanning, and
+    `git diff --check`.
+
+
+## Consequences
+
+### Positive
+
+- Restart-safe Teams destinations inherit OpenAB's existing L2/L3 trust rather
+  than JWT validity alone.
+- Gateway retains full ownership of service URLs and persistent route data.
+- PR 12 receives an explicit active/disabled/revoked lookup contract instead of
+  reconstructing routes from session IDs.
+- Default deployments gain no new filesystem side effect.
+- Atomic versioned storage gives rollback and corruption behavior a testable
+  boundary.
+
+### Negative
+
+- One trusted inbound event now creates an additional asynchronous control
+  exchange when persistence is enabled.
+- A JSON rewrite is proportional to the bounded registry size.
+- Standalone operators must provide a durable Gateway mount explicitly.
+- The one-writer restriction prevents active-active Gateway replicas from
+  sharing this file.
+- Filesystem permissions protect confidentiality only as strongly as the
+  Gateway account and volume.
+
+## Alternatives Rejected
+
+1. **Persist every JWT-valid webhook in Gateway.** This bypasses Core L2/L3 and
+   turns denied conversations into proactive authority.
+2. **Persist only after a bot reply succeeds.** Commands, ACP failures, and
+   cancelled turns would fail to register otherwise trusted conversations.
+3. **Send the full conversation reference to Core.** This leaks `serviceUrl`
+   across the established Gateway-local boundary and risks agent exposure.
+4. **Infer a route from Core session keys.** Session identifiers do not contain
+   authenticated service URL, tenant, app, or install-state evidence.
+5. **Use only a static home channel.** It cannot represent per-conversation
+   trust, refresh, disable, or revocation and invites cross-scope mistakes.
+6. **Enable a default HOME file automatically.** Existing deployments would
+   gain a new sensitive persistent side effect without operator opt-in or a
+   guaranteed durable Gateway mount.
+7. **Use SQLite in PR 11.** A single-writer bounded registry does not yet need a
+   new database dependency; atomic JSON is inspectable and sufficient. A shared
+   transactional store remains the multi-replica follow-up.
+8. **Delete on the first 403.** A single response may be transient or
+   misclassified; bounded consecutive evidence preserves the record while
+   stopping future use after sustained explicit rejection.
+
+## References
+
+- [Microsoft: Send proactive messages](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages)
+- [Microsoft: Conversation events and installation updates](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/subscribe-to-conversation-events)
+- [Microsoft: Bot Connector authentication](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0)
+- [Microsoft: Bot Connector REST API](https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0)
+- [OpenClaw Teams conversation store at reviewed revision](https://github.com/openclaw/openclaw/tree/4994f7bacf308269a0770b4a912c44a746cccec7/extensions/msteams/src)
+- [Hermes Teams adapter at reviewed revision](https://github.com/NousResearch/hermes-agent/blob/00e5a361b60f621ae2246dffdd0a0252895d8493/plugins/platforms/teams/adapter.py)

--- a/docs/adr/teams-typed-scope-and-mention-routing.md
+++ b/docs/adr/teams-typed-scope-and-mention-routing.md
@@ -1,0 +1,191 @@
+# ADR: Teams Typed Scope and Mention Routing
+
+- **Status:** Proposed
+- **Date:** 2026-08-07
+- **Author:** @NeoHsu
+- **Related:**
+  - [Multi-platform adapter architecture](multi-platform-adapters.md)
+  - [Identity trust-none](identity-trust-none.md)
+  - [Teams ephemeral ingress state](teams-ephemeral-ingress-state.md)
+
+---
+
+## Context
+
+Before typed scope was added, Teams published only a conversation route,
+sender, raw text, and an empty mention list. Core therefore evaluated every Gateway event with
+`is_dm = false`, could not distinguish Personal, group chat, and Team channel
+scope, and could not prove that a structured Teams mention targeted the
+receiving bot. Pure text could also resemble an `@mention` without carrying an
+authenticated mention entity.
+
+This proposal must add scope and mention evidence without changing outbound
+routing, widening Graph authority, or requiring a lockstep Core/Gateway rollout.
+
+## Decision
+
+### Additive wire fields
+
+`openab.gateway.event.v1` gains three optional fields. The schema and protocol
+version remain unchanged because old decoders ignore unknown fields and new
+decoders default absent fields:
+
+```rust
+struct GatewayScope {
+    tenant_id: Option<String>,
+    team_id: Option<String>,
+    channel_id: Option<String>,
+    conversation_type: String,
+    trust_scope_id: String,
+    is_dm: bool,
+}
+
+struct RecipientInfo {
+    id: String,
+    name: String,
+}
+
+struct MentionInfo {
+    id: String,
+    text: String,
+}
+
+struct GatewayEvent {
+    // existing fields remain unchanged
+    scope: Option<GatewayScope>,
+    recipient: Option<RecipientInfo>,
+    mention_entities: Vec<MentionInfo>,
+}
+```
+
+The existing `mentions` array remains a list of mentioned entity IDs for
+cross-platform structural gating. `mention_entities` carries the exact Teams
+entity text needed for safe recipient-mention removal. Neither field carries a
+service URL, token, or proactive conversation reference.
+
+`ChannelInfo.id` remains the Bot Connector conversation ID used for session and
+outbound routing. It must not be replaced by `trust_scope_id`.
+
+### Teams scope derivation
+
+After JWT, tenant, required-route, and public-cloud service URL validation, the
+Gateway canonicalizes known Bot Framework conversation types:
+
+| `conversationType` | `is_dm` | Required typed fields | Opaque `trust_scope_id` shape |
+| --- | --- | --- | --- |
+| `personal` | `true` | tenant + conversation | `teams:{tenant}:personal:{conversation}` |
+| `groupChat` | `false` | tenant + conversation | `teams:{tenant}:group-chat:{conversation}` |
+| `channel` | `false` | tenant + Team + channel | `teams:{tenant}:team:{team}:channel:{channel}` |
+
+The key is opaque and is never parsed for authorization. Raw Team and channel
+IDs remain separate fields for allowlist matching. Unknown conversation types,
+`is_dm` contradictions, empty `trust_scope_id`, or channel scope missing Team or
+channel IDs fail closed in the new Core.
+
+### Scope policy and compatibility
+
+First-class Teams scope settings are:
+
+```toml
+[teams]
+allowed_teams = []
+allowed_channels = []
+allow_personal = true
+allow_group_chats = true
+```
+
+Rules:
+
+- Personal is admitted only when `allow_personal = true`.
+- Group chat is admitted only when `allow_group_chats = true`.
+- For Team channels, both lists empty means L2 open. If either list is non-empty,
+  a Team ID or channel ID match admits the scope.
+- L3 `allowed_users` remains an independent security gate and is never bypassed
+  by an L2 scope match.
+
+Presence of any new Teams scope field or corresponding environment variable
+opts into typed policy. If none is present, Core preserves the existing generic
+Gateway L2 behavior: `GATEWAY_ALLOWED_CHANNELS` and `[gateway].allowed_channels`
+continue matching `ChannelInfo.id` (the conversation ID). This legacy fallback
+is explicit and observable; it prevents a rolling upgrade from silently
+opening or closing an existing deployment. New Gateway events without a new
+Core are ignored additively. New Core receiving an old event without `scope`
+uses the legacy gate.
+
+### Mention trust and trigger matrix
+
+The Gateway parses only `Activity.entities[]` entries whose type is `mention`
+and whose `mentioned.id` is non-empty. It publishes their IDs in `mentions` and
+their ID/text pairs in `mention_entities`. `Activity.recipient.id` is published
+separately.
+
+New↔new trigger behavior is:
+
+| Scope | Trigger |
+| --- | --- |
+| Personal | Every otherwise trusted user message; mention not required |
+| Group chat | A structured mention entity has `mentioned.id == recipient.id` |
+| Team channel root/reply | A structured mention entity has `mentioned.id == recipient.id` |
+| Unknown/malformed scope | Drop before commands, sessions, reactions, or ACP |
+
+Pure text such as `@OpenAB` or `<at>OpenAB</at>` without a matching entity never
+satisfies group/channel mention gating. Thread presence does not bypass Teams
+mention gating; ambient/RSC reading remains a separate feature.
+
+After structural mention and L2/L3 trust gates allow the event, Core removes
+only entity text associated with the recipient bot ID. It maps entity order to
+text occurrences, removes matched recipient ranges in reverse order, and trims
+only the resulting edges. Other user/bot mentions and arbitrary whitespace are
+preserved. A malformed recipient entity may trigger by ID but is not removed
+unless its exact non-empty text occurs. Mention-only text is ignored when no
+attachment blocks remain.
+
+Core sets `SenderContext.receiver_id` from `recipient.id`; sender identity,
+conversation routing, event correlation, and message ID semantics remain
+unchanged.
+
+## Security and reliability boundaries
+
+- Scope and mention evidence is created only after existing Bot Framework JWT,
+  tenant, and service URL validation.
+- Mention markup is not authority; structured entity IDs are.
+- Scope allowlists do not replace L3 user trust.
+- This decision adds no Graph, RSC, delegated token, manifest permission, ambient
+  reading, attachment download, or persistent conversation state.
+- Service URLs and credentials remain Gateway-local.
+- Standalone and Unified paths use the same Core scope, mention, and prompt
+  normalization helpers.
+
+## Acceptance criteria
+
+Automated tests must cover:
+
+- additive new/old wire decoding;
+- Personal, groupChat, and channel scope derivation;
+- missing Team/channel fields and unknown conversation types;
+- typed Team-or-channel allowlist semantics and legacy conversation fallback;
+- correct `is_dm` and L3 identity ordering;
+- genuine recipient mention, pure-text spoof, reply mention, multi-mention,
+  duplicate mention, and malformed entity cases;
+- removal of only the recipient mention while preserving other text;
+- slash-command recognition after recipient mention removal;
+- Standalone and Unified use of the same helpers;
+- config, environment fallback, Helm, and platform-schema conformance.
+
+## Consequences
+
+### Positive
+
+- Core receives an explicit, authenticated Teams scope instead of guessing from
+  a route ID.
+- Structured mention gating prevents textual mention spoofing.
+- Personal behavior remains mention-free and existing generic L2 restrictions
+  retain a non-lockstep fallback.
+- Agent context can identify the receiving bot in multi-agent deployments.
+
+### Negative
+
+- Typed Teams L2 policy requires additional Core configuration and tests.
+- Old Core cannot enforce new group/channel mention semantics until upgraded.
+- Mention text lacks explicit character offsets, so cleanup relies on entity
+  order plus exact text matching and deliberately leaves unmatched markup.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -129,6 +129,7 @@ Custom Gateway adapter for platforms like Telegram, LINE, Feishu/Lark, and Googl
 | `trusted_bot_ids` | string[] | `[]` | Bot IDs that bypass the bot filter even when `allow_bot_messages = false`. |
 | `streaming` | bool | `false` | Enable streaming (typewriter) mode — requires the gateway platform to support message editing. |
 | `streaming_placeholder` | bool | `true` | Show "…" placeholder at streaming start. Set `false` for platforms using drafts (e.g. Telegram Rich Messages). |
+| `gateway_ack_timeout_secs` | u64 | `12` | Maximum wait for an operation ACK explicitly advertised by a negotiated gateway. Missing ACKs from legacy peers remain fire-and-forget. Must be greater than 0, less than `pool.prompt_hard_timeout_secs`, and greater than 10 when `platform = "teams"`. |
 | `message_processing_mode` | string | `"per-message"` | Same as Discord. See [Message Dispatch Modes](message-dispatch-modes.md). |
 | `max_buffered_messages` | u32 | `10` | Same as Discord. |
 | `max_batch_tokens` | u32 | `24000` | Same as Discord. |

--- a/docs/platforms/schema/lineworks.toml
+++ b/docs/platforms/schema/lineworks.toml
@@ -132,8 +132,8 @@ pr      = ""
 [[openab_features]]
 feature = "streaming"
 status  = "n_a"
-note    = "No edit API to drive post+edit streaming. The platform is listed in NON_EDITABLE_PLATFORMS so the core forces streaming off and the cosmetic edit/delete commands are dropped by the dispatcher."
-source  = ["crates/openab-core/src/gateway.rs#NON_EDITABLE_PLATFORMS", "crates/openab-gateway/src/adapters/lineworks.rs#dispatch_lineworks_reply"]
+note    = "No edit API to drive post+edit streaming. Negotiated and legacy platform capabilities both advertise streaming/edit as disabled; cosmetic edit/delete commands are dropped by the dispatcher."
+source  = ["crates/openab-gateway/src/lib.rs#gateway_capabilities", "crates/openab-core/src/gateway.rs#legacy_gateway_capabilities", "crates/openab-gateway/src/adapters/lineworks.rs#dispatch_lineworks_reply"]
 pr      = ""
 
 [[openab_features]]

--- a/docs/platforms/schema/teams.toml
+++ b/docs/platforms/schema/teams.toml
@@ -139,7 +139,7 @@ pr = ""
 [[openab_features]]
 feature = "streaming"
 status = "workaround"
-note = "Gateway platforms use core's post+edit cosmetic streaming (`use_streaming` just returns the configured `streaming` flag; no native streaming API). But the Teams gateway never dispatches `edit_message`, so streaming edits don't actually reach Teams — effectively send-once. `update_activity` (PUT) exists in the adapter but is unwired dead code."
+note = "Gateway platforms use core's post+edit cosmetic streaming (`use_streaming` just returns the configured `streaming` flag; no native streaming API). The Teams gateway fail-closed rejects `edit_message`, so streaming edits don't reach Teams and cannot create duplicate messages; delivery is effectively send-once. `update_activity` (PUT) exists in the adapter but is unwired dead code."
 source = [
   "crates/openab-core/src/gateway.rs#use_streaming",
   "crates/openab-gateway/src/adapters/teams.rs#update_activity",
@@ -159,7 +159,7 @@ pr = ""
 [[openab_features]]
 feature = "edit_message"
 status = "not_implemented"
-note = "Core default/`GatewayAdapter::edit_message` emits an `edit_message` command, but Teams is not in `EDIT_RESPONSE_PLATFORMS` (fire-and-forget) AND `handle_reply` has no `edit_message` branch — it falls through to `send_activity`, posting the new text as a fresh message."
+note = "Core default/`GatewayAdapter::edit_message` emits an `edit_message` command, but Teams is not in `EDIT_RESPONSE_PLATFORMS` (fire-and-forget) and `handle_reply` fail-closed rejects the unsupported command. No edit occurs, but it also cannot fall through to `send_activity` and post duplicate text."
 source = [
   "crates/openab-core/src/gateway.rs#edit_message",
   "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
@@ -169,7 +169,7 @@ pr = ""
 [[openab_features]]
 feature = "delete_message"
 status = "not_implemented"
-note = "The `delete_message` command is not handled in `handle_reply`; it falls through to `send_activity`. Platform supports DELETE, but the adapter never calls it."
+note = "The `delete_message` command is fail-closed rejected by `handle_reply`. Platform supports DELETE, but the adapter does not call it yet; importantly, the command cannot fall through to `send_activity`."
 source = [
   "crates/openab-core/src/gateway.rs#delete_message",
   "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
@@ -186,7 +186,7 @@ pr = ""
 [[openab_features]]
 feature = "threads_topics"
 status = "not_implemented"
-note = "The `create_topic` command from `GatewayAdapter::create_thread` is not handled by Teams `handle_reply` (falls through to plain send). Inbound events set `thread_id: None` ('Teams conversations don't have sub-threads in the same way'). Core `create_thread` falls back to the same channel on timeout anyway."
+note = "The `create_topic` command from `GatewayAdapter::create_thread` is fail-closed rejected by Teams `handle_reply` and cannot fall through to plain send. Inbound events set `thread_id: None` ('Teams conversations don't have sub-threads in the same way'). Core `create_thread` falls back to the same channel on timeout anyway."
 source = [
   "crates/openab-core/src/gateway.rs#create_thread",
   "crates/openab-gateway/src/adapters/teams.rs#handle_reply",

--- a/docs/platforms/schema/teams.toml
+++ b/docs/platforms/schema/teams.toml
@@ -6,339 +6,372 @@
 schema_version = "2026-07-08"
 
 [platform]
-name          = "teams"
+name = "teams"
 official_docs = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
-description   = "Microsoft Teams bot reached via the Bot Framework / Azure Bot Connector REST activity protocol (not a direct Teams API)."
+description = "Microsoft Teams bot reached via the Bot Framework / Azure Bot Connector REST activity protocol (not a direct Teams API)."
 
 
 # ═══ Schema 1 — platform-capability (source of truth: official docs) ═════════
 
 [capability.transport]
-kind   = "webhook"
-note   = "Bot Framework POSTs an `Activity` JSON to the bot's `/api/messages` messaging endpoint (one endpoint only)."
+kind = "webhook"
+note = "Bot Framework POSTs an `Activity` JSON to the bot's `/api/messages` messaging endpoint (one endpoint only)."
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [capability.inbound_auth]
 scheme = "jwt_rs256"
-note   = "JWT bearer, RS256/RS384, signed by Bot Framework. L1 = OpenID Connect: fetch JWKS from `login.botframework.com` well-known config; validate `aud`=app_id, `iss`=`https://api.botframework.com`, `exp`, the `serviceurl` claim vs `activity.serviceUrl`, and channel endorsements."
+note = "JWT bearer, RS256/RS384, signed by Bot Framework. L1 = OpenID Connect: fetch JWKS from `login.botframework.com` well-known config; validate `aud`=app_id, `iss`=`https://api.botframework.com`, `exp`, the `serviceurl` claim vs `activity.serviceUrl`, and channel endorsements."
 source = "https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0"
 
 [capability.threads]
-model  = "native"
-note   = "Mixed: channel posts form native reply chains — `conversation.id` encodes the root message ID and replies land in that chain. 1:1 and group chats are flat (no sub-threads). `replyToId` is used for context/reply-target, not routing."
+model = "native"
+note = "Mixed: channel posts form native reply chains — `conversation.id` encodes the root message ID and replies land in that chain. 1:1 and group chats are flat (no sub-threads). `replyToId` is used for context/reply-target, not routing."
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations"
 
 [capability.slash_commands]
 supported = false
-note      = "No native `/`-command protocol for bots. A static command menu can be declared in the app manifest; selections arrive as ordinary `message` activities (plain text). Bots must parse commands from message text."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-commands-menu"
+note = "No native `/`-command protocol for bots. A static command menu can be declared in the app manifest; selections arrive as ordinary `message` activities (plain text). Bots must parse commands from message text."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-commands-menu"
 
 [capability.mentions]
 method = "at_mention"
-note   = "`@mention` via `entities[]` of type `mention`; each mention entity carries `mentioned.id` + `mentioned.name`. In channel/group scope the bot only receives messages where it is @mentioned (unless RSC grants broader access). Bot detects itself by matching a mention's `mentioned.id` to `recipient.id`. Don't trust the text markup (`<at>…</at>`) — use `entities`."
+note = "`@mention` via `entities[]` of type `mention`; each mention entity carries `mentioned.id` + `mentioned.name`. In channel/group scope the bot only receives messages where it is @mentioned (unless RSC grants broader access). Bot detects itself by matching a mention's `mentioned.id` to `recipient.id`. Don't trust the text markup (`<at>…</at>`) — use `entities`."
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations"
 
 [capability.emoji_reactions]
-bot_can_add        = true
-bot_can_remove     = true
+bot_can_add = true
+bot_can_remove = true
 bot_receives_events = true
-note               = "Bot receives reaction events via `messageReaction` activities (`reactionsAdded`/`reactionsRemoved`). Bot add/remove own reactions supported via SDK reaction APIs / connector."
-source             = "https://learn.microsoft.com/en-us/microsoftteams/platform/teams-sdk/in-depth-guides/message-reactions"
+note = "Bot receives reaction events via `messageReaction` activities (`reactionsAdded`/`reactionsRemoved`). Bot add/remove own reactions supported via SDK reaction APIs / connector."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/teams-sdk/in-depth-guides/message-reactions"
 
 [capability.edit_message]
 supported = true
-note      = "Bot can update its own already-sent message: `PUT /v3/conversations/{conversationId}/activities/{activityId}`. Requires caching the activityId returned by the original post."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages"
+note = "Bot can update its own already-sent message: `PUT /v3/conversations/{conversationId}/activities/{activityId}`. Requires caching the activityId returned by the original post."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages"
 
 [capability.delete_message]
 supported = true
-scope     = "own"
-note      = "Own messages only: `DELETE /v3/conversations/{conversationId}/activities/{activityId}`. A bot cannot update or delete messages sent by users."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages"
+scope = "own"
+note = "Own messages only: `DELETE /v3/conversations/{conversationId}/activities/{activityId}`. A bot cannot update or delete messages sent by users."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages"
 
 [capability.rich_content]
 markdown = true
-cards    = true
-buttons  = true
-note     = "Markdown (`textFormat: markdown`), a subset of XML/HTML tags, and Adaptive Cards (buttons, inputs, images). Text-only messages don't support table formatting; rich cards support formatting in the `text` property only and don't support Markdown or tables. `suggestedActions` (`imBack` only, ≤6) work only in 1:1 chats and not alongside attachments."
-source   = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages"
+cards = true
+buttons = true
+note = "Markdown (`textFormat: markdown`), a subset of XML/HTML tags, and Adaptive Cards (buttons, inputs, images). Text-only messages don't support table formatting; rich cards support formatting in the `text` property only and don't support Markdown or tables. `suggestedActions` (`imBack` only, ≤6) work only in 1:1 chats and not alongside attachments."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages"
 
 [capability.attachments]
-inbound     = ["image", "file"]
-outbound    = ["image", "file"]
+inbound = ["image", "file"]
+outbound = ["image", "file"]
 max_size_mb = 1
-note        = "Inbound: user can attach pictures/files. Outbound pictures ≤ 1024×1024 px and ≤ 1 MB, PNG/JPEG/GIF (animated GIF not supported); Markdown inline image renders at 256×256 by default (override via XML width/height). Non-image files are shared via attachment/card links (Graph/SharePoint), not raw upload in the activity. The 1 MB cap is the outbound-picture limit."
-source      = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
+note = "Inbound: user can attach pictures/files. Outbound pictures ≤ 1024×1024 px and ≤ 1 MB, PNG/JPEG/GIF (animated GIF not supported); Markdown inline image renders at 256×256 by default (override via XML width/height). Non-image files are shared via attachment/card links (Graph/SharePoint), not raw upload in the activity. The 1 MB cap is the outbound-picture limit."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [capability.message_length_limit]
 max_chars = 0
-note      = "No fixed character count — a byte/UTF-16 budget, not a char cap. ~100 KB per bot message (approximate; UTF-16, includes text + image links + @mentions + reactions; excludes base64-encoded images). Recommend keeping the message ≤ 80 KB to guarantee delivery. Over-limit → `413 RequestEntityTooLarge` with error code `MessageSizeTooBig`."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages"
+note = "No fixed character count — a byte/UTF-16 budget, not a char cap. ~100 KB per bot message (approximate; UTF-16, includes text + image links + @mentions + reactions; excludes base64-encoded images). Recommend keeping the message ≤ 80 KB to guarantee delivery. Over-limit → `413 RequestEntityTooLarge` with error code `MessageSizeTooBig`."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages"
 
 [capability.dm_support]
 supported = true
-note      = "1:1 personal chat (`conversationType: personal`)."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
+note = "1:1 personal chat (`conversationType: personal`)."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [capability.group_model]
-kinds  = ["personal", "groupChat", "channel"]
-note   = "Taxonomy: `personal` (1:1), `groupChat` (group chat), `channel` (team channel, has reply chains + `channelData.team`/`channel`). Bot install scopes: `personal`, `groupChat`/`groupchat`, `team`."
+kinds = ["personal", "groupChat", "channel"]
+note = "Taxonomy: `personal` (1:1), `groupChat` (group chat), `channel` (team channel, has reply chains + `channelData.team`/`channel`). Bot install scopes: `personal`, `groupChat`/`groupchat`, `team`."
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations"
 
 [capability.group_sender_identity]
 stable_id = "yes"
-note      = "`activity.from.id` (`29:1...`) is a stable, always-present per-user id in group/channel events. `from.aadObjectId` (Entra object id) is also provided but may be absent for guests/anonymous; not consent-gated for basic id."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations"
+note = "`activity.from.id` (`29:1...`) is a stable, always-present per-user id in group/channel events. `from.aadObjectId` (Entra object id) is also provided but may be absent for guests/anonymous; not consent-gated for basic id."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations"
 
 [capability.send_model]
-model               = "hybrid"
+model = "hybrid"
 reply_token_ttl_sec = 0
 max_objects_per_send = 0
-note                = "Reply + proactive. Reply: POST activity to `v3/conversations/{id}/activities` using the per-conversation `serviceUrl`. `serviceUrl` can change and should be refreshed per inbound activity (no fixed reply-window token; OAuth token TTL ~ `expires_in`)."
-source              = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
+note = "Reply + proactive. Reply: POST activity to `v3/conversations/{id}/activities` using the per-conversation `serviceUrl`. `serviceUrl` can change and should be refreshed per inbound activity (no fixed reply-window token; OAuth token TTL ~ `expires_in`)."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [capability.proactive_push]
-supported   = true
+supported = true
 quota_model = "metered"
-note        = "Allowed if the app is installed for the target scope (else `403 ForbiddenOperationException`/`BotNotInConversationRoster`). Per-bot-per-thread send-to-conversation: 7/1s, 8/2s, 60/30s, 1800/3600s; per-app-per-tenant global 50 RPS. Over-limit → `429 Too Many Requests` (also retry `412`/`502`/`504`); use exponential backoff."
-source      = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/rate-limit"
+note = "Allowed if the app is installed for the target scope (else `403 ForbiddenOperationException`/`BotNotInConversationRoster`). Per-bot-per-thread send-to-conversation: 7/1s, 8/2s, 60/30s, 1800/3600s; per-app-per-tenant global 50 RPS. Over-limit → `429 Too Many Requests` (also retry `412`/`502`/`504`); use exponential backoff."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/rate-limit"
 
 [capability.bot_to_bot]
 delivered = false
-note      = "Teams does not deliver other bots' messages to a bot; bots respond to user activities only (@mention-gated in groups/channels)."
-source    = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
+note = "Teams does not deliver other bots' messages to a bot; bots respond to user activities only (@mention-gated in groups/channels)."
+source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [capability.typing_indicator]
 supported = true
-note      = "Bot can send a `typing` activity via the connector. Not currently emitted by the OpenAB adapter."
-source    = "https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0"
+note = "Bot can send a `typing` activity via the connector. Not currently emitted by the OpenAB adapter."
+source = "https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-api-reference?view=azure-bot-service-4.0"
 
 
 # ═══ Schema 2 — openab-feature-support (source of truth: our code + PR) ══════
 
 [[openab_features]]
 feature = "send_message"
-status  = "implemented"
-note    = "Core `GatewayAdapter::send_message` → `send_gateway_reply` → gateway `handle_reply` → `send_activity` POSTs a `message` activity with `textFormat: markdown`."
-source  = ["crates/openab-core/src/gateway.rs#send_message", "crates/openab-gateway/src/adapters/teams.rs#send_activity"]
-pr      = ""
+status = "implemented"
+note = "Core `GatewayAdapter::send_message` → `send_gateway_reply` → gateway `handle_reply` → `send_activity` POSTs a `message` activity with `textFormat: markdown`."
+source = [
+  "crates/openab-core/src/gateway.rs#send_message",
+  "crates/openab-gateway/src/adapters/teams.rs#send_activity",
+]
+pr = ""
 
 [[openab_features]]
 feature = "message_split"
-status  = "partial"
-note    = "Core splits via `split_delivery`; `GatewayAdapter::message_limit()` returns 4096 (hardcoded 'Telegram limit', not Teams' ~100 KB / UTF-16 budget) — chunking works but the bound is generic, not Teams-tuned."
-source  = ["crates/openab-core/src/adapter.rs#message_limit", "crates/openab-core/src/gateway.rs"]
-pr      = ""
+status = "partial"
+note = "Core splits via `split_delivery`; `GatewayAdapter::message_limit()` returns 4096 (hardcoded 'Telegram limit', not Teams' ~100 KB / UTF-16 budget) — chunking works but the bound is generic, not Teams-tuned."
+source = [
+  "crates/openab-core/src/adapter.rs#message_limit",
+  "crates/openab-core/src/gateway.rs",
+]
+pr = ""
 
 [[openab_features]]
 feature = "streaming"
-status  = "workaround"
-note    = "Gateway platforms use core's post+edit cosmetic streaming (`use_streaming` just returns the configured `streaming` flag; no native streaming API). But the Teams gateway never dispatches `edit_message`, so streaming edits don't actually reach Teams — effectively send-once. `update_activity` (PUT) exists in the adapter but is unwired dead code."
-source  = ["crates/openab-core/src/gateway.rs#use_streaming", "crates/openab-gateway/src/adapters/teams.rs#update_activity"]
-pr      = ""
+status = "workaround"
+note = "Gateway platforms use core's post+edit cosmetic streaming (`use_streaming` just returns the configured `streaming` flag; no native streaming API). But the Teams gateway never dispatches `edit_message`, so streaming edits don't actually reach Teams — effectively send-once. `update_activity` (PUT) exists in the adapter but is unwired dead code."
+source = [
+  "crates/openab-core/src/gateway.rs#use_streaming",
+  "crates/openab-gateway/src/adapters/teams.rs#update_activity",
+]
+pr = ""
 
 [[openab_features]]
 feature = "reply_quote"
-status  = "not_implemented"
-note    = "`GatewayAdapter::send_message_with_reply` puts the target id into `quote_message_id` (the visual-quote field via `send_gateway_reply`), not `reply_to`. The Teams adapter reads only `reply.reply_to` (the triggering-event/origin id) → `replyToId`, and ignores `quote_message_id` entirely — so the intended visual quote never reaches Teams. `replyToId` is a reply-target/context id, not a visual quote."
-source  = ["crates/openab-core/src/gateway.rs#send_message_with_reply", "crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
-pr      = ""
+status = "not_implemented"
+note = "`GatewayAdapter::send_message_with_reply` puts the target id into `quote_message_id` (the visual-quote field via `send_gateway_reply`), not `reply_to`. The Teams adapter reads only `reply.reply_to` (the triggering-event/origin id) → `replyToId`, and ignores `quote_message_id` entirely — so the intended visual quote never reaches Teams. `replyToId` is a reply-target/context id, not a visual quote."
+source = [
+  "crates/openab-core/src/gateway.rs#send_message_with_reply",
+  "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
+]
+pr = ""
 
 [[openab_features]]
 feature = "edit_message"
-status  = "not_implemented"
-note    = "Core default/`GatewayAdapter::edit_message` emits an `edit_message` command, but Teams is not in `EDIT_RESPONSE_PLATFORMS` (fire-and-forget) AND `handle_reply` has no `edit_message` branch — it falls through to `send_activity`, posting the new text as a fresh message."
-source  = ["crates/openab-core/src/gateway.rs#edit_message", "crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
-pr      = ""
+status = "not_implemented"
+note = "Core default/`GatewayAdapter::edit_message` emits an `edit_message` command, but Teams is not in `EDIT_RESPONSE_PLATFORMS` (fire-and-forget) AND `handle_reply` has no `edit_message` branch — it falls through to `send_activity`, posting the new text as a fresh message."
+source = [
+  "crates/openab-core/src/gateway.rs#edit_message",
+  "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
+]
+pr = ""
 
 [[openab_features]]
 feature = "delete_message"
-status  = "not_implemented"
-note    = "The `delete_message` command is not handled in `handle_reply`; it falls through to `send_activity`. Platform supports DELETE, but the adapter never calls it."
-source  = ["crates/openab-core/src/gateway.rs#delete_message", "crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
-pr      = ""
+status = "not_implemented"
+note = "The `delete_message` command is not handled in `handle_reply`; it falls through to `send_activity`. Platform supports DELETE, but the adapter never calls it."
+source = [
+  "crates/openab-core/src/gateway.rs#delete_message",
+  "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
+]
+pr = ""
 
 [[openab_features]]
 feature = "emoji_reactions"
-status  = "not_implemented"
-note    = "`handle_reply` explicitly early-returns (silently ignores) `add_reaction`/`remove_reaction`. Platform supports bot reactions, but OpenAB does not send them for Teams."
-source  = ["crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
-pr      = ""
+status = "not_implemented"
+note = "`handle_reply` explicitly early-returns (silently ignores) `add_reaction`/`remove_reaction`. Platform supports bot reactions, but OpenAB does not send them for Teams."
+source = ["crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
+pr = ""
 
 [[openab_features]]
 feature = "threads_topics"
-status  = "not_implemented"
-note    = "The `create_topic` command from `GatewayAdapter::create_thread` is not handled by Teams `handle_reply` (falls through to plain send). Inbound events set `thread_id: None` ('Teams conversations don't have sub-threads in the same way'). Core `create_thread` falls back to the same channel on timeout anyway."
-source  = ["crates/openab-core/src/gateway.rs#create_thread", "crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
-pr      = ""
+status = "not_implemented"
+note = "The `create_topic` command from `GatewayAdapter::create_thread` is not handled by Teams `handle_reply` (falls through to plain send). Inbound events set `thread_id: None` ('Teams conversations don't have sub-threads in the same way'). Core `create_thread` falls back to the same channel on timeout anyway."
+source = [
+  "crates/openab-core/src/gateway.rs#create_thread",
+  "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
+]
+pr = ""
 
 [[openab_features]]
 feature = "media_inbound"
-status  = "not_implemented"
-note    = "Webhook only reads `activity.text`; attachments are neither parsed nor forwarded (`mentions` passed as empty `vec![]`; no attachment extraction). The `ChannelAccount`/`Activity` DTOs don't even model `attachments`."
-source  = ["crates/openab-gateway/src/adapters/teams.rs#Activity"]
-pr      = ""
+status = "not_implemented"
+note = "Webhook only reads `activity.text`; attachments are neither parsed nor forwarded (`mentions` passed as empty `vec![]`; no attachment extraction). The `ChannelAccount`/`Activity` DTOs don't even model `attachments`."
+source = ["crates/openab-gateway/src/adapters/teams.rs#Activity"]
+pr = ""
 
 [[openab_features]]
 feature = "voice_stt"
-status  = "n_a"
-note    = "No voice-note ingestion path in the adapter; not applicable."
-source  = ["crates/openab-gateway/src/adapters/teams.rs"]
-pr      = ""
+status = "n_a"
+note = "No voice-note ingestion path in the adapter; not applicable."
+source = ["crates/openab-gateway/src/adapters/teams.rs"]
+pr = ""
 
 [[openab_features]]
 feature = "trust_gate"
-status  = "implemented"
-note    = "Two layers: platform-level `check_tenant` (optional `allowed_tenants` allowlist) at ingress, plus core's shared `gate_incoming` (L2 scope + L3 identity) applied to all gateway events in `process_gateway_event`."
-source  = ["crates/openab-gateway/src/adapters/teams.rs#check_tenant", "crates/openab-core/src/adapter.rs#gate_incoming"]
-pr      = ""
+status = "implemented"
+note = "Two layers: platform-level `check_tenant` (optional `allowed_tenants` allowlist) at ingress, plus core's shared `gate_incoming` (L2 scope + L3 identity) applied to all gateway events in `process_gateway_event`."
+source = [
+  "crates/openab-gateway/src/adapters/teams.rs#check_tenant",
+  "crates/openab-core/src/adapter.rs#gate_incoming",
+]
+pr = ""
 
 [[openab_features]]
 feature = "deny_echo"
-status  = "implemented"
-note    = "On `DenyIdentity`, core echoes the sender their ID (throttled via `echo_allowed`). Delivered through the gateway send path, so subject to the same reply constraints as normal sends."
-source  = ["crates/openab-core/src/gateway.rs#echo_allowed"]
-pr      = ""
+status = "implemented"
+note = "On `DenyIdentity`, core echoes the sender their ID (throttled via `echo_allowed`). Delivered through the gateway send path, so subject to the same reply constraints as normal sends."
+source = ["crates/openab-core/src/gateway.rs#echo_allowed"]
+pr = ""
 
 [[openab_features]]
 feature = "mention_gating"
-status  = "partial"
-note    = "Core `should_skip_event` enforces @mention gating in groups when `bot_username` is set — but the Teams webhook forwards `mentions: vec![]` ('@mentions parsing deferred to future PR'), so gating can't match a Teams mention. It also only fires for `channel_type` `group`/`supergroup`; Teams sends `groupChat`/`channel`, which don't match. Teams itself only delivers @mentioned messages in channels, which mitigates this at the platform layer."
-source  = ["crates/openab-core/src/gateway.rs#should_skip_event", "crates/openab-gateway/src/adapters/teams.rs#handle_reply"]
-pr      = ""
+status = "partial"
+note = "Core `should_skip_event` enforces @mention gating in groups when `bot_username` is set — but the Teams webhook forwards `mentions: vec![]` ('@mentions parsing deferred to future PR'), so gating can't match a Teams mention. It also only fires for `channel_type` `group`/`supergroup`; Teams sends `groupChat`/`channel`, which don't match. Teams itself only delivers @mentioned messages in channels, which mitigates this at the platform layer."
+source = [
+  "crates/openab-core/src/gateway.rs#should_skip_event",
+  "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
+]
+pr = ""
 
 [[openab_features]]
 feature = "slash_commands"
-status  = "implemented"
-note    = "`/reset` and `/cancel` are parsed from message text by core's gateway loops (WS path + unified `process_gateway_event`); no native Teams slash protocol needed."
-source  = ["crates/openab-core/src/gateway.rs#process_gateway_event"]
-pr      = ""
+status = "implemented"
+note = "`/reset` and `/cancel` are parsed from message text by core's gateway loops (WS path + unified `process_gateway_event`); no native Teams slash protocol needed."
+source = ["crates/openab-core/src/gateway.rs#process_gateway_event"]
+pr = ""
 
 [[openab_features]]
 feature = "multibot"
-status  = "partial"
-note    = "Core supports multi-bot suppression of streaming (`use_streaming(other_bot_present)`); moot on Teams because streaming edits don't reach it and Teams doesn't deliver other bots' messages anyway."
-source  = ["crates/openab-core/src/gateway.rs#use_streaming", "crates/openab-core/src/adapter.rs#use_streaming"]
-pr      = ""
+status = "partial"
+note = "Core supports multi-bot suppression of streaming (`use_streaming(other_bot_present)`); moot on Teams because streaming edits don't reach it and Teams doesn't deliver other bots' messages anyway."
+source = [
+  "crates/openab-core/src/gateway.rs#use_streaming",
+  "crates/openab-core/src/adapter.rs#use_streaming",
+]
+pr = ""
 
 [[openab_features]]
 feature = "group_routing"
-status  = "implemented"
-note    = "Session keyed by `conversation.id` (+ `conversation_type`); `serviceUrl` cached per conversation for reply routing, refreshed (timestamp) on each reply, with a periodic TTL cleanup task in the gateway."
-source  = ["crates/openab-gateway/src/adapters/teams.rs#handle_reply", "crates/openab-gateway/src/lib.rs"]
-pr      = ""
+status = "implemented"
+note = "Session keyed by `conversation.id` (+ `conversation_type`); `serviceUrl` cached per conversation for reply routing, refreshed (timestamp) on each reply, with a periodic TTL cleanup task in the gateway."
+source = [
+  "crates/openab-gateway/src/adapters/teams.rs#handle_reply",
+  "crates/openab-gateway/src/lib.rs",
+]
+pr = ""
 
 [[openab_features]]
 feature = "cron_dispatch"
-status  = "not_implemented"
-note    = "Not wired for scheduled cron dispatch: `VALID_PLATFORMS` (cron.rs) covers only discord/slack/telegram and no adapter is registered for this platform in `cron_adapters`, so `cronjob.toml` jobs targeting it are rejected at startup by `validate_cronjobs`."
-source  = []
-pr      = ""
+status = "not_implemented"
+note = "Not wired for scheduled cron dispatch: `VALID_PLATFORMS` (cron.rs) covers only discord/slack/telegram and no adapter is registered for this platform in `cron_adapters`, so `cronjob.toml` jobs targeting it are rejected at startup by `validate_cronjobs`."
+source = []
+pr = ""
 
 
 # ═══ Schema 3 — platform-quirks (freeform, dated findings log) ═══════════════
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "serviceUrl is per-conversation and must be cached/refreshed"
-note   = "Teams replies are POSTed to a `serviceUrl` that arrives on each inbound activity and can change over time. The adapter caches `conversation.id → (serviceUrl, timestamp)` on ingress and refreshes the timestamp on every reply to avoid TTL expiry mid-conversation; a background task in the gateway evicts stale entries (4 h TTL). If an inbound activity lacks `serviceUrl`, the event is dropped (can't route replies)."
-kind   = "openab_decision"
+date = "2026-07-04"
+title = "serviceUrl is per-conversation and must be cached/refreshed"
+note = "Teams replies are POSTed to a `serviceUrl` that arrives on each inbound activity and can change over time. The adapter caches `conversation.id → (serviceUrl, timestamp)` on ingress and refreshes the timestamp on every reply to avoid TTL expiry mid-conversation; a background task in the gateway evicts stale entries (4 h TTL). If an inbound activity lacks `serviceUrl`, the event is dropped (can't route replies)."
+kind = "openab_decision"
 source = "crates/openab-gateway/src/adapters/teams.rs#handle_reply"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Sender identity: from.id vs aadObjectId"
-note   = "Verified: the adapter uses `activity.from.id` (the `29:1abc...` Bot Framework/Teams user id) as `SenderInfo.id`, not `from.aadObjectId`. `aadObjectId` (Entra object id) is deserialized but unused — it can be null for guests/anonymous users, whereas `from.id` is always present and stable, so it's the correct trust-gate key. Tenant is resolved with fallbacks: top-level `tenant.id` → `channelData.tenant.id` → `conversation.tenantId` because Teams places it differently for personal vs channel webhooks (tests pin this)."
-kind   = "openab_decision"
+date = "2026-07-04"
+title = "Sender identity: from.id vs aadObjectId"
+note = "Verified: the adapter uses `activity.from.id` (the `29:1abc...` Bot Framework/Teams user id) as `SenderInfo.id`, not `from.aadObjectId`. `aadObjectId` (Entra object id) is deserialized but unused — it can be null for guests/anonymous users, whereas `from.id` is always present and stable, so it's the correct trust-gate key. Tenant is resolved with fallbacks: top-level `tenant.id` → `channelData.tenant.id` → `conversation.tenantId` because Teams places it differently for personal vs channel webhooks (tests pin this)."
+kind = "openab_decision"
 source = "crates/openab-gateway/src/adapters/teams.rs#handle_reply"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "The reply/quote target is dropped"
-note   = "`GatewayAdapter::send_message_with_reply` carries the visual-quote target in `quote_message_id` (set from `reply_to_message_id`), but the Teams adapter only reads `reply.reply_to` (the origin/triggering-event id) and maps it to `replyToId`. It never reads `quote_message_id`, so a caller asking for a visual reply/quote gets a plain reply-target `replyToId` at best and no visual quote. This is a distinct gap from the write-side commands."
-kind   = "openab_decision"
+date = "2026-07-04"
+title = "The reply/quote target is dropped"
+note = "`GatewayAdapter::send_message_with_reply` carries the visual-quote target in `quote_message_id` (set from `reply_to_message_id`), but the Teams adapter only reads `reply.reply_to` (the origin/triggering-event id) and maps it to `replyToId`. It never reads `quote_message_id`, so a caller asking for a visual reply/quote gets a plain reply-target `replyToId` at best and no visual quote. This is a distinct gap from the write-side commands."
+kind = "openab_decision"
 source = "crates/openab-gateway/src/adapters/teams.rs#handle_reply"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Auth is heavier than most adapters (endorsements + serviceUrl claim)"
-note   = "JWT validation goes beyond signature/aud/iss/exp: it also enforces (B2) that the signing JWK endorses the activity's `channelId` and (B1) that the token's `serviceurl` claim equals the activity's `serviceUrl` — binding the token to the specific channel/service origin. JWKS keys are cached (1 h TTL) with a force-refresh-on-cache-miss path for Microsoft key rotation. The activity body is parsed before JWT auth (Bot Framework needs `serviceUrl`/`channelId` from the body to validate) — this is why the pre-auth body is capped at 256 KB."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Auth is heavier than most adapters (endorsements + serviceUrl claim)"
+note = "JWT validation goes beyond signature/aud/iss/exp: it also enforces (B2) that the signing JWK endorses the activity's `channelId` and (B1) that the token's `serviceurl` claim equals the activity's `serviceUrl` — binding the token to the specific channel/service origin. JWKS keys are cached (1 h TTL) with a force-refresh-on-cache-miss path for Microsoft key rotation. The activity body is parsed before JWT auth (Bot Framework needs `serviceUrl`/`channelId` from the body to validate) — this is why the pre-auth body is capped at 256 KB."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication?view=azure-bot-service-4.0"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Write-side commands are largely unimplemented"
-note   = "`edit_message`, `delete_message`, `create_topic`, and reactions are all issued by core but the Teams `handle_reply` only special-cases reactions (drop) — everything non-reaction is treated as a plain send. This means streaming (post+edit), thread creation, and message edit/delete are effectively no-ops or mis-sends on Teams today, despite the platform supporting all of them (and despite `update_activity` existing as dead code). This is the main gap for a future PR."
-kind   = "openab_decision"
+date = "2026-07-04"
+title = "Write-side commands are largely unimplemented"
+note = "`edit_message`, `delete_message`, `create_topic`, and reactions are all issued by core but the Teams `handle_reply` only special-cases reactions (drop) — everything non-reaction is treated as a plain send. This means streaming (post+edit), thread creation, and message edit/delete are effectively no-ops or mis-sends on Teams today, despite the platform supporting all of them (and despite `update_activity` existing as dead code). This is the main gap for a future PR."
+kind = "openab_decision"
 source = "crates/openab-gateway/src/adapters/teams.rs#handle_reply"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Bot message budget is ~100 KB UTF-16"
-note   = "Bot message budget is ~100 KB UTF-16 (text + image links + mentions + reactions, excl. base64 images); recommend ≤80 KB, over-limit returns `413 RequestEntityTooLarge` / `MessageSizeTooBig`."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Bot message budget is ~100 KB UTF-16"
+note = "Bot message budget is ~100 KB UTF-16 (text + image links + mentions + reactions, excl. base64 images); recommend ≤80 KB, over-limit returns `413 RequestEntityTooLarge` / `MessageSizeTooBig`."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/format-your-bot-messages"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Send rate limits"
-note   = "Per-bot-per-thread send limits 7/1s, 8/2s, 60/30s, 1800/3600s; global 50 RPS per app per tenant; throttle → `429` (retry `412`/`502`/`504` too), use exponential backoff."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Send rate limits"
+note = "Per-bot-per-thread send limits 7/1s, 8/2s, 60/30s, 1800/3600s; global 50 RPS per app per tenant; throttle → `429` (retry `412`/`502`/`504` too), use exponential backoff."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/rate-limit"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "suggestedActions constraints"
-note   = "`suggestedActions` support `imBack` only, ≤6 buttons, one-on-one chats only, and not alongside attachments (any conversation type)."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "suggestedActions constraints"
+note = "`suggestedActions` support `imBack` only, ≤6 buttons, one-on-one chats only, and not alongside attachments (any conversation type)."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Outbound picture limits"
-note   = "Outbound pictures ≤1024×1024 px, ≤1 MB, PNG/JPEG/GIF; animated GIF unsupported; Markdown inline image defaults to 256×256."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Outbound picture limits"
+note = "Outbound pictures ≤1024×1024 px, ≤1 MB, PNG/JPEG/GIF; animated GIF unsupported; Markdown inline image defaults to 256×256."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/build-conversational-capability"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Reactions supported by platform, unused by OpenAB"
-note   = "Bots can add/remove reactions and receive `messageReaction` (`reactionsAdded`/`reactionsRemoved`) events; OpenAB uses neither for Teams."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Reactions supported by platform, unused by OpenAB"
+note = "Bots can add/remove reactions and receive `messageReaction` (`reactionsAdded`/`reactionsRemoved`) events; OpenAB uses neither for Teams."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/teams-sdk/in-depth-guides/message-reactions"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Bot can edit/delete only its own messages"
-note   = "Bot can edit (`PUT .../activities/{activityId}`) and delete (`DELETE .../activities/{activityId}`) its own messages but never user messages."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Bot can edit/delete only its own messages"
+note = "Bot can edit (`PUT .../activities/{activityId}`) and delete (`DELETE .../activities/{activityId}`) its own messages but never user messages."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/update-and-delete-bot-messages"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "No native bot slash-command protocol"
-note   = "No native bot slash-command protocol; command menus arrive as plain `message` activities and must be text-parsed."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "No native bot slash-command protocol"
+note = "No native bot slash-command protocol; command menus arrive as plain `message` activities and must be text-parsed."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/create-a-bot-commands-menu"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Bot only receives @mentioned messages in channels/group chats"
-note   = "In channels/group chats a bot only receives messages where it is @mentioned (unless RSC); mentions live in `entities[]` (`type: mention`, `mentioned.id`/`.name`), not the text markup."
-kind   = "intrinsic"
+date = "2026-07-04"
+title = "Bot only receives @mentioned messages in channels/group chats"
+note = "In channels/group chats a bot only receives messages where it is @mentioned (unless RSC); mentions live in `entities[]` (`type: mention`, `mentioned.id`/`.name`), not the text markup."
+kind = "intrinsic"
 source = "https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "Verified sender id = activity.from.id"
-note   = "Verified sender id = `activity.from.id` (`29:...`), not `aadObjectId`; adapter forwards `from.id` as trust-gate key."
-kind   = "openab_decision"
+date = "2026-07-04"
+title = "Verified sender id = activity.from.id"
+note = "Verified sender id = `activity.from.id` (`29:...`), not `aadObjectId`; adapter forwards `from.id` as trust-gate key."
+kind = "openab_decision"
 source = "crates/openab-gateway/src/adapters/teams.rs"
 
 [[quirks]]
-date   = "2026-07-04"
-title  = "handle_reply only plain sends + drops reactions"
-note   = "Teams `handle_reply` only handles plain sends + drops reactions; `edit_message`/`delete_message`/`create_topic` are undispatched (fall through to `send_activity`), `quote_message_id` is ignored, and inbound attachments/mentions are not parsed — main gaps for a follow-up PR."
-kind   = "openab_decision"
+date = "2026-07-04"
+title = "handle_reply only plain sends + drops reactions"
+note = "Teams `handle_reply` only handles plain sends + drops reactions; `edit_message`/`delete_message`/`create_topic` are undispatched (fall through to `send_activity`), `quote_message_id` is ignored, and inbound attachments/mentions are not parsed — main gaps for a follow-up PR."
+kind = "openab_decision"
 source = "crates/openab-gateway/src/adapters/teams.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1105,6 +1105,7 @@ async fn main() -> anyhow::Result<()> {
             streaming: gw_cfg.streaming,
             streaming_placeholder: gw_cfg.streaming_placeholder,
             telegram_rich_messages: gw_cfg.telegram_rich_messages,
+            gateway_ack_timeout_secs: gw_cfg.gateway_ack_timeout_secs,
             stt: cfg.stt.clone(),
         };
         let gw_router = router.clone();

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -3,7 +3,10 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use openab_core::adapter::{ChannelRef, ChatAdapter, MessageRef};
+use openab_core::adapter::{
+    AdapterCapabilities, ChannelRef, ChatAdapter, MessageLimit, MessageRef, StatusBackend,
+    StreamingMode,
+};
 use openab_gateway::schema::{Content, GatewayReply, ReplyChannel};
 use openab_gateway::AppState;
 use std::collections::HashMap;
@@ -152,7 +155,68 @@ impl ChatAdapter for UnifiedGatewayAdapter {
     }
 
     fn message_limit(&self) -> usize {
-        4096 // conservative limit across platforms
+        4096 // conservative legacy limit across platforms
+    }
+
+    fn capabilities(&self, platform: &str) -> AdapterCapabilities {
+        let telegram_streaming = self
+            .gw_state
+            .telegram_streaming
+            .unwrap_or(self.gw_state.telegram_rich_messages);
+        let (can_edit, can_delete, streaming_mode, status_backend) = match platform {
+            "telegram" => (
+                self.gw_state.telegram_rich_messages,
+                false,
+                if telegram_streaming && self.gw_state.telegram_rich_messages {
+                    StreamingMode::Edit
+                } else {
+                    StreamingMode::Disabled
+                },
+                StatusBackend::Reactions,
+            ),
+            // Unified mode currently has no per-platform streaming switch for
+            // these adapters. Keep them send-once rather than inheriting the
+            // unrelated Telegram setting.
+            "feishu" => (
+                true,
+                true,
+                StreamingMode::Disabled,
+                StatusBackend::Reactions,
+            ),
+            "googlechat" => (
+                true,
+                false,
+                StreamingMode::Disabled,
+                StatusBackend::Reactions,
+            ),
+            "wecom" => (false, false, StreamingMode::Disabled, StatusBackend::None),
+            "teams" | "line" | "lineworks" | "acp" => {
+                (false, false, StreamingMode::Disabled, StatusBackend::None)
+            }
+            _ => (
+                false,
+                false,
+                StreamingMode::Disabled,
+                StatusBackend::Reactions,
+            ),
+        };
+        AdapterCapabilities {
+            send_ack: false,
+            edit_ack: false,
+            delete_ack: false,
+            can_edit,
+            can_delete,
+            streaming_mode,
+            show_streaming_placeholder: !(platform == "telegram"
+                && self.gw_state.telegram_rich_messages),
+            message_limit: match platform {
+                "acp" => MessageLimit::Unlimited,
+                "lineworks" => MessageLimit::Characters { max: 2000 },
+                "wecom" => MessageLimit::Characters { max: 2048 },
+                _ => MessageLimit::Characters { max: 4096 },
+            },
+            status_backend,
+        }
     }
 
     async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
@@ -245,5 +309,48 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         // table→code-block pre-pass so tables display with proper formatting.
         // Only applies to Telegram; other platforms in unified mode keep wrapping.
         platform == "telegram" && self.gw_state.telegram_rich_messages
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn adapter_with_telegram_streaming(streaming: bool) -> UnifiedGatewayAdapter {
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(4);
+        let mut state = AppState::test_default(event_tx);
+        state.telegram_streaming = Some(streaming);
+        state.telegram_rich_messages = streaming;
+        UnifiedGatewayAdapter::new(Arc::new(state))
+    }
+
+    #[test]
+    fn teams_capabilities_do_not_inherit_telegram_streaming() {
+        let adapter = adapter_with_telegram_streaming(true);
+        let capabilities = adapter.capabilities("teams");
+        assert_eq!(capabilities.streaming_mode, StreamingMode::Disabled);
+        assert!(!capabilities.can_edit);
+        assert_eq!(capabilities.status_backend, StatusBackend::None);
+    }
+
+    #[test]
+    fn telegram_capabilities_follow_telegram_streaming() {
+        let adapter = adapter_with_telegram_streaming(true);
+        let capabilities = adapter.capabilities("telegram");
+        assert_eq!(capabilities.streaming_mode, StreamingMode::Edit);
+        assert!(!capabilities.show_streaming_placeholder);
+    }
+
+    #[test]
+    fn telegram_without_rich_drafts_is_send_once() {
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel(4);
+        let mut state = AppState::test_default(event_tx);
+        state.telegram_streaming = Some(true);
+        state.telegram_rich_messages = false;
+        let adapter = UnifiedGatewayAdapter::new(Arc::new(state));
+
+        let capabilities = adapter.capabilities("telegram");
+        assert_eq!(capabilities.streaming_mode, StreamingMode::Disabled);
+        assert!(!capabilities.can_edit);
     }
 }

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -100,12 +100,19 @@ impl UnifiedGatewayAdapter {
             #[cfg(feature = "teams")]
             "teams" => {
                 if let Some(ref teams) = self.gw_state.teams {
-                    openab_gateway::adapters::teams::handle_reply(
+                    if let Err(e) = openab_gateway::adapters::teams::handle_reply(
                         reply,
                         teams,
                         &self.gw_state.teams_service_urls,
                     )
-                    .await;
+                    .await
+                    {
+                        tracing::error!(
+                            error = %e,
+                            command = ?reply.command.as_deref(),
+                            "teams reply rejected"
+                        );
+                    }
                 }
             }
             #[cfg(feature = "acp")]


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked draft:** logical base `stack/teams-00-capabilities` is PR #1490. GitHub requires an upstream PR base to exist in `openabdev/openab`, so this draft temporarily targets `main` and may show preceding stack layers. Do not merge it until #1490 is merged and this branch is rebased onto current `main`; then review only its single incremental commit.

## What problem does this solve?

Prevent unsupported Teams control commands from being rendered as user-visible messages.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365158868619404/1531339032527765655  
Microsoft Teams roadmap discussion.

## Review Contract

### Goal

Prevent unsupported Teams control commands from being rendered as user-visible messages.

### Non-goals

No Connector HTTP policy, route persistence, reaction implementation, or command UX is added.

### Accepted Residual Risks

Legacy reaction command forms remain no-ops until the opt-in reaction slice lands; this preserves compatibility without claiming delivery.

### Acceptance Criteria

Unknown or unsupported commands return an error before any platform send, while ordinary content replies and the documented compatibility forms retain their prior behavior.

### Follow-ups

Add negotiated reaction support and richer commands only in their dedicated PRs.

## At a Glance

```
Gateway command → supported? → dispatch
                         └─ no → reject before content send
```

## Prior Art & Industry Research

Not applicable — this is a narrow bug fix that prevents an unsupported control command from falling through to ordinary content delivery.

## Proposed Solution

- Reject unsupported Teams Gateway commands instead of falling through to a content send.
- Keep explicitly recognized no-op compatibility commands bounded.
- Add regression coverage for command dispatch outcomes.

## Why this approach?

Failing before content dispatch is the smallest compatible fix and prevents control data from becoming a visible message.

## Alternatives Considered

Continue treating unknown commands as sends (rejected: user-visible control leakage) or silently ignore every command (rejected: hides incompatibility).

## Validation

`cargo check -p openab-gateway --features teams`
