### PR TITLE
feat(acp): opt-in live streaming over the ACP server path

### DIFF
--- a/crates/openab-core/src/acp/connection.rs
+++ b/crates/openab-core/src/acp/connection.rs
@@ -578,9 +578,9 @@ impl AcpConnection {
         Ok(())
     }
 
-    pub async fn session_new(&mut self, cwd: &str) -> Result<String> {
+    pub async fn session_new(&mut self, cwd: &str, mcp_servers: &[serde_json::Value]) -> Result<String> {
         let resp = self
-            .send_request("session/new", Some(json!({"cwd": cwd, "mcpServers": []})))
+            .send_request("session/new", Some(session_new_params(cwd, mcp_servers)))
             .await?;
 
         let session_id = resp
@@ -793,11 +793,16 @@ impl AcpConnection {
 
     /// Resume a previous session by ID. Returns Ok(()) if the agent accepted
     /// the load, or an error if it failed (caller should fall back to session/new).
-    pub async fn session_load(&mut self, session_id: &str, cwd: &str) -> Result<()> {
+    pub async fn session_load(
+        &mut self,
+        session_id: &str,
+        cwd: &str,
+        mcp_servers: &[serde_json::Value],
+    ) -> Result<()> {
         let resp = self
             .send_request(
                 "session/load",
-                Some(json!({"sessionId": session_id, "cwd": cwd, "mcpServers": []})),
+                Some(session_load_params(session_id, cwd, mcp_servers)),
             )
             .await?;
         // Accept any non-error response as success
@@ -841,6 +846,21 @@ impl AcpConnection {
     }
 }
 
+/// `session/new` params. `mcp_servers` are client-declared http-type entries
+/// forwarded verbatim (ACP passthrough); empty for every other caller.
+fn session_new_params(cwd: &str, mcp_servers: &[serde_json::Value]) -> serde_json::Value {
+    json!({"cwd": cwd, "mcpServers": mcp_servers})
+}
+
+/// `session/load` params — same `mcpServers` passthrough as `session_new_params`.
+fn session_load_params(
+    session_id: &str,
+    cwd: &str,
+    mcp_servers: &[serde_json::Value],
+) -> serde_json::Value {
+    json!({"sessionId": session_id, "cwd": cwd, "mcpServers": mcp_servers})
+}
+
 impl Drop for AcpConnection {
     fn drop(&mut self) {
         if let Some(handle) = self._stderr_handle.take() {
@@ -852,8 +872,43 @@ impl Drop for AcpConnection {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_agent_env, build_permission_response, pick_best_option};
+    use super::{
+        build_agent_env, build_permission_response, pick_best_option, session_load_params,
+        session_new_params,
+    };
     use serde_json::json;
+
+    #[test]
+    fn session_new_params_carry_the_passed_mcp_servers_verbatim() {
+        let servers = vec![json!({
+            "name": "nuphos-credentials",
+            "type": "http",
+            "url": "https://x.example/mcp",
+            "headers": [{"name": "Authorization", "value": "Bearer t"}]
+        })];
+        assert_eq!(
+            session_new_params("/w", &servers),
+            json!({"cwd": "/w", "mcpServers": servers})
+        );
+        // No declaration → the historical empty array, unchanged on the wire.
+        assert_eq!(
+            session_new_params("/w", &[]),
+            json!({"cwd": "/w", "mcpServers": []})
+        );
+    }
+
+    #[test]
+    fn session_load_params_carry_the_passed_mcp_servers_verbatim() {
+        let servers = vec![json!({"name": "s", "type": "http", "url": "https://x/mcp"})];
+        assert_eq!(
+            session_load_params("sess_1", "/w", &servers),
+            json!({"sessionId": "sess_1", "cwd": "/w", "mcpServers": servers})
+        );
+        assert_eq!(
+            session_load_params("sess_1", "/w", &[]),
+            json!({"sessionId": "sess_1", "cwd": "/w", "mcpServers": []})
+        );
+    }
 
     #[test]
     fn picks_allow_always_over_other_options() {

--- a/crates/openab-core/src/acp/connection.rs
+++ b/crates/openab-core/src/acp/connection.rs
@@ -578,9 +578,17 @@ impl AcpConnection {
         Ok(())
     }
 
-    pub async fn session_new(&mut self, cwd: &str, mcp_servers: &[serde_json::Value]) -> Result<String> {
+    pub async fn session_new(
+        &mut self,
+        cwd: &str,
+        mcp_servers: &[serde_json::Value],
+        session_meta: Option<&serde_json::Value>,
+    ) -> Result<String> {
         let resp = self
-            .send_request("session/new", Some(session_new_params(cwd, mcp_servers)))
+            .send_request(
+                "session/new",
+                Some(session_new_params(cwd, mcp_servers, session_meta)),
+            )
             .await?;
 
         let session_id = resp
@@ -798,11 +806,12 @@ impl AcpConnection {
         session_id: &str,
         cwd: &str,
         mcp_servers: &[serde_json::Value],
+        session_meta: Option<&serde_json::Value>,
     ) -> Result<()> {
         let resp = self
             .send_request(
                 "session/load",
-                Some(session_load_params(session_id, cwd, mcp_servers)),
+                Some(session_load_params(session_id, cwd, mcp_servers, session_meta)),
             )
             .await?;
         // Accept any non-error response as success
@@ -848,17 +857,32 @@ impl AcpConnection {
 
 /// `session/new` params. `mcp_servers` are client-declared http-type entries
 /// forwarded verbatim (ACP passthrough); empty for every other caller.
-fn session_new_params(cwd: &str, mcp_servers: &[serde_json::Value]) -> serde_json::Value {
-    json!({"cwd": cwd, "mcpServers": mcp_servers})
+/// `session_meta` is the client's `_meta` object, forwarded verbatim when
+/// present (claude-agent-acp reads e.g. `_meta.systemPrompt`); `None` omits the key.
+fn session_new_params(
+    cwd: &str,
+    mcp_servers: &[serde_json::Value],
+    session_meta: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let mut params = json!({"cwd": cwd, "mcpServers": mcp_servers});
+    if let Some(meta) = session_meta {
+        params["_meta"] = meta.clone();
+    }
+    params
 }
 
-/// `session/load` params — same `mcpServers` passthrough as `session_new_params`.
+/// `session/load` params — same `mcpServers` / `_meta` passthrough as `session_new_params`.
 fn session_load_params(
     session_id: &str,
     cwd: &str,
     mcp_servers: &[serde_json::Value],
+    session_meta: Option<&serde_json::Value>,
 ) -> serde_json::Value {
-    json!({"sessionId": session_id, "cwd": cwd, "mcpServers": mcp_servers})
+    let mut params = json!({"sessionId": session_id, "cwd": cwd, "mcpServers": mcp_servers});
+    if let Some(meta) = session_meta {
+        params["_meta"] = meta.clone();
+    }
+    params
 }
 
 impl Drop for AcpConnection {
@@ -887,25 +911,45 @@ mod tests {
             "headers": [{"name": "Authorization", "value": "Bearer t"}]
         })];
         assert_eq!(
-            session_new_params("/w", &servers),
+            session_new_params("/w", &servers, None),
             json!({"cwd": "/w", "mcpServers": servers})
         );
         // No declaration → the historical empty array, unchanged on the wire.
         assert_eq!(
-            session_new_params("/w", &[]),
+            session_new_params("/w", &[], None),
             json!({"cwd": "/w", "mcpServers": []})
         );
+    }
+
+    #[test]
+    fn session_new_params_carry_the_passed_meta_verbatim_and_omit_it_when_none() {
+        let meta = json!({"systemPrompt": "be terse", "nested": {"k": [1, 2]}});
+        assert_eq!(
+            session_new_params("/w", &[], Some(&meta)),
+            json!({"cwd": "/w", "mcpServers": [], "_meta": meta})
+        );
+        assert!(session_new_params("/w", &[], None).get("_meta").is_none());
+    }
+
+    #[test]
+    fn session_load_params_carry_the_passed_meta_verbatim_and_omit_it_when_none() {
+        let meta = json!({"systemPrompt": "be terse"});
+        assert_eq!(
+            session_load_params("sess_1", "/w", &[], Some(&meta)),
+            json!({"sessionId": "sess_1", "cwd": "/w", "mcpServers": [], "_meta": meta})
+        );
+        assert!(session_load_params("sess_1", "/w", &[], None).get("_meta").is_none());
     }
 
     #[test]
     fn session_load_params_carry_the_passed_mcp_servers_verbatim() {
         let servers = vec![json!({"name": "s", "type": "http", "url": "https://x/mcp"})];
         assert_eq!(
-            session_load_params("sess_1", "/w", &servers),
+            session_load_params("sess_1", "/w", &servers, None),
             json!({"sessionId": "sess_1", "cwd": "/w", "mcpServers": servers})
         );
         assert_eq!(
-            session_load_params("sess_1", "/w", &[]),
+            session_load_params("sess_1", "/w", &[], None),
             json!({"sessionId": "sess_1", "cwd": "/w", "mcpServers": []})
         );
     }

--- a/crates/openab-core/src/acp/pool.rs
+++ b/crates/openab-core/src/acp/pool.rs
@@ -53,6 +53,9 @@ struct PoolState {
     /// Kept here so an evicted-then-recreated session re-declares the same
     /// servers on its next spawn.
     session_mcp_servers: HashMap<String, Vec<serde_json::Value>>,
+    /// Client-supplied session `_meta` per session (ACP passthrough), kept for
+    /// the same reason as `session_mcp_servers`.
+    session_meta: HashMap<String, serde_json::Value>,
 }
 
 pub struct SessionPool {
@@ -189,6 +192,7 @@ fn purge_session_entries(state: &mut PoolState, key: &str) {
     // the same key.
     state.session_workdirs.remove(key);
     state.session_mcp_servers.remove(key);
+    state.session_meta.remove(key);
 }
 
 /// Escalating kill for a hung agent's process group: wait 10s after the
@@ -305,6 +309,7 @@ impl SessionPool {
                 creating: HashMap::new(),
                 session_workdirs,
                 session_mcp_servers: HashMap::new(),
+                session_meta: HashMap::new(),
             }),
             config,
             max_sessions,
@@ -404,6 +409,7 @@ impl SessionPool {
         thread_id: &str,
         working_dir_override: Option<&str>,
         mcp_servers: &[serde_json::Value],
+        session_meta: Option<&serde_json::Value>,
     ) -> Result<bool> {
         let create_gate = {
             let mut state = self.state.write().await;
@@ -416,6 +422,11 @@ impl SessionPool {
                 state
                     .session_mcp_servers
                     .insert(thread_id.to_string(), mcp_servers.to_vec());
+            }
+            if let Some(meta) = session_meta {
+                if state.session_meta.get(thread_id) != Some(meta) {
+                    state.session_meta.insert(thread_id.to_string(), meta.clone());
+                }
             }
             get_or_insert_gate(&mut state.creating, thread_id)
         };
@@ -485,7 +496,7 @@ impl SessionPool {
 
         // Resolve effective working directory: stored per-session > explicit override > global config.
         // Stored value has highest priority to enforce immutability (ADR §4.5).
-        let (stored_workdir, session_mcp_servers) = {
+        let (stored_workdir, session_mcp_servers, session_meta) = {
             let state = self.state.read().await;
             (
                 state.session_workdirs.get(thread_id).cloned(),
@@ -494,6 +505,7 @@ impl SessionPool {
                     .get(thread_id)
                     .cloned()
                     .unwrap_or_default(),
+                state.session_meta.get(thread_id).cloned(),
             )
         };
 
@@ -580,7 +592,12 @@ impl SessionPool {
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
                 match new_conn
-                    .session_load(sid, &effective_workdir, &session_mcp_servers)
+                    .session_load(
+                        sid,
+                        &effective_workdir,
+                        &session_mcp_servers,
+                        session_meta.as_ref(),
+                    )
                     .await
                 {
                     Ok(()) => {
@@ -620,7 +637,11 @@ impl SessionPool {
 
         if !resumed {
             new_conn
-                .session_new(&effective_workdir, &session_mcp_servers)
+                .session_new(
+                    &effective_workdir,
+                    &session_mcp_servers,
+                    session_meta.as_ref(),
+                )
                 .await?;
 
             // Apply default config options (e.g. mode=bypass, model=swe-1-6)
@@ -1099,6 +1120,7 @@ mod tests {
             creating: HashMap::new(),
             session_workdirs: HashMap::new(),
             session_mcp_servers: HashMap::new(),
+            session_meta: HashMap::new(),
         }
     }
 
@@ -1382,6 +1404,10 @@ mod tests {
                 "hung".to_string(),
                 vec![serde_json::json!({"type": "http", "name": "x", "url": "http://x"})],
             )]),
+            session_meta: HashMap::from([(
+                "hung".to_string(),
+                serde_json::json!({"systemPrompt": "x"}),
+            )]),
         };
 
         purge_session_entries(&mut state, "hung");
@@ -1394,6 +1420,7 @@ mod tests {
         assert!(!state.persisted.contains_key("hung"));
         assert!(!state.session_workdirs.contains_key("hung"));
         assert!(!state.session_mcp_servers.contains_key("hung"));
+        assert!(!state.session_meta.contains_key("hung"));
         // The creating gate is concurrency control, not session state: it must
         // survive so an in-flight get_or_create holder stays serialized.
         assert!(state.creating.contains_key("hung"));

--- a/crates/openab-core/src/acp/pool.rs
+++ b/crates/openab-core/src/acp/pool.rs
@@ -49,6 +49,10 @@ struct PoolState {
     /// Per-session working directory overrides (from control directives).
     /// thread_key → canonical workspace path.
     session_workdirs: HashMap<String, String>,
+    /// Client-declared http-type MCP servers per session (ACP passthrough).
+    /// Kept here so an evicted-then-recreated session re-declares the same
+    /// servers on its next spawn.
+    session_mcp_servers: HashMap<String, Vec<serde_json::Value>>,
 }
 
 pub struct SessionPool {
@@ -184,6 +188,7 @@ fn purge_session_entries(state: &mut PoolState, key: &str) {
     // a concurrent get_or_create mint a fresh gate and run two creations for
     // the same key.
     state.session_workdirs.remove(key);
+    state.session_mcp_servers.remove(key);
 }
 
 /// Escalating kill for a hung agent's process group: wait 10s after the
@@ -299,6 +304,7 @@ impl SessionPool {
                 suspended,
                 creating: HashMap::new(),
                 session_workdirs,
+                session_mcp_servers: HashMap::new(),
             }),
             config,
             max_sessions,
@@ -397,9 +403,20 @@ impl SessionPool {
         &self,
         thread_id: &str,
         working_dir_override: Option<&str>,
+        mcp_servers: &[serde_json::Value],
     ) -> Result<bool> {
         let create_gate = {
             let mut state = self.state.write().await;
+            // A non-empty declaration updates the stored set even when a live
+            // session short-circuits below: it takes effect on the next spawn,
+            // never restarting a live session.
+            if !mcp_servers.is_empty()
+                && state.session_mcp_servers.get(thread_id).map(Vec::as_slice) != Some(mcp_servers)
+            {
+                state
+                    .session_mcp_servers
+                    .insert(thread_id.to_string(), mcp_servers.to_vec());
+            }
             get_or_insert_gate(&mut state.creating, thread_id)
         };
         let _create_guard = create_gate.lock().await;
@@ -468,9 +485,16 @@ impl SessionPool {
 
         // Resolve effective working directory: stored per-session > explicit override > global config.
         // Stored value has highest priority to enforce immutability (ADR §4.5).
-        let stored_workdir = {
+        let (stored_workdir, session_mcp_servers) = {
             let state = self.state.read().await;
-            state.session_workdirs.get(thread_id).cloned()
+            (
+                state.session_workdirs.get(thread_id).cloned(),
+                state
+                    .session_mcp_servers
+                    .get(thread_id)
+                    .cloned()
+                    .unwrap_or_default(),
+            )
         };
 
         let effective_workdir = if let Some(stored) = stored_workdir {
@@ -555,7 +579,10 @@ impl SessionPool {
         let mut load_failed: Option<&str> = None;
         if let Some(ref sid) = saved_session_id {
             if new_conn.supports_load_session {
-                match new_conn.session_load(sid, &effective_workdir).await {
+                match new_conn
+                    .session_load(sid, &effective_workdir, &session_mcp_servers)
+                    .await
+                {
                     Ok(()) => {
                         info!(thread_id = %crate::redact::redact_session_ids(thread_id), session_id = %crate::redact::redact_session_ids(sid), "session resumed via session/load");
                         resumed = true;
@@ -592,7 +619,9 @@ impl SessionPool {
         }
 
         if !resumed {
-            new_conn.session_new(&effective_workdir).await?;
+            new_conn
+                .session_new(&effective_workdir, &session_mcp_servers)
+                .await?;
 
             // Apply default config options (e.g. mode=bypass, model=swe-1-6)
             for (config_id, value) in &self.default_config_options {
@@ -1069,6 +1098,7 @@ mod tests {
             persisted: HashMap::new(),
             creating: HashMap::new(),
             session_workdirs: HashMap::new(),
+            session_mcp_servers: HashMap::new(),
         }
     }
 
@@ -1348,6 +1378,10 @@ mod tests {
             ]),
             creating: HashMap::from([("hung".to_string(), Arc::new(Mutex::new(())))]),
             session_workdirs: HashMap::from([("hung".to_string(), "/tmp/ws".to_string())]),
+            session_mcp_servers: HashMap::from([(
+                "hung".to_string(),
+                vec![serde_json::json!({"type": "http", "name": "x", "url": "http://x"})],
+            )]),
         };
 
         purge_session_entries(&mut state, "hung");
@@ -1359,6 +1393,7 @@ mod tests {
         assert!(!state.suspended.contains_key("hung"));
         assert!(!state.persisted.contains_key("hung"));
         assert!(!state.session_workdirs.contains_key("hung"));
+        assert!(!state.session_mcp_servers.contains_key("hung"));
         // The creating gate is concurrency control, not session state: it must
         // survive so an in-flight get_or_create holder stays serialized.
         assert!(state.creating.contains_key("hung"));

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -415,6 +415,17 @@ pub trait ChatAdapter: Send + Sync + 'static {
         Ok(())
     }
 
+    /// Forward a raw agent-side ACP `session/update` payload (thought chunks,
+    /// tool_call / tool_call_update) to platforms that can relay it natively —
+    /// today only the ACP server path. Default: drop.
+    async fn forward_agent_update(
+        &self,
+        _channel: &ChannelRef,
+        _update: serde_json::Value,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Whether this platform renders Markdown tables natively. When `true`, the
     /// router skips the `convert_tables` pre-pass (which rewrites tables into
     /// code blocks / bullet lists for platforms that cannot render them) and
@@ -940,6 +951,22 @@ impl AdapterRouter {
                             break;
                         }
 
+                        // ACP relays thought/tool updates natively — forward the raw
+                        // payload before the lossy classify/status mapping below.
+                        if platform_is_acp {
+                            if let Some(update) =
+                                notification.params.as_ref().and_then(|p| p.get("update"))
+                            {
+                                if matches!(
+                                    update.get("sessionUpdate").and_then(|v| v.as_str()),
+                                    Some("agent_thought_chunk" | "tool_call" | "tool_call_update")
+                                ) {
+                                    let _ = adapter
+                                        .forward_agent_update(&thread_channel, update.clone())
+                                        .await;
+                                }
+                            }
+                        }
                         if let Some(event) = classify_notification(&notification) {
                             match event {
                                 AcpEvent::Text(t) => {

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -805,8 +805,16 @@ impl AdapterRouter {
                             // user sees the complete content at turn end.
                             let mut consecutive_failures: u32 = 0;
                             const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+                            // Default 1500ms respects real platforms' edit rate limits;
+                            // in-process consumers (e.g. the ACP server) can lower it via
+                            // OPENAB_STREAM_EDIT_INTERVAL_MS for tighter live deltas.
+                            let interval_ms = std::env::var("OPENAB_STREAM_EDIT_INTERVAL_MS")
+                                .ok()
+                                .and_then(|v| v.parse::<u64>().ok())
+                                .filter(|ms| (50..=60_000).contains(ms))
+                                .unwrap_or(1500);
                             loop {
-                                tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+                                tokio::time::sleep(std::time::Duration::from_millis(interval_ms)).await;
                                 if buf_rx.has_changed().unwrap_or(false) {
                                     let content = buf_rx.borrow_and_update().clone();
                                     if content != last {

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -745,6 +745,11 @@ impl AdapterRouter {
         // prefix from `compose_display` would corrupt the deltas, so ACP streams the raw
         // append-only answer text and surfaces tools separately (review F2 / roadmap).
         let platform_is_acp = thread_channel.platform == "acp";
+        // ACP is an in-process channel with no edit rate limit: bypass the paced
+        // edit loop and relay each text snapshot inline, so text stays in strict
+        // arrival order with the tool/thought updates forwarded on the same path.
+        // The gateway diffs successive snapshots into append-only chunks.
+        let acp_direct = streaming && platform_is_acp;
         let prompt_hard_timeout = self.prompt_hard_timeout;
         let liveness_check_interval = self.liveness_check_interval;
 
@@ -786,8 +791,16 @@ impl AdapterRouter {
                     let mut native_last_flush = tokio::time::Instant::now();
                     const NATIVE_FLUSH_MS: u128 = 400;
 
+                    // ACP direct relay: no placeholder, no edit loop — text
+                    // snapshots go out inline from the recv loop below.
+                    let acp_draft_msg = MessageRef {
+                        message_id: "draft".to_string(),
+                        channel: thread_channel.clone(),
+                    };
+
                     // Streaming edit: send placeholder, spawn edit loop
-                    let (buf_tx, placeholder_msg, edit_handle) = if streaming && !native {
+                    let (buf_tx, placeholder_msg, edit_handle) =
+                        if streaming && !native && !acp_direct {
                         let initial = if reset {
                             "⚠️ _Session expired, starting fresh..._\n\n…".to_string()
                         } else {
@@ -971,7 +984,13 @@ impl AdapterRouter {
                             match event {
                                 AcpEvent::Text(t) => {
                                     text_buf.push_str(&t);
-                                    if native {
+                                    if acp_direct {
+                                        // Awaited inline so the snapshot reaches the
+                                        // gateway before any later tool/thought relay.
+                                        let _ = adapter
+                                            .edit_message(&acp_draft_msg, &text_buf)
+                                            .await;
+                                    } else if native {
                                         // Lazy stream_begin: open the stream on first text.
                                         if native_msg.is_none() && !stream_begin_failed {
                                             match adapter.stream_begin(&thread_channel, recipient.clone()).await {
@@ -1141,6 +1160,19 @@ impl AdapterRouter {
                     // FULL buffer (they sit at output start, which the slice may
                     // drop) so a leading [[reply_to:...]] survives the narration
                     // it was emitted alongside.
+                    // ACP direct relay: the raw buffer is exactly what the inline
+                    // snapshots carried; the terminal send below repeats it verbatim
+                    // so the gateway's snapshot diff yields no duplicate chunk.
+                    let acp_streamed = if acp_direct {
+                        text_buf.clone()
+                    } else {
+                        String::new()
+                    };
+                    let acp_error = if acp_direct {
+                        response_error.clone()
+                    } else {
+                        None
+                    };
                     let (directives, text_buf) =
                         split_delivery(&text_buf, answer_start, keep_full_text);
                     // The session-reset notice lives at the head of the buffer; a
@@ -1247,6 +1279,23 @@ impl AdapterRouter {
                                     delivery_failed = true;
                                 }
                             }
+                        }
+                    } else if acp_direct {
+                        // Terminal delivery closes the turn at the gateway (Done →
+                        // session/prompt response). Repeating the exact streamed
+                        // snapshot diffs to nothing new; content the deltas never
+                        // carried (error banner, empty-turn sentinel) is appended
+                        // so it still reaches the client exactly once.
+                        let terminal = if acp_streamed.is_empty() {
+                            final_content.clone()
+                        } else if let Some(ref err) = acp_error {
+                            format!("{acp_streamed}\n\n⚠️ {err}")
+                        } else {
+                            acp_streamed
+                        };
+                        if let Err(e) = adapter.send_message(&thread_channel, &terminal).await {
+                            tracing::warn!(error = ?e, platform = %thread_channel.platform, "acp terminal send failed");
+                            delivery_failed = true;
                         }
                     } else if let Some(msg) = placeholder_msg {
                         if let Some(ref reply_id) = directives.reply_to {

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -703,10 +703,12 @@ impl AdapterRouter {
         let message_limit = reply_message_limit(&thread_channel.platform, adapter.message_limit());
         // ACP must not inherit the unified adapter's Telegram streaming flag (wrong
         // coupling): it streams append-only `agent_message_chunk` deltas built from the
-        // post+edit (`edit_message` snapshot) path, i.e. streaming=false. Decide it
-        // explicitly by platform rather than by whatever Telegram happens to be set to.
+        // post+edit (`edit_message` snapshot) path. Default stays send-once; opt in to
+        // live deltas explicitly with OPENAB_ACP_STREAMING=true|1.
         let streaming = if thread_channel.platform == "acp" {
-            false
+            std::env::var("OPENAB_ACP_STREAMING")
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false)
         } else {
             adapter.use_streaming(other_bot_present)
         };

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -607,7 +607,7 @@ impl AdapterRouter {
                 .unwrap_or(&ctx.thread_channel.channel_id)
         );
 
-        if let Err(e) = self.pool.get_or_create(&thread_key, None, &[]).await {
+        if let Err(e) = self.pool.get_or_create(&thread_key, None, &[], None).await {
             let msg = format_user_error(&e.to_string());
             let _ = adapter
                 .send_message(&ctx.thread_channel, &format!("⚠️ {msg}"))

--- a/crates/openab-core/src/adapter.rs
+++ b/crates/openab-core/src/adapter.rs
@@ -607,7 +607,7 @@ impl AdapterRouter {
                 .unwrap_or(&ctx.thread_channel.channel_id)
         );
 
-        if let Err(e) = self.pool.get_or_create(&thread_key, None).await {
+        if let Err(e) = self.pool.get_or_create(&thread_key, None, &[]).await {
             let msg = format_user_error(&e.to_string());
             let _ = adapter
                 .send_message(&ctx.thread_channel, &format!("⚠️ {msg}"))

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -595,7 +595,7 @@ async fn ambient_consumer_loop(
         }
 
         // Ensure session exists.
-        if let Err(e) = target.ensure_session(&session_key, None, &[]).await {
+        if let Err(e) = target.ensure_session(&session_key, None, &[], None).await {
             warn!(
                 channel_id = %crate::redact::redact_session_ids(&channel_id),
                 error = %e,

--- a/crates/openab-core/src/ambient.rs
+++ b/crates/openab-core/src/ambient.rs
@@ -595,7 +595,7 @@ async fn ambient_consumer_loop(
         }
 
         // Ensure session exists.
-        if let Err(e) = target.ensure_session(&session_key, None).await {
+        if let Err(e) = target.ensure_session(&session_key, None, &[]).await {
             warn!(
                 channel_id = %crate::redact::redact_session_ids(&channel_id),
                 error = %e,

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1136,6 +1136,7 @@ impl EventHandler for Handler {
                 estimated_tokens,
                 other_bot_present: other_bot_present_flag,
                 recipient: None, // Slack-only (assistant mode); N/A for Discord
+                mcp_servers: Vec::new(),
             };
             if let Err(e) = dispatcher
                 .submit(thread_key, thread_channel, adapter, buf_msg)
@@ -1377,6 +1378,7 @@ impl EventHandler for Handler {
                 estimated_tokens,
                 other_bot_present,
                 recipient: None,
+                mcp_servers: Vec::new(),
             };
 
             if let Err(e) = dispatcher

--- a/crates/openab-core/src/discord.rs
+++ b/crates/openab-core/src/discord.rs
@@ -1137,6 +1137,7 @@ impl EventHandler for Handler {
                 other_bot_present: other_bot_present_flag,
                 recipient: None, // Slack-only (assistant mode); N/A for Discord
                 mcp_servers: Vec::new(),
+                session_meta: None,
             };
             if let Err(e) = dispatcher
                 .submit(thread_key, thread_channel, adapter, buf_msg)
@@ -1379,6 +1380,7 @@ impl EventHandler for Handler {
                 other_bot_present,
                 recipient: None,
                 mcp_servers: Vec::new(),
+                session_meta: None,
             };
 
             if let Err(e) = dispatcher

--- a/crates/openab-core/src/dispatch.rs
+++ b/crates/openab-core/src/dispatch.rs
@@ -55,6 +55,10 @@ pub struct BufferedMessage {
     /// mode's native streaming is active. `None` for non-Slack platforms and
     /// bot-authored turns.
     pub recipient: Option<(String, String)>,
+    /// Client-declared http-type MCP servers (ACP passthrough), forwarded to
+    /// `ensure_session` so they reach the inner agent's session/new. Empty for
+    /// non-ACP platforms.
+    pub mcp_servers: Vec<serde_json::Value>,
 }
 
 /// How `thread_key` is built for the dispatcher's per-thread map.
@@ -132,7 +136,14 @@ pub trait DispatchTarget: Send + Sync + 'static {
 
     /// Ensure the ACP session for `session_key` exists (idempotent).
     /// Returns `true` if a new session was created, `false` if it already existed.
-    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<bool>;
+    /// `mcp_servers` are client-declared http-type MCP entries to pass to the
+    /// agent's session/new (empty for platforms without the ACP passthrough).
+    async fn ensure_session(
+        &self,
+        session_key: &str,
+        working_dir: Option<&str>,
+        mcp_servers: &[serde_json::Value],
+    ) -> Result<bool>;
 
     /// Destroy the session for `session_key` (used to rollback on directive failure).
     async fn reset_session(&self, session_key: &str);
@@ -165,8 +176,15 @@ impl DispatchTarget for AdapterRouter {
         self.bot_home_path()
     }
 
-    async fn ensure_session(&self, session_key: &str, working_dir: Option<&str>) -> Result<bool> {
-        self.pool().get_or_create(session_key, working_dir).await
+    async fn ensure_session(
+        &self,
+        session_key: &str,
+        working_dir: Option<&str>,
+        mcp_servers: &[serde_json::Value],
+    ) -> Result<bool> {
+        self.pool()
+            .get_or_create(session_key, working_dir, mcp_servers)
+            .await
     }
 
     async fn reset_session(&self, session_key: &str) {
@@ -692,10 +710,19 @@ async fn dispatch_batch(
     let workspace_override: Option<String> =
         ws_resolved.as_ref().and_then(|r| r.as_ref().ok().cloned());
 
+    // Freshest non-empty declaration in the batch wins (a batch is one turn; the
+    // stored set is updated pool-side and takes effect on next spawn).
+    let mcp_servers: Vec<serde_json::Value> = batch
+        .iter()
+        .rev()
+        .find(|m| !m.mcp_servers.is_empty())
+        .map(|m| m.mcp_servers.clone())
+        .unwrap_or_default();
+
     // Ensure session exists. The create_gate mutex inside get_or_create serializes
     // concurrent callers — only the winner gets created_now == true.
     let created_now = match target
-        .ensure_session(&session_key, workspace_override.as_deref())
+        .ensure_session(&session_key, workspace_override.as_deref(), &mcp_servers)
         .await
     {
         Ok(created) => created,
@@ -1414,6 +1441,7 @@ mod tests {
             &self,
             _session_key: &str,
             _working_dir: Option<&str>,
+            _mcp_servers: &[serde_json::Value],
         ) -> Result<bool> {
             if let Some(msg) = self.ensure_err.lock().unwrap().take() {
                 return Err(anyhow::anyhow!(msg));
@@ -1511,6 +1539,7 @@ mod tests {
             estimated_tokens: tokens,
             other_bot_present: false,
             recipient: None,
+            mcp_servers: vec![],
         }
     }
 

--- a/crates/openab-core/src/dispatch.rs
+++ b/crates/openab-core/src/dispatch.rs
@@ -59,6 +59,9 @@ pub struct BufferedMessage {
     /// `ensure_session` so they reach the inner agent's session/new. Empty for
     /// non-ACP platforms.
     pub mcp_servers: Vec<serde_json::Value>,
+    /// Client-supplied session `_meta` (ACP passthrough), forwarded verbatim to
+    /// the inner agent's session/new. `None` for non-ACP platforms.
+    pub session_meta: Option<serde_json::Value>,
 }
 
 /// How `thread_key` is built for the dispatcher's per-thread map.
@@ -136,13 +139,15 @@ pub trait DispatchTarget: Send + Sync + 'static {
 
     /// Ensure the ACP session for `session_key` exists (idempotent).
     /// Returns `true` if a new session was created, `false` if it already existed.
-    /// `mcp_servers` are client-declared http-type MCP entries to pass to the
-    /// agent's session/new (empty for platforms without the ACP passthrough).
+    /// `mcp_servers` are client-declared http-type MCP entries and `session_meta`
+    /// the client's `_meta` object, both passed to the agent's session/new
+    /// (empty / `None` for platforms without the ACP passthrough).
     async fn ensure_session(
         &self,
         session_key: &str,
         working_dir: Option<&str>,
         mcp_servers: &[serde_json::Value],
+        session_meta: Option<&serde_json::Value>,
     ) -> Result<bool>;
 
     /// Destroy the session for `session_key` (used to rollback on directive failure).
@@ -181,9 +186,10 @@ impl DispatchTarget for AdapterRouter {
         session_key: &str,
         working_dir: Option<&str>,
         mcp_servers: &[serde_json::Value],
+        session_meta: Option<&serde_json::Value>,
     ) -> Result<bool> {
         self.pool()
-            .get_or_create(session_key, working_dir, mcp_servers)
+            .get_or_create(session_key, working_dir, mcp_servers, session_meta)
             .await
     }
 
@@ -718,11 +724,20 @@ async fn dispatch_batch(
         .find(|m| !m.mcp_servers.is_empty())
         .map(|m| m.mcp_servers.clone())
         .unwrap_or_default();
+    let session_meta: Option<serde_json::Value> = batch
+        .iter()
+        .rev()
+        .find_map(|m| m.session_meta.clone());
 
     // Ensure session exists. The create_gate mutex inside get_or_create serializes
     // concurrent callers — only the winner gets created_now == true.
     let created_now = match target
-        .ensure_session(&session_key, workspace_override.as_deref(), &mcp_servers)
+        .ensure_session(
+            &session_key,
+            workspace_override.as_deref(),
+            &mcp_servers,
+            session_meta.as_ref(),
+        )
         .await
     {
         Ok(created) => created,
@@ -1442,6 +1457,7 @@ mod tests {
             _session_key: &str,
             _working_dir: Option<&str>,
             _mcp_servers: &[serde_json::Value],
+            _session_meta: Option<&serde_json::Value>,
         ) -> Result<bool> {
             if let Some(msg) = self.ensure_err.lock().unwrap().take() {
                 return Err(anyhow::anyhow!(msg));
@@ -1540,6 +1556,7 @@ mod tests {
             other_bot_present: false,
             recipient: None,
             mcp_servers: vec![],
+            session_meta: None,
         }
     }
 

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -132,6 +132,9 @@ struct GwChannel {
     #[serde(rename = "type")]
     channel_type: String,
     thread_id: Option<String>,
+    /// Client-declared http-type MCP servers (ACP passthrough). Absent → empty.
+    #[serde(default)]
+    mcp_servers: Vec<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1186,6 +1189,7 @@ pub async fn run_gateway_adapter(
                                             // TODO: implement gateway multibot detection
                                             other_bot_present: false,
                                             recipient: None, // Slack-only (assistant mode); N/A for gateway
+                                            mcp_servers: event.channel.mcp_servers.clone(),
                                         };
                                         if let Err(e) = dispatcher
                                             .submit(thread_key, thread_channel, adapter, buf_msg)
@@ -1636,6 +1640,7 @@ pub async fn process_gateway_event(
             estimated_tokens,
             other_bot_present: false,
             recipient: None,
+            mcp_servers: event.channel.mcp_servers.clone(),
         };
         if let Err(e) = dispatcher
             .submit(thread_key, thread_channel, adapter, buf_msg)

--- a/crates/openab-core/src/gateway.rs
+++ b/crates/openab-core/src/gateway.rs
@@ -135,6 +135,9 @@ struct GwChannel {
     /// Client-declared http-type MCP servers (ACP passthrough). Absent → empty.
     #[serde(default)]
     mcp_servers: Vec<serde_json::Value>,
+    /// Client-supplied session `_meta` (ACP passthrough). Absent → `None`.
+    #[serde(default)]
+    session_meta: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -1190,6 +1193,7 @@ pub async fn run_gateway_adapter(
                                             other_bot_present: false,
                                             recipient: None, // Slack-only (assistant mode); N/A for gateway
                                             mcp_servers: event.channel.mcp_servers.clone(),
+                                            session_meta: event.channel.session_meta.clone(),
                                         };
                                         if let Err(e) = dispatcher
                                             .submit(thread_key, thread_channel, adapter, buf_msg)
@@ -1641,6 +1645,7 @@ pub async fn process_gateway_event(
             other_bot_present: false,
             recipient: None,
             mcp_servers: event.channel.mcp_servers.clone(),
+                                            session_meta: event.channel.session_meta.clone(),
         };
         if let Err(e) = dispatcher
             .submit(thread_key, thread_channel, adapter, buf_msg)

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -1808,6 +1808,7 @@ async fn handle_message(
         other_bot_present,
         recipient: stream_recipient,
         mcp_servers: Vec::new(),
+        session_meta: None,
     };
     if let Err(e) = dispatcher
         .submit(thread_key, thread_channel, adapter_dyn, buf_msg)

--- a/crates/openab-core/src/slack.rs
+++ b/crates/openab-core/src/slack.rs
@@ -1807,6 +1807,7 @@ async fn handle_message(
         estimated_tokens,
         other_bot_present,
         recipient: stream_recipient,
+        mcp_servers: Vec::new(),
     };
     if let Err(e) = dispatcher
         .submit(thread_key, thread_channel, adapter_dyn, buf_msg)

--- a/crates/openab-core/tests/acp_stream_order.rs
+++ b/crates/openab-core/tests/acp_stream_order.rs
@@ -1,0 +1,283 @@
+//! End-to-end ordering tests for the ACP direct-relay streaming path: a scripted
+//! fake agent emits interleaved text / tool / thought session updates over real
+//! stdio, and a recording ChatAdapter captures the relay order on the other side.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use openab_core::acp::{ContentBlock, SessionPool};
+use openab_core::adapter::{AdapterRouter, ChannelRef, ChatAdapter, MessageRef};
+use openab_core::config::{AgentConfig, ReactionsConfig};
+use openab_core::markdown::TableMode;
+use openab_core::reactions::StatusReactionController;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+/// Tests in this binary mutate process env (HOME, OPENAB_ACP_STREAMING); run them
+/// one at a time. This file is its own test process, so no other test binary sees
+/// the mutations.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(Mutex::default)
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Call {
+    Send(String),
+    Edit { message_id: String, content: String },
+    Update(String),
+}
+
+struct RecordingAdapter {
+    calls: Mutex<Vec<Call>>,
+    streaming: bool,
+}
+
+impl RecordingAdapter {
+    fn new(streaming: bool) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            streaming,
+        }
+    }
+    fn calls(&self) -> Vec<Call> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ChatAdapter for RecordingAdapter {
+    fn platform(&self) -> &'static str {
+        "unified"
+    }
+    fn message_limit(&self) -> usize {
+        4096
+    }
+    async fn send_message(&self, channel: &ChannelRef, content: &str) -> Result<MessageRef> {
+        self.calls.lock().unwrap().push(Call::Send(content.to_string()));
+        Ok(MessageRef {
+            channel: channel.clone(),
+            message_id: "m1".into(),
+        })
+    }
+    async fn create_thread(
+        &self,
+        _: &ChannelRef,
+        _: &MessageRef,
+        _: &str,
+    ) -> Result<ChannelRef> {
+        unimplemented!()
+    }
+    async fn add_reaction(&self, _: &MessageRef, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn remove_reaction(&self, _: &MessageRef, _: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
+        self.calls.lock().unwrap().push(Call::Edit {
+            message_id: msg.message_id.clone(),
+            content: content.to_string(),
+        });
+        Ok(())
+    }
+    async fn forward_agent_update(
+        &self,
+        _: &ChannelRef,
+        update: serde_json::Value,
+    ) -> Result<()> {
+        let kind = update
+            .get("sessionUpdate")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        self.calls.lock().unwrap().push(Call::Update(kind));
+        Ok(())
+    }
+    fn use_streaming(&self, _other_bot_present: bool) -> bool {
+        self.streaming
+    }
+}
+
+/// A line-delimited JSON-RPC fake agent: answers initialize / session/new, and on
+/// session/prompt emits text chunks interleaved with tool + thought updates before
+/// the final response — the exact shape that reproduced the production reordering.
+const FAKE_AGENT: &str = r##"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$line" in
+    *'"initialize"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"agentInfo":{"name":"fake","version":"0"},"agentCapabilities":{}}}\n' "$id"
+      ;;
+    *'"session/new"'*)
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"sess_fake"}}\n' "$id"
+      ;;
+    *'"session/prompt"'*)
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Linode C"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_fake","update":{"sessionUpdate":"tool_call","toolCallId":"t1","title":"check availability","status":"pending"}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_fake","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"LI ok"}}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_fake","update":{"sessionUpdate":"tool_call_update","toolCallId":"t1","title":"check availability","status":"completed"}}}\n'
+      printf '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess_fake","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":" done"}}}}\n'
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$id"
+      ;;
+  esac
+done
+"##;
+
+struct Fixture {
+    router: AdapterRouter,
+    channel: ChannelRef,
+    _tmp: tempfile::TempDir,
+}
+
+async fn setup(platform: &str, thread_key: &str) -> Fixture {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Isolate ~/.openab persistence (thread_map.json / session_meta.json).
+    std::env::set_var("HOME", tmp.path());
+    std::env::set_var("OPENAB_ACP_STREAMING", "1");
+    std::env::remove_var("OPENAB_STREAM_EDIT_INTERVAL_MS");
+
+    let script = tmp.path().join("fake_agent.sh");
+    std::fs::write(&script, FAKE_AGENT).expect("write fake agent");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let agent_cfg = AgentConfig {
+        command: script.to_string_lossy().into_owned(),
+        args: vec![],
+        working_dir: tmp.path().to_string_lossy().into_owned(),
+        env: HashMap::new(),
+        inherit_env: vec![],
+        command_explicit: true,
+    };
+    let pool = Arc::new(SessionPool::new(agent_cfg, 1, 60, HashMap::new()));
+    pool.get_or_create(thread_key, None, &[])
+        .await
+        .expect("session spawn against fake agent");
+
+    let router = AdapterRouter::new(
+        pool,
+        ReactionsConfig::default(),
+        TableMode::Code,
+        30,
+        1,
+        HashMap::new(),
+        tmp.path().to_path_buf(),
+    );
+    let channel = ChannelRef {
+        platform: platform.into(),
+        channel_id: format!("{platform}_chan"),
+        thread_id: None,
+        parent_id: None,
+        origin_event_id: Some("evt_test".into()),
+    };
+    Fixture {
+        router,
+        channel,
+        _tmp: tmp,
+    }
+}
+
+async fn run_turn(fx: &Fixture, adapter: &Arc<dyn ChatAdapter>, thread_key: &str) {
+    let reactions = Arc::new(StatusReactionController::new(
+        false,
+        adapter.clone(),
+        MessageRef {
+            channel: fx.channel.clone(),
+            message_id: "trigger".into(),
+        },
+        Default::default(),
+        Default::default(),
+    ));
+    fx.router
+        .stream_prompt_blocks(
+            adapter,
+            thread_key,
+            vec![ContentBlock::Text { text: "hi".into() }],
+            &fx.channel,
+            reactions,
+            false,
+            None,
+        )
+        .await
+        .expect("turn completes");
+}
+
+// ACP + streaming: text snapshots are relayed inline, so they interleave with
+// tool/thought updates in exact arrival order, and the terminal send repeats the
+// last snapshot verbatim (the gateway diffs it to nothing → no duplicate tail).
+#[tokio::test(flavor = "multi_thread")]
+async fn acp_streaming_relays_text_inline_in_arrival_order() {
+    let _guard = env_lock();
+    let fx = setup("acp", "acp:order").await;
+    let recorder = Arc::new(RecordingAdapter::new(false));
+    let adapter: Arc<dyn ChatAdapter> = recorder.clone();
+    run_turn(&fx, &adapter, "acp:order").await;
+
+    let calls = recorder.calls();
+    let expected = vec![
+        Call::Edit {
+            message_id: "draft".into(),
+            content: "Linode C".into(),
+        },
+        Call::Update("tool_call".into()),
+        Call::Update("agent_thought_chunk".into()),
+        Call::Edit {
+            message_id: "draft".into(),
+            content: "Linode CLI ok".into(),
+        },
+        Call::Update("tool_call_update".into()),
+        Call::Edit {
+            message_id: "draft".into(),
+            content: "Linode CLI ok done".into(),
+        },
+        Call::Send("Linode CLI ok done".into()),
+    ];
+    assert_eq!(
+        calls, expected,
+        "ACP streaming must relay text in arrival order and finish with a \
+         terminal send identical to the last snapshot"
+    );
+}
+
+// Non-ACP platforms keep the paced edit loop: with the default 1500ms interval a
+// fast turn produces no mid-stream partial edits — text is never relayed inline
+// and agent updates are not forwarded.
+#[tokio::test(flavor = "multi_thread")]
+async fn non_acp_streaming_keeps_paced_edit_loop() {
+    let _guard = env_lock();
+    let fx = setup("gateway", "gateway:paced").await;
+    let recorder = Arc::new(RecordingAdapter::new(true));
+    let adapter: Arc<dyn ChatAdapter> = recorder.clone();
+    run_turn(&fx, &adapter, "gateway:paced").await;
+
+    let calls = recorder.calls();
+    assert!(
+        !calls.iter().any(|c| matches!(c, Call::Update(_))),
+        "agent updates must not be forwarded off the ACP path: {calls:?}"
+    );
+    assert_eq!(
+        calls.first(),
+        Some(&Call::Send("…".into())),
+        "non-ACP streaming still opens with the placeholder: {calls:?}"
+    );
+    // The fake turn finishes far below the 1500ms pacing interval, so the only
+    // edit is the finalize write — no inline per-chunk edits.
+    let edits: Vec<&Call> = calls
+        .iter()
+        .filter(|c| matches!(c, Call::Edit { .. }))
+        .collect();
+    assert_eq!(edits.len(), 1, "expected only the finalize edit: {calls:?}");
+    match edits[0] {
+        Call::Edit { content, .. } => assert!(
+            content.contains("Linode CLI ok done"),
+            "finalize edit must carry the full text: {content}"
+        ),
+        _ => unreachable!(),
+    }
+}

--- a/crates/openab-core/tests/acp_stream_order.rs
+++ b/crates/openab-core/tests/acp_stream_order.rs
@@ -156,7 +156,7 @@ async fn setup(platform: &str, thread_key: &str) -> Fixture {
         command_explicit: true,
     };
     let pool = Arc::new(SessionPool::new(agent_cfg, 1, 60, HashMap::new()));
-    pool.get_or_create(thread_key, None, &[])
+    pool.get_or_create(thread_key, None, &[], None)
         .await
         .expect("session spawn against fake agent");
 

--- a/crates/openab-gateway/src/adapters/acp_server.rs
+++ b/crates/openab-gateway/src/adapters/acp_server.rs
@@ -2522,8 +2522,15 @@ pub async fn handle_reply(reply: &GatewayReply, registry: &AcpReplyRegistry) {
             // Fence stale replies: after a timeout/cancel the channel_id is reused by the
             // next turn. A late reply carries the previous turn's `evt_<uuid>` in
             // `reply_to`; deliver only when it matches the active turn. Empty `reply_to`
-            // (no origin id) fails open so legit traffic is never dropped.
-            Some(sink) if reply.reply_to.is_empty() || reply.reply_to == sink.turn_id => {
+            // (no origin id) fails open so legit traffic is never dropped. `"draft"` is
+            // the streaming edit loop's placeholder MessageRef id (ACP shows no
+            // placeholder message), so mid-turn `edit_message` snapshots carry it —
+            // fail open for it too or streaming deltas are all dropped as stale.
+            Some(sink)
+                if reply.reply_to.is_empty()
+                    || reply.reply_to == "draft"
+                    || reply.reply_to == sink.turn_id =>
+            {
                 sink.tx.clone()
             }
             Some(_) => {

--- a/crates/openab-gateway/src/adapters/acp_server.rs
+++ b/crates/openab-gateway/src/adapters/acp_server.rs
@@ -331,6 +331,9 @@ struct AcpSession {
     /// "cancelled"` to the prompt's own request id (rather than hard-aborting
     /// the task and orphaning that id).
     cancel: Option<Arc<tokio::sync::Notify>>,
+    /// Client-declared `"type":"http"` mcpServers entries (raw JSON), forwarded
+    /// verbatim to core on each prompt. Empty unless OPENAB_ACP_MCP_SERVERS is on.
+    mcp_servers: Vec<serde_json::Value>,
 }
 
 /// A client-declared MCP-over-ACP server (the RFD `"type":"acp"` `mcpServers` entry). Not in
@@ -391,6 +394,32 @@ fn accept_acp_servers(servers: Vec<AcpMcpServer>) -> Result<Vec<AcpMcpServer>, S
         ));
     }
     Ok(deduped)
+}
+
+/// Extract the `"type":"http"` entries of a `mcpServers` array as raw JSON, for
+/// verbatim passthrough to the inner agent session. Capped at
+/// `MAX_ACP_SERVERS_PER_SESSION` (extras dropped, not an error).
+fn parse_http_mcp_servers(params: Option<&Value>) -> Vec<serde_json::Value> {
+    params
+        .and_then(|p| p.get("mcpServers"))
+        .and_then(|m| m.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|e| e.get("type").and_then(Value::as_str) == Some("http"))
+                .take(MAX_ACP_SERVERS_PER_SESSION)
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Env gate for the http-mcpServers passthrough (`OPENAB_ACP_MCP_SERVERS=true|1`).
+/// Read once per connection; handlers take the value as a parameter so tests
+/// never mutate process env.
+fn acp_mcp_servers_enabled() -> bool {
+    std::env::var("OPENAB_ACP_MCP_SERVERS")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
 }
 
 pub enum ReplyChunk {
@@ -1362,6 +1391,8 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
 
     // Frame tracing (OPENAB_ACP_TRACE) — read once per connection.
     let trace = acp_trace_enabled();
+    // http-mcpServers passthrough gate (OPENAB_ACP_MCP_SERVERS) — read once per connection.
+    let mcp_enabled = acp_mcp_servers_enabled();
 
     // Session state for this connection
     let sessions: Arc<tokio::sync::Mutex<HashMap<String, AcpSession>>> =
@@ -1534,7 +1565,7 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
 
         match req.method.as_str() {
             "initialize" => {
-                let resp = handle_initialize(&req);
+                let resp = handle_initialize(&req, mcp_enabled);
                 // Only mark the connection initialized when negotiation succeeded.
                 let negotiated_ok = resp.error.is_none();
                 let _ = out_tx.send(serde_json::to_string(&resp).unwrap());
@@ -1578,8 +1609,13 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
                         continue;
                     }
                 };
+                let http_mcp_servers = if mcp_enabled {
+                    parse_http_mcp_servers(req.params.as_ref())
+                } else {
+                    Vec::new()
+                };
                 let (resp, channel_id) =
-                    handle_session_new(&sessions, id.clone()).await;
+                    handle_session_new(&sessions, id.clone(), http_mcp_servers).await;
                 let _ = out_tx.send(serde_json::to_string(&resp).unwrap());
 
                 // If the client declared "type":"acp" MCP servers, open + register a tunnel to
@@ -1628,7 +1664,8 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
                         }
                     };
                 let (resp, resumed_channel) =
-                    handle_session_resume(&sessions, id.clone(), req.params.as_ref()).await;
+                    handle_session_resume(&sessions, id.clone(), req.params.as_ref(), mcp_enabled)
+                        .await;
                 let _ = out_tx.send(serde_json::to_string(&resp).unwrap());
 
                 // Retire tunnels for declarations this resume withdrew.
@@ -1920,7 +1957,7 @@ pub static ACP_ACTIVE_CONNECTIONS: std::sync::atomic::AtomicI64 =
 // Method handlers
 // ---------------------------------------------------------------------------
 
-fn handle_initialize(req: &JsonRpcRequest) -> JsonRpcResponse {
+fn handle_initialize(req: &JsonRpcRequest, mcp_http: bool) -> JsonRpcResponse {
     let id = req.id.clone().unwrap_or(Value::Null);
     // Validate the official request (protocolVersion is required) before negotiating.
     let init: crate::adapters::acp_schema::InitializeRequest =
@@ -1955,11 +1992,10 @@ fn handle_initialize(req: &JsonRpcRequest) -> JsonRpcResponse {
                 // NOTHING already claims "no MCP transport support" — while this gateway ships
                 // MCP-over-ACP. Silence was not neutral (R4).
                 //
-                // http and sse are FALSE, and that is verified rather than assumed: `session/new`
-                // runs `parse_acp_mcp_servers`, keeps only `"type":"acp"` entries, and then calls
-                // `handle_session_new(&sessions, id)` — `req.params` reaches nothing else. An http
-                // or sse declaration is silently dropped, so advertising `true` would be a claim
-                // with no implementation behind it.
+                // http is TRUE only when the OPENAB_ACP_MCP_SERVERS passthrough is enabled
+                // (`mcp_http` — session/new then stores the http entries and forwards them to
+                // core on each prompt). sse stays FALSE: those declarations are still dropped,
+                // so advertising `true` would be a claim with no implementation behind it.
                 //
                 // The ACP capability is declared as a **reverse-DNS-namespaced `_meta` key**, per
                 // the 2026-07-28 MCP `_meta` namespaced-key convention (SEP-1788 — its own reserved
@@ -1971,7 +2007,7 @@ fn handle_initialize(req: &JsonRpcRequest) -> JsonRpcResponse {
                 // fork the generated types, which F1(a) deliberately avoided. It would move to that
                 // typed map if and when the vendored schema gains it; the ADR carries that note.
                 "mcpCapabilities": {
-                    "http": false,
+                    "http": mcp_http,
                     "sse": false,
                     "_meta": { "dev.openab/acp": true }
                 },
@@ -1999,6 +2035,9 @@ fn handle_initialize(req: &JsonRpcRequest) -> JsonRpcResponse {
 async fn handle_session_new(
     sessions: &Arc<tokio::sync::Mutex<HashMap<String, AcpSession>>>,
     id: Value,
+    // Parsed http-type mcpServers entries to store on the session (already env-gated
+    // and capped by the caller).
+    mcp_servers: Vec<serde_json::Value>,
 ) -> (JsonRpcResponse, String) {
     // sessionId and channel_id share one uuid so channel_id is always
     // re-derivable from a persisted sessionId (see session/resume).
@@ -2012,6 +2051,7 @@ async fn handle_session_new(
             channel_id: channel_id.clone(),
             busy: false,
             cancel: None,
+            mcp_servers,
         },
     );
 
@@ -2062,6 +2102,8 @@ async fn handle_session_resume(
     sessions: &Arc<tokio::sync::Mutex<HashMap<String, AcpSession>>>,
     id: Value,
     params: Option<&Value>,
+    // OPENAB_ACP_MCP_SERVERS gate, read by the caller so tests never mutate env.
+    mcp_enabled: bool,
 ) -> (JsonRpcResponse, Option<String>) {
     let session_id = match params.and_then(|p| p.get("sessionId")).and_then(|v| v.as_str()) {
         Some(s) => s.to_string(),
@@ -2116,12 +2158,30 @@ async fn handle_session_resume(
             None,
         );
     }
+    // Same ABSENT-vs-EMPTY reading as the tunnel withdrawal below: only a real
+    // `mcpServers` ARRAY replaces the stored http entries; absent/null/malformed
+    // keeps them. Gate off → store nothing.
+    let declared_array = matches!(
+        params.and_then(|p| p.get("mcpServers")),
+        Some(Value::Array(_))
+    );
+    let mcp_servers = if !mcp_enabled {
+        Vec::new()
+    } else if declared_array {
+        parse_http_mcp_servers(params)
+    } else {
+        guard
+            .get(&session_id)
+            .map(|s| s.mcp_servers.clone())
+            .unwrap_or_default()
+    };
     guard.insert(
         session_id.clone(),
         AcpSession {
             channel_id: channel_id.clone(),
             busy: false,
             cancel: None,
+            mcp_servers,
         },
     );
     drop(guard);
@@ -2275,9 +2335,10 @@ async fn handle_session_prompt(
         }
     };
 
-    // The session was reserved a moment ago under the lock; just read its channel_id.
-    let channel_id = match sessions.lock().await.get(&session_id) {
-        Some(s) => s.channel_id.clone(),
+    // The session was reserved a moment ago under the lock; just read its channel_id
+    // and stored http mcpServers entries.
+    let (channel_id, mcp_servers) = match sessions.lock().await.get(&session_id) {
+        Some(s) => (s.channel_id.clone(), s.mcp_servers.clone()),
         None => {
             let resp =
                 JsonRpcResponse::error(
@@ -2299,6 +2360,7 @@ async fn handle_session_prompt(
             id: channel_id.clone(),
             channel_type: "dm".into(),
             thread_id: None,
+            mcp_servers,
         },
         SenderInfo {
             id: "acp_client".into(),
@@ -2624,7 +2686,9 @@ mod acp_conformance {
 
     #[test]
     fn initialize_response() {
-        // mirror of handle_initialize
+        // mirror of handle_initialize — checked for both values of mcpCapabilities.http
+        // (the OPENAB_ACP_MCP_SERVERS gate).
+        for http in [false, true] {
         conforms::<sc::InitializeResponse>(json!({
             "protocolVersion": 1,
             "agentCapabilities": {
@@ -2633,13 +2697,14 @@ mod acp_conformance {
                 // mirroring is worse than no mirror, because it still looks like coverage. This
                 // also proves `_meta` is schema-legal here, which is what makes the ACP capability
                 // expressible before upstream has a real field for it.
-                "mcpCapabilities": { "http": false, "sse": false, "_meta": { "dev.openab/acp": true } },
+                "mcpCapabilities": { "http": http, "sse": false, "_meta": { "dev.openab/acp": true } },
                 "sessionCapabilities": { "resume": {} },
                 "promptCapabilities": { "image": false, "audio": false, "embeddedContext": false }
             },
             "agentInfo": { "name": "openab", "title": "OpenAB", "version": "0.0.0" },
             "authMethods": []
         }));
+        }
     }
 
     #[test]
@@ -3577,7 +3642,8 @@ mod acp_requests {
 mod acp_handlers {
     use super::{
         handle_initialize, handle_session_new, handle_session_resume, parse_acp_mcp_servers,
-        AcpMcpServer, AcpSession, JsonRpcRequest,
+        parse_http_mcp_servers, AcpMcpServer, AcpSession, JsonRpcRequest,
+        MAX_ACP_SERVERS_PER_SESSION,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -3599,7 +3665,7 @@ mod acp_handlers {
 
     #[test]
     fn initialize_returns_conformant_capabilities() {
-        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({"protocolVersion": 1}))))).unwrap();
+        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({"protocolVersion": 1}))), false)).unwrap();
         assert_eq!(v["id"], json!(1));
         let result = &v["result"];
         assert_eq!(result["protocolVersion"], json!(1));
@@ -3627,16 +3693,16 @@ mod acp_handlers {
     #[test]
     fn initialize_negotiates_version_and_rejects_bad() {
         // a higher client version negotiates down to ours (1)
-        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({"protocolVersion": 5}))))).unwrap();
+        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({"protocolVersion": 5}))), false)).unwrap();
         assert_eq!(v["result"]["protocolVersion"], json!(1));
         // version 0 is below our minimum → -32602
-        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({"protocolVersion": 0}))))).unwrap();
+        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({"protocolVersion": 0}))), false)).unwrap();
         assert_eq!(v["error"]["code"], json!(-32602));
         // missing protocolVersion → -32602
-        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({}))))).unwrap();
+        let v = serde_json::to_value(handle_initialize(&init_req(Some(json!({}))), false)).unwrap();
         assert_eq!(v["error"]["code"], json!(-32602));
         // missing params → -32602
-        let v = serde_json::to_value(handle_initialize(&init_req(None))).unwrap();
+        let v = serde_json::to_value(handle_initialize(&init_req(None), false)).unwrap();
         assert_eq!(v["error"]["code"], json!(-32602));
     }
 
@@ -3644,7 +3710,7 @@ mod acp_handlers {
     async fn session_new_mints_and_stores_a_session() {
         let sessions = new_sessions();
         let v =
-            serde_json::to_value(handle_session_new(&sessions, json!(2)).await.0).unwrap();
+            serde_json::to_value(handle_session_new(&sessions, json!(2), Vec::new()).await.0).unwrap();
         let sid = v["result"]["sessionId"].as_str().unwrap();
         assert!(sid.starts_with("sess_"), "sessionId must be sess_<uuid>: {sid}");
         assert!(sessions.lock().await.contains_key(sid), "session must be stored");
@@ -3672,6 +3738,100 @@ mod acp_handlers {
         assert!(parse_acp_mcp_servers(None).is_empty());
     }
 
+    #[test]
+    fn parse_http_mcp_servers_keeps_http_entries_verbatim_and_caps() {
+        let http = json!({
+            "name": "nuphos-credentials",
+            "type": "http",
+            "url": "https://x.example/mcp",
+            "headers": [{"name": "Authorization", "value": "Bearer t"}]
+        });
+        let params = json!({
+            "cwd": "/w",
+            "mcpServers": [
+                {"type": "acp", "id": "srv-1", "name": "browser"},
+                http,
+                {"type": "stdio", "name": "s", "command": "x"},
+                {"type": "sse", "name": "e", "url": "https://sse"},
+                {"name": "typeless"}
+            ]
+        });
+        assert_eq!(parse_http_mcp_servers(Some(&params)), vec![http]);
+        assert!(parse_http_mcp_servers(Some(&json!({"cwd": "/w"}))).is_empty());
+        assert!(parse_http_mcp_servers(None).is_empty());
+
+        // Over-declaration is bounded deterministically: extras dropped, no error.
+        let many: Vec<serde_json::Value> = (0..MAX_ACP_SERVERS_PER_SESSION + 4)
+            .map(|i| json!({"type": "http", "name": format!("s{i}"), "url": "https://x"}))
+            .collect();
+        let kept = parse_http_mcp_servers(Some(&json!({"mcpServers": many})));
+        assert_eq!(kept.len(), MAX_ACP_SERVERS_PER_SESSION);
+        assert_eq!(kept[0]["name"], json!("s0"), "first entries win, in order");
+    }
+
+    #[tokio::test]
+    async fn session_new_stores_http_mcp_servers_on_the_session() {
+        let sessions = new_sessions();
+        let server = json!({"type": "http", "name": "creds", "url": "https://x/mcp"});
+        let v = serde_json::to_value(
+            handle_session_new(&sessions, json!(2), vec![server.clone()]).await.0,
+        )
+        .unwrap();
+        let sid = v["result"]["sessionId"].as_str().unwrap().to_string();
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().mcp_servers, vec![server]);
+    }
+
+    #[tokio::test]
+    async fn resume_absent_mcp_servers_keeps_stored_entries_and_empty_clears() {
+        let sessions = new_sessions();
+        let server = json!({"type": "http", "name": "creds", "url": "https://x/mcp"});
+        let v = serde_json::to_value(
+            handle_session_new(&sessions, json!(1), vec![server.clone()]).await.0,
+        )
+        .unwrap();
+        let sid = v["result"]["sessionId"].as_str().unwrap().to_string();
+
+        // Omitted mcpServers: the client said nothing → stored entries survive.
+        let absent = json!({"sessionId": sid, "cwd": "/w"});
+        handle_session_resume(&sessions, json!(2), Some(&absent), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().mcp_servers, vec![server.clone()]);
+
+        // Null is next to absent, not an empty declaration.
+        let null = json!({"sessionId": sid, "cwd": "/w", "mcpServers": null});
+        handle_session_resume(&sessions, json!(3), Some(&null), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().mcp_servers, vec![server.clone()]);
+
+        // An explicit [] is a full re-declaration offering none → cleared.
+        let empty = json!({"sessionId": sid, "cwd": "/w", "mcpServers": []});
+        handle_session_resume(&sessions, json!(4), Some(&empty), true).await;
+        assert!(sessions.lock().await.get(&sid).unwrap().mcp_servers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resume_with_gate_disabled_stores_nothing() {
+        let sessions = new_sessions();
+        let sid = format!("sess_{}", Uuid::new_v4());
+        let p = json!({
+            "sessionId": sid,
+            "cwd": "/w",
+            "mcpServers": [{"type": "http", "name": "creds", "url": "https://x/mcp"}]
+        });
+        handle_session_resume(&sessions, json!(1), Some(&p), false).await;
+        assert!(sessions.lock().await.get(&sid).unwrap().mcp_servers.is_empty());
+    }
+
+    #[test]
+    fn initialize_advertises_http_only_when_gated_on() {
+        let v = serde_json::to_value(handle_initialize(
+            &init_req(Some(json!({"protocolVersion": 1}))),
+            true,
+        ))
+        .unwrap();
+        let mcp = &v["result"]["agentCapabilities"]["mcpCapabilities"];
+        assert_eq!(mcp["http"], json!(true));
+        assert_eq!(mcp["sse"], json!(false), "sse declarations are still dropped");
+    }
+
 
     #[tokio::test]
     async fn session_resume_valid_stores_and_invalid_errors() {
@@ -3679,18 +3839,18 @@ mod acp_handlers {
         // valid sess_<uuid> → {} and the session is (re)stored
         let sid = format!("sess_{}", Uuid::new_v4());
         let params = json!({"sessionId": sid, "cwd": "/w", "mcpServers": []});
-        let v = serde_json::to_value(handle_session_resume(&sessions, json!(3), Some(&params)).await.0)
+        let v = serde_json::to_value(handle_session_resume(&sessions, json!(3), Some(&params), false).await.0)
             .unwrap();
         assert_eq!(v["result"], json!({}));
         assert!(sessions.lock().await.contains_key(&sid));
         // malformed sessionId shape → -32602
         let bad = json!({"sessionId": "not-a-session", "cwd": "/w", "mcpServers": []});
-        let v = serde_json::to_value(handle_session_resume(&sessions, json!(4), Some(&bad)).await.0)
+        let v = serde_json::to_value(handle_session_resume(&sessions, json!(4), Some(&bad), false).await.0)
             .unwrap();
         assert_eq!(v["error"]["code"], json!(-32602));
         // missing sessionId → -32602
         let v = serde_json::to_value(
-            handle_session_resume(&sessions, json!(5), Some(&json!({"cwd": "/w"}))).await.0,
+            handle_session_resume(&sessions, json!(5), Some(&json!({"cwd": "/w"})), false).await.0,
         )
         .unwrap();
         assert_eq!(v["error"]["code"], json!(-32602));
@@ -3721,7 +3881,7 @@ mod acp_review_fixes {
         for _ in 0..MAX_SESSIONS_PER_CONNECTION {
             let sid = format!("sess_{}", Uuid::new_v4());
             let p = json!({ "sessionId": sid });
-            let v = serde_json::to_value(handle_session_resume(&sessions, json!(1), Some(&p)).await.0)
+            let v = serde_json::to_value(handle_session_resume(&sessions, json!(1), Some(&p), false).await.0)
                 .unwrap();
             assert_eq!(v["result"], json!({}), "resume under cap should succeed");
             ids.push(sid);
@@ -3729,13 +3889,13 @@ mod acp_review_fixes {
         assert_eq!(sessions.lock().await.len(), MAX_SESSIONS_PER_CONNECTION);
         // A new distinct session over the cap is refused with ACP_OVERLOADED.
         let over = json!({ "sessionId": format!("sess_{}", Uuid::new_v4()) });
-        let v = serde_json::to_value(handle_session_resume(&sessions, json!(2), Some(&over)).await.0)
+        let v = serde_json::to_value(handle_session_resume(&sessions, json!(2), Some(&over), false).await.0)
             .unwrap();
         assert_eq!(v["error"]["code"], json!(ACP_OVERLOADED), "over-cap resume must be refused");
         // Re-resuming an already-present session is exempt (idempotent).
         let existing = json!({ "sessionId": ids[0] });
         let v =
-            serde_json::to_value(handle_session_resume(&sessions, json!(3), Some(&existing)).await.0)
+            serde_json::to_value(handle_session_resume(&sessions, json!(3), Some(&existing), false).await.0)
                 .unwrap();
         assert_eq!(v["result"], json!({}), "re-resume of existing session must bypass the cap");
     }
@@ -3890,13 +4050,13 @@ mod acp_review_fixes {
 
         // 1. missing sessionId
         let (resp, chan) =
-            handle_session_resume(&sessions, json!(1), Some(&json!({"cwd": "/w"}))).await;
+            handle_session_resume(&sessions, json!(1), Some(&json!({"cwd": "/w"})), false).await;
         assert_eq!(serde_json::to_value(resp).unwrap()["error"]["code"], json!(-32602));
         assert!(chan.is_none(), "missing sessionId must not yield a channel");
 
         // 2. malformed sessionId
         let bad = json!({"sessionId": "not-a-session", "cwd": "/w"});
-        let (resp, chan) = handle_session_resume(&sessions, json!(2), Some(&bad)).await;
+        let (resp, chan) = handle_session_resume(&sessions, json!(2), Some(&bad), false).await;
         assert_eq!(serde_json::to_value(resp).unwrap()["error"]["code"], json!(-32602));
         assert!(chan.is_none(), "malformed sessionId must not yield a channel");
 
@@ -3904,11 +4064,11 @@ mod acp_review_fixes {
         //    derive-from-params guard would have happily produced a channel here.
         for _ in 0..MAX_SESSIONS_PER_CONNECTION {
             let p = json!({ "sessionId": format!("sess_{}", Uuid::new_v4()) });
-            let (_r, chan) = handle_session_resume(&sessions, json!(3), Some(&p)).await;
+            let (_r, chan) = handle_session_resume(&sessions, json!(3), Some(&p), false).await;
             assert!(chan.is_some(), "resume under the cap should succeed");
         }
         let over = json!({ "sessionId": format!("sess_{}", Uuid::new_v4()) });
-        let (resp, chan) = handle_session_resume(&sessions, json!(4), Some(&over)).await;
+        let (resp, chan) = handle_session_resume(&sessions, json!(4), Some(&over), false).await;
         assert_eq!(
             serde_json::to_value(resp).unwrap()["error"]["code"],
             json!(ACP_OVERLOADED)
@@ -3923,10 +4083,11 @@ mod acp_review_fixes {
                 channel_id: derive_channel_id(&busy_sid).unwrap(),
                 busy: true,
                 cancel: Some(Arc::new(tokio::sync::Notify::new())),
+                mcp_servers: Vec::new(),
             },
         );
         let (resp, chan) =
-            handle_session_resume(&sessions, json!(5), Some(&json!({"sessionId": busy_sid}))).await;
+            handle_session_resume(&sessions, json!(5), Some(&json!({"sessionId": busy_sid})), false).await;
         assert_eq!(serde_json::to_value(resp).unwrap()["error"]["code"], json!(-32001));
         assert!(chan.is_none(), "a busy-rejected resume must not yield a channel");
     }
@@ -4108,6 +4269,7 @@ mod acp_review_fixes {
                 channel_id: format!("acp_{}", Uuid::new_v4()),
                 busy: true,
                 cancel: Some(cancel.clone()),
+                mcp_servers: Vec::new(),
             },
         );
         // Cancel arrives before the handler's stream loop (reserved-then-immediate-cancel).
@@ -4138,6 +4300,91 @@ mod acp_review_fixes {
         assert!(!s.busy && s.cancel.is_none(), "cancel must release busy + cancel handle");
     }
 
+    // OPENAB_ACP_MCP_SERVERS passthrough: entries stored at session/new ride every
+    // prompt's GatewayEvent as `channel.mcp_servers`, so core can forward them to
+    // the inner agent session.
+    #[tokio::test]
+    async fn prompt_event_carries_the_sessions_stored_http_mcp_servers() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel::<String>(16);
+        let mut st = crate::AppState::test_default(event_tx);
+        st.acp_reply_registry = Some(new_reply_registry());
+        let state = Arc::new(st);
+
+        let sessions = sessions_map();
+        let server = json!({
+            "name": "nuphos-credentials",
+            "type": "http",
+            "url": "https://x.example/mcp",
+            "headers": [{"name": "Authorization", "value": "Bearer t"}]
+        });
+        let (resp, _channel) =
+            handle_session_new(&sessions, json!(1), vec![server.clone()]).await;
+        let sid = serde_json::to_value(resp).unwrap()["result"]["sessionId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Reserve the prompt like the read loop, with the cancel pre-fired so the
+        // handler exits right after dispatching the event.
+        let cancel = Arc::new(tokio::sync::Notify::new());
+        {
+            let mut g = sessions.lock().await;
+            let s = g.get_mut(&sid).unwrap();
+            s.busy = true;
+            s.cancel = Some(cancel.clone());
+        }
+        cancel.notify_one();
+
+        let (out_tx, _out_rx) = mpsc::unbounded_channel::<String>();
+        let params = json!({"sessionId": sid, "prompt": [{"type": "text", "text": "hi"}]});
+        handle_session_prompt(&state, &sessions, json!(7), Some(&params), &out_tx, sid.clone(), cancel, "conn-test", 0)
+            .await;
+
+        let event_json = event_rx.try_recv().expect("prompt must dispatch a GatewayEvent");
+        let event: serde_json::Value = serde_json::from_str(&event_json).unwrap();
+        assert_eq!(
+            event["channel"]["mcp_servers"],
+            json!([server]),
+            "the stored http entries must ride the event verbatim"
+        );
+    }
+
+    // A session declaring nothing serializes no `mcp_servers` key at all (back-compat wire).
+    #[tokio::test]
+    async fn prompt_event_omits_mcp_servers_when_none_declared() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel::<String>(16);
+        let mut st = crate::AppState::test_default(event_tx);
+        st.acp_reply_registry = Some(new_reply_registry());
+        let state = Arc::new(st);
+
+        let sessions = sessions_map();
+        let (resp, _channel) = handle_session_new(&sessions, json!(1), Vec::new()).await;
+        let sid = serde_json::to_value(resp).unwrap()["result"]["sessionId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let cancel = Arc::new(tokio::sync::Notify::new());
+        {
+            let mut g = sessions.lock().await;
+            let s = g.get_mut(&sid).unwrap();
+            s.busy = true;
+            s.cancel = Some(cancel.clone());
+        }
+        cancel.notify_one();
+
+        let (out_tx, _out_rx) = mpsc::unbounded_channel::<String>();
+        let params = json!({"sessionId": sid, "prompt": [{"type": "text", "text": "hi"}]});
+        handle_session_prompt(&state, &sessions, json!(7), Some(&params), &out_tx, sid.clone(), cancel, "conn-test", 0)
+            .await;
+
+        let event_json = event_rx.try_recv().expect("prompt must dispatch a GatewayEvent");
+        let event: serde_json::Value = serde_json::from_str(&event_json).unwrap();
+        assert!(
+            event["channel"].get("mcp_servers").is_none(),
+            "an empty set must not appear on the wire: {event}"
+        );
+    }
+
     // R16-F2 — session/resume on a session with a prompt in flight is rejected (busy), so the
     // active turn's cancel handle + state are NOT clobbered by resume's unconditional rewrite.
     #[tokio::test]
@@ -4151,11 +4398,12 @@ mod acp_review_fixes {
                 channel_id: format!("acp_{}", Uuid::new_v4()),
                 busy: true,
                 cancel: Some(cancel.clone()),
+                mcp_servers: Vec::new(),
             },
         );
 
         let params = json!({"sessionId": sid, "cwd": "/w", "mcpServers": []});
-        let (resp, resumed) = handle_session_resume(&sessions, json!(9), Some(&params)).await;
+        let (resp, resumed) = handle_session_resume(&sessions, json!(9), Some(&params), false).await;
         let v = serde_json::to_value(resp).unwrap();
         assert_eq!(v["error"]["code"], json!(-32001), "resume while busy must be rejected");
         assert!(
@@ -4188,7 +4436,7 @@ mod acp_review_fixes {
         let cancel = Arc::new(tokio::sync::Notify::new());
         sessions.lock().await.insert(
             sid.clone(),
-            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()) },
+            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()), mcp_servers: Vec::new() },
         );
 
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
@@ -4264,6 +4512,7 @@ mod acp_review_fixes {
                 channel_id: format!("acp_{}", Uuid::new_v4()),
                 busy: true,
                 cancel: Some(cancel.clone()),
+                mcp_servers: Vec::new(),
             },
         );
         let params = json!({"sessionId": sid});

--- a/crates/openab-gateway/src/adapters/acp_server.rs
+++ b/crates/openab-gateway/src/adapters/acp_server.rs
@@ -1358,6 +1358,7 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
     let connection_closed = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     info!(connection = %connection_id, "ACP client connected");
+    ACP_ACTIVE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
 
     // Frame tracing (OPENAB_ACP_TRACE) — read once per connection.
     let trace = acp_trace_enabled();
@@ -1907,8 +1908,13 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
     );
 
     send_task.abort();
+    ACP_ACTIVE_CONNECTIONS.fetch_sub(1, Ordering::Relaxed);
     info!(connection = %connection_id, "ACP client disconnected");
 }
+
+/// Live ACP WebSocket connection count, for the unified binary's /statusz.
+pub static ACP_ACTIVE_CONNECTIONS: std::sync::atomic::AtomicI64 =
+    std::sync::atomic::AtomicI64::new(0);
 
 // ---------------------------------------------------------------------------
 // Method handlers

--- a/crates/openab-gateway/src/adapters/acp_server.rs
+++ b/crates/openab-gateway/src/adapters/acp_server.rs
@@ -396,6 +396,9 @@ fn accept_acp_servers(servers: Vec<AcpMcpServer>) -> Result<Vec<AcpMcpServer>, S
 pub enum ReplyChunk {
     /// Incremental text snapshot (full text so far)
     Text(String),
+    /// Raw agent-side `session/update` payload (thought chunk, tool_call, …)
+    /// relayed verbatim to the ACP client.
+    Update(serde_json::Value),
     /// Agent finished responding
     Done,
 }
@@ -2388,6 +2391,20 @@ async fn handle_session_prompt(
                         };
                         let _ = out_tx.send(serde_json::to_string(&notification).unwrap());
                     }
+                    Ok(Some(ReplyChunk::Update(update))) => {
+                        // Relay agent-side thought/tool updates verbatim under the
+                        // outer session id. Does not touch `sent_len` — the text
+                        // delta stream stays append-only and unaffected.
+                        let notification = JsonRpcNotification {
+                            jsonrpc: "2.0",
+                            method: "session/update".into(),
+                            params: json!({
+                                "sessionId": session_id,
+                                "update": update
+                            }),
+                        };
+                        let _ = out_tx.send(serde_json::to_string(&notification).unwrap());
+                    }
                     Ok(Some(ReplyChunk::Done)) | Ok(None) => break,
                     Err(_) => {
                         warn!(session = %redact_id(&session_id), "ACP: prompt timed out waiting for reply");
@@ -2547,6 +2564,12 @@ pub async fn handle_reply(reply: &GatewayReply, registry: &AcpReplyRegistry) {
             if tx.send(ReplyChunk::Text(full_text)).is_err() {
                 debug!(channel = key, "ACP reply send failed (client likely disconnected)");
                 registry.lock().unwrap_or_else(|e| e.into_inner()).remove(key);
+            }
+        }
+        Some("agent_update") => {
+            // Raw agent-side session/update payload (JSON in the text field).
+            if let Ok(update) = serde_json::from_str::<serde_json::Value>(&full_text) {
+                let _ = tx.send(ReplyChunk::Update(update));
             }
         }
         None | Some("send_message") => {

--- a/crates/openab-gateway/src/adapters/acp_server.rs
+++ b/crates/openab-gateway/src/adapters/acp_server.rs
@@ -334,6 +334,9 @@ struct AcpSession {
     /// Client-declared `"type":"http"` mcpServers entries (raw JSON), forwarded
     /// verbatim to core on each prompt. Empty unless OPENAB_ACP_MCP_SERVERS is on.
     mcp_servers: Vec<serde_json::Value>,
+    /// Client-supplied session `_meta` object (raw JSON), forwarded verbatim to
+    /// core on each prompt. `None` unless OPENAB_ACP_MCP_SERVERS is on.
+    session_meta: Option<serde_json::Value>,
 }
 
 /// A client-declared MCP-over-ACP server (the RFD `"type":"acp"` `mcpServers` entry). Not in
@@ -413,9 +416,30 @@ fn parse_http_mcp_servers(params: Option<&Value>) -> Vec<serde_json::Value> {
         .unwrap_or_default()
 }
 
-/// Env gate for the http-mcpServers passthrough (`OPENAB_ACP_MCP_SERVERS=true|1`).
-/// Read once per connection; handlers take the value as a parameter so tests
-/// never mutate process env.
+/// Upper bound on a forwarded session `_meta` object (serialized bytes), so a
+/// client cannot bloat the gateway event channel through it.
+const MAX_SESSION_META_BYTES: usize = 256 * 1024;
+
+/// Extract the `_meta` object of session/new or session/resume params as raw
+/// JSON, for verbatim passthrough to the inner agent session. Non-objects are
+/// ignored; an object over `MAX_SESSION_META_BYTES` is dropped with a warning.
+fn parse_session_meta(params: Option<&Value>) -> Option<serde_json::Value> {
+    let meta = params.and_then(|p| p.get("_meta")).filter(|m| m.is_object())?;
+    let bytes = serde_json::to_vec(meta).map(|v| v.len()).unwrap_or(usize::MAX);
+    if bytes > MAX_SESSION_META_BYTES {
+        warn!(
+            bytes,
+            max = MAX_SESSION_META_BYTES,
+            "ACP: session _meta exceeds size cap; dropped"
+        );
+        return None;
+    }
+    Some(meta.clone())
+}
+
+/// Env gate for the ACP passthrough (`OPENAB_ACP_MCP_SERVERS=true|1`): http
+/// mcpServers entries and the session `_meta` object. Read once per connection;
+/// handlers take the value as a parameter so tests never mutate process env.
 fn acp_mcp_servers_enabled() -> bool {
     std::env::var("OPENAB_ACP_MCP_SERVERS")
         .map(|v| v == "true" || v == "1")
@@ -1609,13 +1633,17 @@ async fn handle_acp_connection(state: Arc<crate::AppState>, socket: WebSocket) {
                         continue;
                     }
                 };
-                let http_mcp_servers = if mcp_enabled {
-                    parse_http_mcp_servers(req.params.as_ref())
+                let (http_mcp_servers, session_meta) = if mcp_enabled {
+                    (
+                        parse_http_mcp_servers(req.params.as_ref()),
+                        parse_session_meta(req.params.as_ref()),
+                    )
                 } else {
-                    Vec::new()
+                    (Vec::new(), None)
                 };
                 let (resp, channel_id) =
-                    handle_session_new(&sessions, id.clone(), http_mcp_servers).await;
+                    handle_session_new(&sessions, id.clone(), http_mcp_servers, session_meta)
+                        .await;
                 let _ = out_tx.send(serde_json::to_string(&resp).unwrap());
 
                 // If the client declared "type":"acp" MCP servers, open + register a tunnel to
@@ -2035,9 +2063,10 @@ fn handle_initialize(req: &JsonRpcRequest, mcp_http: bool) -> JsonRpcResponse {
 async fn handle_session_new(
     sessions: &Arc<tokio::sync::Mutex<HashMap<String, AcpSession>>>,
     id: Value,
-    // Parsed http-type mcpServers entries to store on the session (already env-gated
-    // and capped by the caller).
+    // Parsed http-type mcpServers entries and `_meta` object to store on the
+    // session (already env-gated and capped by the caller).
     mcp_servers: Vec<serde_json::Value>,
+    session_meta: Option<serde_json::Value>,
 ) -> (JsonRpcResponse, String) {
     // sessionId and channel_id share one uuid so channel_id is always
     // re-derivable from a persisted sessionId (see session/resume).
@@ -2052,6 +2081,7 @@ async fn handle_session_new(
             busy: false,
             cancel: None,
             mcp_servers,
+            session_meta,
         },
     );
 
@@ -2175,6 +2205,20 @@ async fn handle_session_resume(
             .map(|s| s.mcp_servers.clone())
             .unwrap_or_default()
     };
+    // Likewise for `_meta`: only a real OBJECT replaces the stored one (an
+    // oversized one is dropped, not a withdrawal); absent/null/malformed keeps it.
+    let stored_meta = guard.get(&session_id).and_then(|s| s.session_meta.clone());
+    let declared_object = matches!(
+        params.and_then(|p| p.get("_meta")),
+        Some(Value::Object(_))
+    );
+    let session_meta = if !mcp_enabled {
+        None
+    } else if declared_object {
+        parse_session_meta(params).or(stored_meta)
+    } else {
+        stored_meta
+    };
     guard.insert(
         session_id.clone(),
         AcpSession {
@@ -2182,6 +2226,7 @@ async fn handle_session_resume(
             busy: false,
             cancel: None,
             mcp_servers,
+            session_meta,
         },
     );
     drop(guard);
@@ -2336,9 +2381,9 @@ async fn handle_session_prompt(
     };
 
     // The session was reserved a moment ago under the lock; just read its channel_id
-    // and stored http mcpServers entries.
-    let (channel_id, mcp_servers) = match sessions.lock().await.get(&session_id) {
-        Some(s) => (s.channel_id.clone(), s.mcp_servers.clone()),
+    // and stored passthrough values (http mcpServers entries, `_meta`).
+    let (channel_id, mcp_servers, session_meta) = match sessions.lock().await.get(&session_id) {
+        Some(s) => (s.channel_id.clone(), s.mcp_servers.clone(), s.session_meta.clone()),
         None => {
             let resp =
                 JsonRpcResponse::error(
@@ -2361,6 +2406,7 @@ async fn handle_session_prompt(
             channel_type: "dm".into(),
             thread_id: None,
             mcp_servers,
+            session_meta,
         },
         SenderInfo {
             id: "acp_client".into(),
@@ -3642,8 +3688,8 @@ mod acp_requests {
 mod acp_handlers {
     use super::{
         handle_initialize, handle_session_new, handle_session_resume, parse_acp_mcp_servers,
-        parse_http_mcp_servers, AcpMcpServer, AcpSession, JsonRpcRequest,
-        MAX_ACP_SERVERS_PER_SESSION,
+        parse_http_mcp_servers, parse_session_meta, AcpMcpServer, AcpSession, JsonRpcRequest,
+        MAX_ACP_SERVERS_PER_SESSION, MAX_SESSION_META_BYTES,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -3710,7 +3756,7 @@ mod acp_handlers {
     async fn session_new_mints_and_stores_a_session() {
         let sessions = new_sessions();
         let v =
-            serde_json::to_value(handle_session_new(&sessions, json!(2), Vec::new()).await.0).unwrap();
+            serde_json::to_value(handle_session_new(&sessions, json!(2), Vec::new(), None).await.0).unwrap();
         let sid = v["result"]["sessionId"].as_str().unwrap();
         assert!(sid.starts_with("sess_"), "sessionId must be sess_<uuid>: {sid}");
         assert!(sessions.lock().await.contains_key(sid), "session must be stored");
@@ -3774,7 +3820,7 @@ mod acp_handlers {
         let sessions = new_sessions();
         let server = json!({"type": "http", "name": "creds", "url": "https://x/mcp"});
         let v = serde_json::to_value(
-            handle_session_new(&sessions, json!(2), vec![server.clone()]).await.0,
+            handle_session_new(&sessions, json!(2), vec![server.clone()], None).await.0,
         )
         .unwrap();
         let sid = v["result"]["sessionId"].as_str().unwrap().to_string();
@@ -3786,7 +3832,7 @@ mod acp_handlers {
         let sessions = new_sessions();
         let server = json!({"type": "http", "name": "creds", "url": "https://x/mcp"});
         let v = serde_json::to_value(
-            handle_session_new(&sessions, json!(1), vec![server.clone()]).await.0,
+            handle_session_new(&sessions, json!(1), vec![server.clone()], None).await.0,
         )
         .unwrap();
         let sid = v["result"]["sessionId"].as_str().unwrap().to_string();
@@ -3818,6 +3864,80 @@ mod acp_handlers {
         });
         handle_session_resume(&sessions, json!(1), Some(&p), false).await;
         assert!(sessions.lock().await.get(&sid).unwrap().mcp_servers.is_empty());
+    }
+
+    #[test]
+    fn parse_session_meta_keeps_objects_verbatim_and_caps_size() {
+        let meta = json!({"systemPrompt": "be terse", "nested": {"k": [1, 2]}});
+        let params = json!({"cwd": "/w", "mcpServers": [], "_meta": meta});
+        assert_eq!(parse_session_meta(Some(&params)), Some(meta));
+        assert_eq!(parse_session_meta(Some(&json!({"cwd": "/w"}))), None);
+        assert_eq!(parse_session_meta(Some(&json!({"_meta": null}))), None);
+        assert_eq!(parse_session_meta(Some(&json!({"_meta": "str"}))), None);
+        assert_eq!(parse_session_meta(Some(&json!({"_meta": [1]}))), None);
+        assert_eq!(parse_session_meta(None), None);
+
+        // Oversized objects are dropped, not truncated.
+        let big = json!({"systemPrompt": "x".repeat(MAX_SESSION_META_BYTES + 1)});
+        assert_eq!(parse_session_meta(Some(&json!({"_meta": big}))), None);
+        let fits = json!({"systemPrompt": "x".repeat(MAX_SESSION_META_BYTES - 64)});
+        assert_eq!(parse_session_meta(Some(&json!({"_meta": fits}))), Some(fits));
+    }
+
+    #[tokio::test]
+    async fn session_new_stores_session_meta_on_the_session() {
+        let sessions = new_sessions();
+        let meta = json!({"systemPrompt": "be terse"});
+        let v = serde_json::to_value(
+            handle_session_new(&sessions, json!(2), Vec::new(), Some(meta.clone())).await.0,
+        )
+        .unwrap();
+        let sid = v["result"]["sessionId"].as_str().unwrap().to_string();
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, Some(meta));
+    }
+
+    #[tokio::test]
+    async fn resume_absent_meta_keeps_stored_and_present_replaces() {
+        let sessions = new_sessions();
+        let meta = json!({"systemPrompt": "v1"});
+        let v = serde_json::to_value(
+            handle_session_new(&sessions, json!(1), Vec::new(), Some(meta.clone())).await.0,
+        )
+        .unwrap();
+        let sid = v["result"]["sessionId"].as_str().unwrap().to_string();
+
+        // Omitted _meta: the client said nothing → the stored object survives.
+        let absent = json!({"sessionId": sid, "cwd": "/w"});
+        handle_session_resume(&sessions, json!(2), Some(&absent), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, Some(meta.clone()));
+
+        // Null / non-object is next to absent, not a replacement.
+        let null = json!({"sessionId": sid, "cwd": "/w", "_meta": null});
+        handle_session_resume(&sessions, json!(3), Some(&null), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, Some(meta.clone()));
+
+        // An oversized object is dropped, which is not a withdrawal either.
+        let big = json!({"sessionId": sid, "cwd": "/w", "_meta": {"systemPrompt": "x".repeat(MAX_SESSION_META_BYTES + 1)}});
+        handle_session_resume(&sessions, json!(4), Some(&big), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, Some(meta.clone()));
+
+        // A present object replaces the stored one (an empty {} included).
+        let v2 = json!({"systemPrompt": "v2"});
+        let present = json!({"sessionId": sid, "cwd": "/w", "_meta": v2});
+        handle_session_resume(&sessions, json!(5), Some(&present), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, Some(v2));
+        let empty = json!({"sessionId": sid, "cwd": "/w", "_meta": {}});
+        handle_session_resume(&sessions, json!(6), Some(&empty), true).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, Some(json!({})));
+    }
+
+    #[tokio::test]
+    async fn resume_with_gate_disabled_stores_no_meta() {
+        let sessions = new_sessions();
+        let sid = format!("sess_{}", Uuid::new_v4());
+        let p = json!({"sessionId": sid, "cwd": "/w", "_meta": {"systemPrompt": "x"}});
+        handle_session_resume(&sessions, json!(1), Some(&p), false).await;
+        assert_eq!(sessions.lock().await.get(&sid).unwrap().session_meta, None);
     }
 
     #[test]
@@ -4084,6 +4204,7 @@ mod acp_review_fixes {
                 busy: true,
                 cancel: Some(Arc::new(tokio::sync::Notify::new())),
                 mcp_servers: Vec::new(),
+                session_meta: None,
             },
         );
         let (resp, chan) =
@@ -4270,6 +4391,7 @@ mod acp_review_fixes {
                 busy: true,
                 cancel: Some(cancel.clone()),
                 mcp_servers: Vec::new(),
+                session_meta: None,
             },
         );
         // Cancel arrives before the handler's stream loop (reserved-then-immediate-cancel).
@@ -4318,7 +4440,7 @@ mod acp_review_fixes {
             "headers": [{"name": "Authorization", "value": "Bearer t"}]
         });
         let (resp, _channel) =
-            handle_session_new(&sessions, json!(1), vec![server.clone()]).await;
+            handle_session_new(&sessions, json!(1), vec![server.clone()], None).await;
         let sid = serde_json::to_value(resp).unwrap()["result"]["sessionId"]
             .as_str()
             .unwrap()
@@ -4358,7 +4480,7 @@ mod acp_review_fixes {
         let state = Arc::new(st);
 
         let sessions = sessions_map();
-        let (resp, _channel) = handle_session_new(&sessions, json!(1), Vec::new()).await;
+        let (resp, _channel) = handle_session_new(&sessions, json!(1), Vec::new(), None).await;
         let sid = serde_json::to_value(resp).unwrap()["result"]["sessionId"]
             .as_str()
             .unwrap()
@@ -4383,6 +4505,50 @@ mod acp_review_fixes {
             event["channel"].get("mcp_servers").is_none(),
             "an empty set must not appear on the wire: {event}"
         );
+        assert!(
+            event["channel"].get("session_meta").is_none(),
+            "an absent _meta must not appear on the wire: {event}"
+        );
+    }
+
+    // The session `_meta` stored at session/new rides every prompt's GatewayEvent as
+    // `channel.session_meta`, so core can forward it to the inner agent session.
+    #[tokio::test]
+    async fn prompt_event_carries_the_sessions_stored_meta() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel::<String>(16);
+        let mut st = crate::AppState::test_default(event_tx);
+        st.acp_reply_registry = Some(new_reply_registry());
+        let state = Arc::new(st);
+
+        let sessions = sessions_map();
+        let meta = json!({"systemPrompt": "be terse", "nested": {"k": [1, 2]}});
+        let (resp, _channel) =
+            handle_session_new(&sessions, json!(1), Vec::new(), Some(meta.clone())).await;
+        let sid = serde_json::to_value(resp).unwrap()["result"]["sessionId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let cancel = Arc::new(tokio::sync::Notify::new());
+        {
+            let mut g = sessions.lock().await;
+            let s = g.get_mut(&sid).unwrap();
+            s.busy = true;
+            s.cancel = Some(cancel.clone());
+        }
+        cancel.notify_one();
+
+        let (out_tx, _out_rx) = mpsc::unbounded_channel::<String>();
+        let params = json!({"sessionId": sid, "prompt": [{"type": "text", "text": "hi"}]});
+        handle_session_prompt(&state, &sessions, json!(7), Some(&params), &out_tx, sid.clone(), cancel, "conn-test", 0)
+            .await;
+
+        let event_json = event_rx.try_recv().expect("prompt must dispatch a GatewayEvent");
+        let event: serde_json::Value = serde_json::from_str(&event_json).unwrap();
+        assert_eq!(
+            event["channel"]["session_meta"],
+            meta,
+            "the stored _meta must ride the event verbatim"
+        );
     }
 
     // R16-F2 — session/resume on a session with a prompt in flight is rejected (busy), so the
@@ -4399,6 +4565,7 @@ mod acp_review_fixes {
                 busy: true,
                 cancel: Some(cancel.clone()),
                 mcp_servers: Vec::new(),
+                session_meta: None,
             },
         );
 
@@ -4436,7 +4603,7 @@ mod acp_review_fixes {
         let cancel = Arc::new(tokio::sync::Notify::new());
         sessions.lock().await.insert(
             sid.clone(),
-            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()), mcp_servers: Vec::new() },
+            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()), mcp_servers: Vec::new(), session_meta: None },
         );
 
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
@@ -4498,7 +4665,7 @@ mod acp_review_fixes {
         let cancel = Arc::new(tokio::sync::Notify::new());
         sessions.lock().await.insert(
             sid.clone(),
-            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()), mcp_servers: Vec::new() },
+            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()), mcp_servers: Vec::new(), session_meta: None },
         );
 
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
@@ -4593,6 +4760,7 @@ mod acp_review_fixes {
                 busy: true,
                 cancel: Some(cancel.clone()),
                 mcp_servers: Vec::new(),
+                session_meta: None,
             },
         );
         let params = json!({"sessionId": sid});

--- a/crates/openab-gateway/src/adapters/acp_server.rs
+++ b/crates/openab-gateway/src/adapters/acp_server.rs
@@ -4480,6 +4480,86 @@ mod acp_review_fixes {
         assert_eq!(final_stop.as_deref(), Some("end_turn"), "a completed turn ends end_turn");
     }
 
+    // Streamed `edit_message` snapshots and `agent_update` relays must reach the client
+    // in exactly the order handle_reply saw them, and a terminal `send_message` that
+    // repeats the last snapshot must diff to nothing (no duplicate tail) while still
+    // completing the turn with the session/prompt response.
+    #[tokio::test]
+    async fn streamed_deltas_interleave_in_order_and_terminal_snapshot_dedupes() {
+        let (event_tx, _event_rx) = tokio::sync::broadcast::channel::<String>(16);
+        let registry = new_reply_registry();
+        let mut st = crate::AppState::test_default(event_tx);
+        st.acp_reply_registry = Some(registry.clone());
+        let state = Arc::new(st);
+
+        let sessions = sessions_map();
+        let sid = format!("sess_{}", Uuid::new_v4());
+        let channel_id = format!("acp_{}", Uuid::new_v4());
+        let cancel = Arc::new(tokio::sync::Notify::new());
+        sessions.lock().await.insert(
+            sid.clone(),
+            AcpSession { channel_id: channel_id.clone(), busy: true, cancel: Some(cancel.clone()), mcp_servers: Vec::new() },
+        );
+
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
+        let st2 = state.clone();
+        let sessions2 = sessions.clone();
+        let sid2 = sid.clone();
+        let handle = tokio::spawn(async move {
+            let params = json!({"sessionId": sid2, "prompt": [{"type": "text", "text": "hi"}]});
+            handle_session_prompt(&st2, &sessions2, json!(12), Some(&params), &out_tx, sid2.clone(), cancel, "conn-test", 0)
+                .await;
+        });
+
+        let mut turn_id = None;
+        for _ in 0..10_000 {
+            if let Some(t) = registry.lock().unwrap().get(&channel_id).map(|s| s.turn_id.clone()) {
+                turn_id = Some(t);
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let turn_id = turn_id.expect("handler must register a reply sink");
+
+        // Mid-turn snapshots carry the "draft" placeholder id; updates carry the turn id.
+        let tool_call = json!({"sessionUpdate": "tool_call", "toolCallId": "t1", "title": "check", "status": "pending"});
+        let thought = json!({"sessionUpdate": "agent_thought_chunk", "content": {"type": "text", "text": "hmm"}});
+        handle_reply(&reply(&channel_id, "draft", "Linode C", Some("edit_message")), &registry).await;
+        handle_reply(&reply(&channel_id, &turn_id, &tool_call.to_string(), Some("agent_update")), &registry).await;
+        handle_reply(&reply(&channel_id, "draft", "Linode CLI ok", Some("edit_message")), &registry).await;
+        handle_reply(&reply(&channel_id, &turn_id, &thought.to_string(), Some("agent_update")), &registry).await;
+        // Terminal reply repeats the last snapshot verbatim — must emit no new chunk.
+        handle_reply(&reply(&channel_id, &turn_id, "Linode CLI ok", Some("send_message")), &registry).await;
+        handle.await.unwrap();
+
+        let mut updates: Vec<(String, String)> = Vec::new();
+        let mut final_stop = None;
+        while let Ok(s) = out_rx.try_recv() {
+            let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+            if v["method"] == json!("session/update") {
+                let u = &v["params"]["update"];
+                updates.push((
+                    u["sessionUpdate"].as_str().unwrap_or("").to_string(),
+                    u["content"]["text"].as_str().unwrap_or("").to_string(),
+                ));
+            }
+            if v.get("id") == Some(&json!(12)) {
+                final_stop = v["result"]["stopReason"].as_str().map(str::to_string);
+            }
+        }
+        let expected = vec![
+            ("agent_message_chunk".to_string(), "Linode C".to_string()),
+            ("tool_call".to_string(), String::new()),
+            ("agent_message_chunk".to_string(), "LI ok".to_string()),
+            ("agent_thought_chunk".to_string(), "hmm".to_string()),
+        ];
+        assert_eq!(
+            updates, expected,
+            "session updates must preserve arrival order with no duplicate terminal chunk"
+        );
+        assert_eq!(final_stop.as_deref(), Some("end_turn"), "turn must still complete via the prompt response");
+    }
+
     // R17-F3c — a request-shaped `session/cancel` (id present) must NOT be acknowledged with
     // an empty success frame. ACP defines cancel as notification-only, so a request form is a
     // protocol violation → -32600 invalid request, and the cancel signal is not fired.

--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -604,6 +604,7 @@ mod event_types {
                 channel_type: channel_type.to_string(),
                 thread_id,
                 mcp_servers: Vec::new(),
+                session_meta: None,
             },
             SenderInfo {
                 id: sender_open_id.to_string(),

--- a/crates/openab-gateway/src/adapters/feishu.rs
+++ b/crates/openab-gateway/src/adapters/feishu.rs
@@ -603,6 +603,7 @@ mod event_types {
                 id: chat_id.to_string(),
                 channel_type: channel_type.to_string(),
                 thread_id,
+                mcp_servers: Vec::new(),
             },
             SenderInfo {
                 id: sender_open_id.to_string(),

--- a/crates/openab-gateway/src/adapters/googlechat.rs
+++ b/crates/openab-gateway/src/adapters/googlechat.rs
@@ -732,6 +732,7 @@ fn send_googlechat_event(
             id: space_name.to_string(),
             channel_type: space_type,
             thread_id,
+            mcp_servers: Vec::new(),
         },
         SenderInfo {
             id: sender_id.to_string(),

--- a/crates/openab-gateway/src/adapters/googlechat.rs
+++ b/crates/openab-gateway/src/adapters/googlechat.rs
@@ -733,6 +733,7 @@ fn send_googlechat_event(
             channel_type: space_type,
             thread_id,
             mcp_servers: Vec::new(),
+            session_meta: None,
         },
         SenderInfo {
             id: sender_id.to_string(),

--- a/crates/openab-gateway/src/adapters/line.rs
+++ b/crates/openab-gateway/src/adapters/line.rs
@@ -384,6 +384,7 @@ async fn build_gateway_event_from_line_event(
             channel_type,
             thread_id: None,
             mcp_servers: Vec::new(),
+            session_meta: None,
         },
         SenderInfo {
             id: user_id.into(),

--- a/crates/openab-gateway/src/adapters/line.rs
+++ b/crates/openab-gateway/src/adapters/line.rs
@@ -383,6 +383,7 @@ async fn build_gateway_event_from_line_event(
             id: channel_id,
             channel_type,
             thread_id: None,
+            mcp_servers: Vec::new(),
         },
         SenderInfo {
             id: user_id.into(),

--- a/crates/openab-gateway/src/adapters/lineworks.rs
+++ b/crates/openab-gateway/src/adapters/lineworks.rs
@@ -973,6 +973,7 @@ fn classify_event(event: &LineWorksEvent) -> Option<(GatewayEvent, Option<Pendin
             id: channel_id,
             channel_type,
             thread_id: None,
+            mcp_servers: Vec::new(),
         },
         SenderInfo {
             id: user_id.into(),

--- a/crates/openab-gateway/src/adapters/lineworks.rs
+++ b/crates/openab-gateway/src/adapters/lineworks.rs
@@ -974,6 +974,7 @@ fn classify_event(event: &LineWorksEvent) -> Option<(GatewayEvent, Option<Pendin
             channel_type,
             thread_id: None,
             mcp_servers: Vec::new(),
+            session_meta: None,
         },
         SenderInfo {
             id: user_id.into(),

--- a/crates/openab-gateway/src/adapters/teams.rs
+++ b/crates/openab-gateway/src/adapters/teams.rs
@@ -533,6 +533,7 @@ pub async fn webhook(
             channel_type: conversation_type.to_string(),
             thread_id: None, // Teams conversations don't have sub-threads in the same way
             mcp_servers: Vec::new(),
+            session_meta: None,
         },
         SenderInfo {
             id: sender_id.to_string(),

--- a/crates/openab-gateway/src/adapters/teams.rs
+++ b/crates/openab-gateway/src/adapters/teams.rs
@@ -532,6 +532,7 @@ pub async fn webhook(
             id: conversation_id.to_string(),
             channel_type: conversation_type.to_string(),
             thread_id: None, // Teams conversations don't have sub-threads in the same way
+            mcp_servers: Vec::new(),
         },
         SenderInfo {
             id: sender_id.to_string(),

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -209,6 +209,7 @@ pub async fn webhook(
             id: msg.chat.id.to_string(),
             channel_type: msg.chat.chat_type.clone(),
             thread_id: msg.message_thread_id.map(|id| id.to_string()),
+            mcp_servers: Vec::new(),
         },
         SenderInfo {
             id: from.map(|u| u.id.to_string()).unwrap_or_default(),

--- a/crates/openab-gateway/src/adapters/telegram.rs
+++ b/crates/openab-gateway/src/adapters/telegram.rs
@@ -210,6 +210,7 @@ pub async fn webhook(
             channel_type: msg.chat.chat_type.clone(),
             thread_id: msg.message_thread_id.map(|id| id.to_string()),
             mcp_servers: Vec::new(),
+            session_meta: None,
         },
         SenderInfo {
             id: from.map(|u| u.id.to_string()).unwrap_or_default(),

--- a/crates/openab-gateway/src/adapters/wecom.rs
+++ b/crates/openab-gateway/src/adapters/wecom.rs
@@ -1063,6 +1063,7 @@ pub async fn webhook(
             id: channel_id,
             channel_type: "direct".into(),
             thread_id: None,
+            mcp_servers: Vec::new(),
         },
         crate::schema::SenderInfo {
             id: msg.from_user.clone(),

--- a/crates/openab-gateway/src/adapters/wecom.rs
+++ b/crates/openab-gateway/src/adapters/wecom.rs
@@ -1064,6 +1064,7 @@ pub async fn webhook(
             channel_type: "direct".into(),
             thread_id: None,
             mcp_servers: Vec::new(),
+            session_meta: None,
         },
         crate::schema::SenderInfo {
             id: msg.from_user.clone(),

--- a/crates/openab-gateway/src/schema.rs
+++ b/crates/openab-gateway/src/schema.rs
@@ -26,6 +26,10 @@ pub struct ChannelInfo {
     /// agent session (ACP passthrough only; empty for every other platform).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mcp_servers: Vec<serde_json::Value>,
+    /// Client-supplied session `_meta` object forwarded verbatim to the inner
+    /// agent session (ACP passthrough only; `None` for every other platform).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_meta: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/openab-gateway/src/schema.rs
+++ b/crates/openab-gateway/src/schema.rs
@@ -22,6 +22,10 @@ pub struct ChannelInfo {
     #[serde(rename = "type")]
     pub channel_type: String,
     pub thread_id: Option<String>,
+    /// Client-declared `"type":"http"` MCP servers forwarded verbatim to the inner
+    /// agent session (ACP passthrough only; empty for every other platform).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mcp_servers: Vec<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,8 +320,11 @@ fn platform_trust_override(
     }
 }
 
+static PROCESS_STARTED: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let _ = PROCESS_STARTED.set(std::time::Instant::now());
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -1324,8 +1327,9 @@ async fn main() -> anyhow::Result<()> {
             gw_state.warn_unenforceable_l1(true);
 
             // Build axum router with platform webhook routes
-            let mut app =
-                axum::Router::new().route("/health", axum::routing::get(|| async { "ok" }));
+            let mut app = axum::Router::new()
+                .route("/health", axum::routing::get(|| async { "ok" }))
+                .route("/statusz", axum::routing::get(statusz));
 
             #[cfg(feature = "telegram")]
             if gw_state.telegram_bot_token.is_some() {
@@ -2084,4 +2088,35 @@ agent_id = "1000002"
 
         assert_eq!(has_unified_wecom_config(&cfg), cfg!(feature = "wecom"));
     }
+}
+
+
+/// Minimal machine-readable status for the ACP sandbox consumer (uptime,
+/// live ACP connections, running claude-agent-acp child processes). Read-only
+/// and unauthenticated like /health — expose it only on trusted networks.
+async fn statusz() -> axum::Json<serde_json::Value> {
+    let started = *PROCESS_STARTED.get_or_init(std::time::Instant::now);
+
+    let mut agent_processes = 0u32;
+    if let Ok(entries) = std::fs::read_dir("/proc") {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(pid) = name.to_str().filter(|n| n.chars().all(|c| c.is_ascii_digit())) else {
+                continue;
+            };
+            if let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) {
+                if String::from_utf8_lossy(&cmdline).contains("claude-agent-acp") {
+                    agent_processes += 1;
+                }
+            }
+        }
+    }
+
+    axum::Json(serde_json::json!({
+        "status": "ok",
+        "uptime_seconds": started.elapsed().as_secs(),
+        "acp_connections": openab_gateway::adapters::acp_server::ACP_ACTIVE_CONNECTIONS
+            .load(std::sync::atomic::Ordering::Relaxed),
+        "agent_processes": agent_processes,
+    }))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2094,6 +2094,16 @@ agent_id = "1000002"
 /// Minimal machine-readable status for the ACP sandbox consumer (uptime,
 /// live ACP connections, running claude-agent-acp child processes). Read-only
 /// and unauthenticated like /health — expose it only on trusted networks.
+#[cfg(any(
+    feature = "telegram",
+    feature = "line",
+    feature = "feishu",
+    feature = "googlechat",
+    feature = "wecom",
+    feature = "teams",
+    feature = "acp",
+    feature = "lineworks",
+))]
 async fn statusz() -> axum::Json<serde_json::Value> {
     let started = *PROCESS_STARTED.get_or_init(std::time::Instant::now);
 
@@ -2112,11 +2122,16 @@ async fn statusz() -> axum::Json<serde_json::Value> {
         }
     }
 
+    #[cfg(feature = "acp")]
+    let acp_connections = openab_gateway::adapters::acp_server::ACP_ACTIVE_CONNECTIONS
+        .load(std::sync::atomic::Ordering::Relaxed);
+    #[cfg(not(feature = "acp"))]
+    let acp_connections = 0;
+
     axum::Json(serde_json::json!({
         "status": "ok",
         "uptime_seconds": started.elapsed().as_secs(),
-        "acp_connections": openab_gateway::adapters::acp_server::ACP_ACTIVE_CONNECTIONS
-            .load(std::sync::atomic::Ordering::Relaxed),
+        "acp_connections": acp_connections,
         "agent_processes": agent_processes,
     }))
 }

--- a/src/unified_adapter.rs
+++ b/src/unified_adapter.rs
@@ -199,6 +199,16 @@ impl ChatAdapter for UnifiedGatewayAdapter {
         Ok(())
     }
 
+    async fn forward_agent_update(
+        &self,
+        channel: &ChannelRef,
+        update: serde_json::Value,
+    ) -> Result<()> {
+        let reply = self.build_reply(channel, &update.to_string(), Some("agent_update"), None);
+        self.dispatch_reply(&reply).await;
+        Ok(())
+    }
+
     async fn edit_message(&self, msg: &MessageRef, content: &str) -> Result<()> {
         let mut reply = self.build_reply(&msg.channel, content, Some("edit_message"), None);
         // Use the actual platform message_id (e.g. "draft" for streaming, or numeric for edits)


### PR DESCRIPTION
## Summary

Two small changes that enable live streaming over the ACP server path. Today the whole reply reaches an ACP client as a single terminal `agent_message_chunk`, even though the underlying agent (e.g. `claude-agent-acp` with `includePartialMessages: true`) streams partial chunks continuously.

1. **`feat(acp): opt-in live streaming via OPENAB_ACP_STREAMING`**
   `AdapterRouter` hard-codes `streaming = false` for `platform == "acp"`. This keeps that default but lets a deployment opt in with `OPENAB_ACP_STREAMING=true|1`, re-using the existing snapshot edit loop — the ACP server already converts growing `edit_message` snapshots into append-only deltas via `stream_delta`.

2. **`fix(acp): deliver streaming edit snapshots through the stale-reply fence`**
   With streaming enabled, mid-turn `edit_message` replies still never reach the client: the unified adapter overrides `reply_to` with the placeholder `MessageRef` id, which is the dummy `"draft"` (ACP shows no placeholder message), and the ACP server's stale-reply fence only passes an empty `reply_to` or the active `turn_id` — so every snapshot is dropped as stale and only the final `send_message` (which carries `origin_event_id`) gets through. The fence now also fails open for `"draft"`, which in the ACP path can only originate from the streaming edit loop. Telegram draft behavior is untouched.

## Behavior

- Default (`OPENAB_ACP_STREAMING` unset): unchanged — send-once, single terminal chunk.
- Opted in: clients receive append-only `agent_message_chunk` deltas at the edit-loop cadence (~1.5s), then the final tail, then the normal `PromptResponse`.

## Testing

Verified against a live `Dockerfile.unified --target claude` container driven by an external ACP client:
- without the second commit, streaming mode still delivered one terminal chunk and the logs showed `ACP dropping stale reply from a superseded turn` every ~1.5s during generation;
- with both commits, a ~2,600-char reply arrived as 9 append-only deltas ~1.5s apart followed by the correct stop reason, and concatenated deltas matched the final text;
- default (flag unset) still delivers the single terminal chunk (send-once unchanged).
