### PR TITLE
test: use example values instead of real ARNs in parsing tests

### DIFF
--- a/operator/src/ingress.rs
+++ b/operator/src/ingress.rs
@@ -1176,7 +1176,7 @@ mod tests {
     fn cloud_map_service_id_parses_from_arn() {
         assert_eq!(
             cloud_map_service_id_from_arn(
-                "arn:aws:servicediscovery:us-east-1:903779448426:service/srv-abc123"
+                "arn:aws:servicediscovery:us-east-1:123456789012:service/srv-abc123"
             ),
             Some("srv-abc123".to_string())
         );

--- a/operator/src/secrets.rs
+++ b/operator/src/secrets.rs
@@ -165,20 +165,20 @@ mod tests {
         // (which used to hand this straight to GetSecretValue and fail,
         // since that API has no knowledge of the trailing ECS suffix).
         let (base, key) = split_ecs_json_key_suffix(
-            "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP:TELEGRAM_BOT_TOKEN::",
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:example/telegram/bot-AbCdEf:TELEGRAM_BOT_TOKEN::",
         )
         .unwrap();
-        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP");
+        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:123456789012:secret:example/telegram/bot-AbCdEf");
         assert_eq!(key, Some("TELEGRAM_BOT_TOKEN"));
     }
 
     #[test]
     fn split_ecs_json_key_suffix_unchanged_for_plain_arn() {
         let (base, key) = split_ecs_json_key_suffix(
-            "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP",
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:example/telegram/bot-AbCdEf",
         )
         .unwrap();
-        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:oab/telegram/pahudxbot-AC80TP");
+        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:123456789012:secret:example/telegram/bot-AbCdEf");
         assert_eq!(key, None);
     }
 
@@ -196,8 +196,8 @@ mod tests {
         // json-key="mysecret" — "mysecret" here is part of the secret
         // name/base ARN, not a suffix field.
         let (base, key) =
-            split_ecs_json_key_suffix("arn:aws:secretsmanager:us-east-1:903779448426:secret:mysecret::").unwrap();
-        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:903779448426:secret:mysecret");
+            split_ecs_json_key_suffix("arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret::").unwrap();
+        assert_eq!(base, "arn:aws:secretsmanager:us-east-1:123456789012:secret:mysecret");
         assert_eq!(key, None);
     }
 
@@ -207,7 +207,7 @@ mod tests {
         // scope for in-process resolution — fail closed with a clear error
         // instead of silently mishandling it.
         let err = split_ecs_json_key_suffix(
-            "arn:aws:secretsmanager:us-east-1:903779448426:secret:appauthexample-AbCdEf::AWSPREVIOUS:",
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:appauthexample-AbCdEf::AWSPREVIOUS:",
         )
         .unwrap_err();
         assert!(err.to_string().contains("version"));
@@ -216,7 +216,7 @@ mod tests {
     #[test]
     fn split_ecs_json_key_suffix_rejects_version_id() {
         let err = split_ecs_json_key_suffix(
-            "arn:aws:secretsmanager:us-east-1:903779448426:secret:appauthexample-AbCdEf:::9d4cb84b-ad69-40c0-a0ab-cead3EXAMPLE",
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:appauthexample-AbCdEf:::9d4cb84b-ad69-40c0-a0ab-cead3EXAMPLE",
         )
         .unwrap_err();
         assert!(err.to_string().contains("version"));
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn split_ecs_json_key_suffix_rejects_key_and_version_stage_together() {
         let err = split_ecs_json_key_suffix(
-            "arn:aws:secretsmanager:us-east-1:903779448426:secret:appauthexample-AbCdEf:username1:AWSPREVIOUS:",
+            "arn:aws:secretsmanager:us-east-1:123456789012:secret:appauthexample-AbCdEf:username1:AWSPREVIOUS:",
         )
         .unwrap_err();
         assert!(err.to_string().contains("version"));
@@ -233,16 +233,16 @@ mod tests {
 
     #[test]
     fn parse_aws_sm_uri_extracts_id_and_key() {
-        let (id, key) = parse_aws_sm_uri("aws-sm://oab/telegram/pahudxbot#TELEGRAM_BOT_TOKEN")
+        let (id, key) = parse_aws_sm_uri("aws-sm://example/telegram/bot#TELEGRAM_BOT_TOKEN")
             .unwrap()
             .unwrap();
-        assert_eq!(id, "oab/telegram/pahudxbot");
+        assert_eq!(id, "example/telegram/bot");
         assert_eq!(key, "TELEGRAM_BOT_TOKEN");
     }
 
     #[test]
     fn parse_aws_sm_uri_rejects_missing_hash() {
-        assert!(parse_aws_sm_uri("aws-sm://oab/telegram/pahudxbot").unwrap().is_err());
+        assert!(parse_aws_sm_uri("aws-sm://example/telegram/bot").unwrap().is_err());
     }
 
     #[test]


### PR DESCRIPTION
These are ARN-parsing tests, so the ARN *shape* is what they exercise. The account ID and secret names were incidental to that — but real, and this repository is public.

## Changes

| Was | Now |
|---|---|
| `903779448426` | `123456789012` (AWS documentation account) |
| `oab/telegram/pahudxbot-AC80TP` | `example/telegram/bot-AbCdEf` |
| `aws-sm://oab/telegram/pahudxbot` | `aws-sm://example/telegram/bot` |

`example/telegram/bot-AbCdEf` follows the `appauthexample-AbCdEf` convention already used a few tests further down in the same file, so the fixtures are now internally consistent.

Files: `operator/src/secrets.rs`, `operator/src/ingress.rs`.

## Nothing needs rotating

No secret **value** was ever in these tests — only the ARN of the secret that holds the Telegram bot token. The name is not a credential and grants no access. What it did do is tell any reader which secrets this account holds, and test fixtures have no reason to carry that.

## Behaviour is unchanged

Every input/expected pair was updated together, so each test asserts exactly the same parsing behaviour:

- the JSON-key-suffix test still splits `…:TELEGRAM_BOT_TOKEN::` off the base ARN
- the plain-ARN test still returns `key: None`
- the `mysecret::` test still proves empty optional fields are not misread as a JSON key
- the version-stage / version-id / key-plus-stage tests still assert the same fail-closed errors
- `parse_aws_sm_uri` still splits the `#FIELD` fragment

Verified with `rustfmt --check` (parses cleanly; only pre-existing formatting diffs). Not compiled locally — the change is string literals inside `#[cfg(test)]` functions, so CI is the right place to confirm.

## History is deliberately untouched

Rewriting it would not un-publish anything: GitHub retains orphaned commits until support garbage-collects them, this repo has 195 forks whose networks keep the objects reachable by SHA, and anyone who cloned already has them. Meanwhile a force-push would break the 25 open PRs and every clone, and would change every commit SHA after the rewrite point — including ones referenced from `openabdev/openab-pty`.

Since the exposed data is an account ID and a secret name rather than a credential, the cost is not worth paying. This PR stops future readers seeing it and keeps the pattern from spreading.