### PR TITLE
ci(nightly): add nightly build channel tracking latest agent CLIs

### DIFF
--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -158,6 +158,17 @@ jobs:
               grep -Fx "$expected" "$file"
             done
           }
+          assert_count() {
+            local expected_count="$1"
+            local expected_line="$2"
+            local file="$3"
+            local actual_count
+            actual_count=$(grep -Fxc "$expected_line" "$file" || true)
+            [ "$actual_count" -eq "$expected_count" ] || {
+              echo "Expected $expected_count copies of '$expected_line' in $file, found $actual_count" >&2
+              exit 1
+            }
+          }
 
           assert_line 'ARG KIRO_CLI_VERSION=2.13.0' Dockerfile Dockerfile.package Dockerfile.unified
           assert_line 'ARG KIRO_SHA256_AMD64=d8c5277358b4a82b2d9a9ed2d52e110862536dc82b9e32c3719fc5f5a9834c94' Dockerfile Dockerfile.package Dockerfile.unified
@@ -168,6 +179,18 @@ jobs:
           assert_line 'ARG DEVIN_VERSION=3000.2.17' Dockerfile.devin Dockerfile.package Dockerfile.unified
           assert_line 'ARG DEVIN_SHA256_AMD64=f0e1e9363afc6ee68c4ef87bab4aeb7ff5cc08a5fa838350ef3ceefdbb2a2be2' Dockerfile.devin Dockerfile.package Dockerfile.unified
           assert_line 'ARG DEVIN_SHA256_ARM64=116dc71ef085a922bc3ff0ea0377d4b26c529a431d58246e36572913e2d25624' Dockerfile.devin Dockerfile.package Dockerfile.unified
-          assert_line 'ENV AGY_VERSION=1.1.13' Dockerfile.antigravity Dockerfile.package Dockerfile.unified Dockerfile.final Dockerfile.ci
+          assert_line 'ENV AGY_VERSION=1.1.13' Dockerfile.antigravity Dockerfile.unified Dockerfile.final Dockerfile.ci
+          assert_line 'ARG AGY_VERSION=1.1.13' Dockerfile.package
+          assert_line 'ENV AGY_VERSION="${AGY_VERSION}"' Dockerfile.package
+          assert_line 'LABEL dev.openab.agy.version="${AGY_VERSION}"' Dockerfile.package
           assert_line 'ARG AGY_SHA256_AMD64=edc7c32b5ab4fc2e4da03381fee83ed566dea6b56b56f9329cd13cd77947a1d9' Dockerfile.antigravity Dockerfile.package Dockerfile.unified Dockerfile.final Dockerfile.ci
           assert_line 'ARG AGY_SHA256_ARM64=a9fdd2a386770c27dbf784436bd4de70d4d4901c832d5ec6abf27758d5c370f8' Dockerfile.antigravity Dockerfile.package Dockerfile.unified Dockerfile.final Dockerfile.ci
+
+          # Nightly checksum relaxation must be explicit and limited to the two
+          # TLS-only vendor paths. Kiro instead requires a resolved strong ETag;
+          # Devin remains unconditionally checksum-verified.
+          assert_count 2 'ARG ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=false' Dockerfile.package
+          assert_count 2 '          ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=true" ;;' .github/workflows/nightly-build.yml
+          assert_count 2 '    elif [ "$ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS" != "true" ]; then \' Dockerfile.package
+          assert_line '    elif [ -z "$ETAG" ]; then \' Dockerfile.package
+          assert_line '    echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \' Dockerfile.package

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -179,6 +179,9 @@ jobs:
           assert_line 'ARG DEVIN_VERSION=3000.2.17' Dockerfile.devin Dockerfile.package Dockerfile.unified
           assert_line 'ARG DEVIN_SHA256_AMD64=f0e1e9363afc6ee68c4ef87bab4aeb7ff5cc08a5fa838350ef3ceefdbb2a2be2' Dockerfile.devin Dockerfile.package Dockerfile.unified
           assert_line 'ARG DEVIN_SHA256_ARM64=116dc71ef085a922bc3ff0ea0377d4b26c529a431d58246e36572913e2d25624' Dockerfile.devin Dockerfile.package Dockerfile.unified
+          assert_occurrences 1 '--retry 6 --retry-all-errors --retry-delay 10 --retry-max-time 120' Dockerfile.hermes
+          assert_occurrences 1 '--retry 6 --retry-all-errors --retry-delay 10 --retry-max-time 120' Dockerfile.package
+          assert_occurrences 1 '--retry 6 --retry-all-errors --retry-delay 10 --retry-max-time 120' Dockerfile.unified
           assert_line 'ENV AGY_VERSION=1.1.13' Dockerfile.antigravity Dockerfile.unified Dockerfile.final Dockerfile.ci
           assert_line 'ARG AGY_VERSION=1.1.13' Dockerfile.package
           assert_line 'ENV AGY_VERSION="${AGY_VERSION}"' Dockerfile.package

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -158,14 +158,14 @@ jobs:
               grep -Fx "$expected" "$file"
             done
           }
-          assert_count() {
+          assert_occurrences() {
             local expected_count="$1"
-            local expected_line="$2"
+            local needle="$2"
             local file="$3"
             local actual_count
-            actual_count=$(grep -Fxc "$expected_line" "$file" || true)
+            actual_count=$(grep -Fc -- "$needle" "$file" || true)
             [ "$actual_count" -eq "$expected_count" ] || {
-              echo "Expected $expected_count copies of '$expected_line' in $file, found $actual_count" >&2
+              echo "Expected $expected_count occurrences of '$needle' in $file, found $actual_count" >&2
               exit 1
             }
           }
@@ -187,10 +187,27 @@ jobs:
           assert_line 'ARG AGY_SHA256_ARM64=a9fdd2a386770c27dbf784436bd4de70d4d4901c832d5ec6abf27758d5c370f8' Dockerfile.antigravity Dockerfile.package Dockerfile.unified Dockerfile.final Dockerfile.ci
 
           # Nightly checksum relaxation must be explicit and limited to the two
-          # TLS-only vendor paths. Kiro instead requires a resolved strong ETag;
-          # Devin remains unconditionally checksum-verified.
-          assert_count 2 'ARG ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=false' Dockerfile.package
-          assert_count 2 '          ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=true" ;;' .github/workflows/nightly-build.yml
-          assert_count 2 '    elif [ "$ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS" != "true" ]; then \' Dockerfile.package
-          assert_line '    elif [ -z "$ETAG" ]; then \' Dockerfile.package
-          assert_line '    echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \' Dockerfile.package
+          # TLS-only vendor paths. These substring checks intentionally ignore
+          # indentation, line continuations, and BUILD_ARGS ordering.
+          assert_occurrences 2 'ARG ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=false' Dockerfile.package
+          assert_occurrences 2 'elif [ "$ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS" != "true" ]; then' Dockerfile.package
+          assert_occurrences 1 'elif [ -z "$ETAG" ]; then' Dockerfile.package
+          assert_occurrences 1 'echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c -' Dockerfile.package
+
+          # Parse the resolver case arms so a third variant cannot silently opt
+          # in even if the workflow is reformatted or BUILD_ARGS are reordered.
+          OPT_IN_VARIANTS=$(awk '
+            /^[[:space:]]*[[:alnum:]_-]+\)$/ {
+              variant=$1
+              sub(/\)$/, "", variant)
+            }
+            index($0, "ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=true") {
+              print variant
+            }
+          ' .github/workflows/nightly-build.yml | sort)
+          EXPECTED_OPT_IN_VARIANTS=$(printf 'antigravity\ngrok')
+          [ "$OPT_IN_VARIANTS" = "$EXPECTED_OPT_IN_VARIANTS" ] || {
+            echo "Expected only antigravity and grok nightly opt-ins; found:" >&2
+            printf '%s\n' "$OPT_IN_VARIANTS" >&2
+            exit 1
+          }

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,432 @@
+name: Nightly Build
+
+# Daily builds carrying the *latest* coding CLI for each agent variant.
+#
+# The release and pre-beta channels cannot do this: every variant pins its CLI
+# version as an ARG (and, for binary downloads, a SHA256) inside
+# Dockerfile.package, so rebuilding from main republishes the same CLI however
+# often it runs. This lane compiles the same openab binary from main, then
+# overwrites the agent CLI ARGs with the version each vendor published most
+# recently.
+#
+# Channel contract, deliberately different from pre-beta-build.yml:
+#   - Drop-in, no compatibility guarantee. These images track vendor latest and
+#     may break at any time; they are not a release.
+#   - Freshness over cohort atomicity: each variant publishes independently
+#     (fail-fast: false), so one vendor breaking their latest does not hold back
+#     the rest. A failed variant keeps yesterday's tag; the red job is the alert.
+#   - nightly-<variant> is the moving tag; nightly-YYYYMMDD-<run-id>-<variant>
+#     is the immutable rollback point.
+#   - Release (v*) and pre-beta-* tags and their build path are untouched.
+#
+# native + agentcore are intentionally absent: they carry no coding CLI by
+# definition, so there is nothing to freshen.
+
+on:
+  schedule:
+    # Off-peak, offset from the hour to dodge the scheduler rush.
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+    inputs:
+      variants:
+        description: 'Variants to build (comma-separated, or "all")'
+        required: false
+        type: string
+        default: 'all'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-build
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  # Every agent-CLI variant. native + agentcore excluded: no CLI to freshen.
+  ALL_VARIANTS: 'kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,opencode,antigravity,pi'
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Resolve the variant matrix.
+  # ---------------------------------------------------------------------------
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      variants: ${{ steps.resolve.outputs.variants }}
+    steps:
+      - name: Resolve variant matrix
+        id: resolve
+        env:
+          INPUT_VARIANTS: ${{ inputs.variants }}
+        run: |
+          set -euo pipefail
+          if [ "$INPUT_VARIANTS" = "all" ] || [ -z "$INPUT_VARIANTS" ]; then
+            VARIANTS="$ALL_VARIANTS"
+          else
+            VARIANTS="$INPUT_VARIANTS"
+            for v in $(echo "$VARIANTS" | tr ',' ' '); do
+              v=$(echo "$v" | xargs)
+              if ! echo ",$ALL_VARIANTS," | grep -q ",$v,"; then
+                echo "::error::Unknown or unsupported nightly variant: $v (allowed: $ALL_VARIANTS)"
+                exit 1
+              fi
+            done
+          fi
+          JSON=$(echo "$VARIANTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
+          echo "variants=${JSON}" >> "$GITHUB_OUTPUT"
+          echo "Building: $VARIANTS"
+
+  # ---------------------------------------------------------------------------
+  # Compile openab (and openab-agent, agy-acp) once per architecture.
+  # Identical to pre-beta-build.yml — the openab binary is built from main; only
+  # the agent CLI layer is freshened. Uploads binaries as artifacts.
+  # ---------------------------------------------------------------------------
+  compile:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable (2026-07-13)
+
+      - name: Cache cargo registry & target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: nightly-compile-${{ matrix.platform.arch }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            nightly-compile-${{ matrix.platform.arch }}-
+
+      - name: Build openab
+        run: cargo build --release --features unified
+
+      - name: Build openab-agent
+        run: cd openab-agent && printf '\n[workspace]\n' >> Cargo.toml && cargo build --release
+
+      # agy-acp/Cargo.toml already declares [workspace] permanently, so no runtime
+      # injection is needed here — unlike openab-agent above.
+      - name: Build agy-acp
+        run: cd agy-acp && cargo build --release
+
+      - name: Collect binaries
+        run: |
+          mkdir -p bins
+          cp target/release/openab bins/
+          cp openab-agent/target/release/openab-agent bins/
+          cp agy-acp/target/release/agy-acp bins/
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-bins-${{ matrix.platform.arch }}
+          path: bins/
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Package: resolve the vendor's latest CLI version, then build a lightweight
+  # image per variant (no Rust compilation) with the resolved version passed as
+  # a build-arg override.
+  # ---------------------------------------------------------------------------
+  build:
+    needs: [matrix, compile]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download pre-built binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-bins-${{ matrix.platform.arch }}
+          path: bin
+
+      - name: Make binaries executable
+        run: chmod +x bin/*
+
+      - name: Resolve the vendor's latest CLI version
+        id: resolve
+        env:
+          # Used only for the Hermes cross-repo Contents API request. An
+          # authenticated fetch avoids the shared-runner 429s seen on
+          # raw.githubusercontent.com, while the resolved commit keeps the
+          # installer immutable.
+          GH_TOKEN: ${{ github.token }}
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+
+          # BUILD_ARGS accumulates the --build-arg overrides fed to buildx.
+          # For SHA-pinned variants we deliberately pass empty SHAs: the
+          # Dockerfile.package check is skipped when the SHA arg is empty
+          # (release/pre-beta still pass their pinned SHAs and stay verified).
+          BUILD_ARGS=""
+
+          github_api() {
+            curl -fsSL --retry 3 --retry-all-errors \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'X-GitHub-Api-Version: 2022-11-28' "$@"
+          }
+
+          # Validate a resolved version string before it reaches a build-arg.
+          check_ver() {
+            case "$1" in
+              ''|null|*[!A-Za-z0-9._+-]*)
+                echo "::error::invalid CLI version for $VARIANT: '$1'"; exit 1 ;;
+            esac
+          }
+
+          case "$VARIANT" in
+            kiro)
+              # No public version index; the vendor serves a `latest` path that
+              # the existing stable/${VERSION}/ URL template resolves to. Version
+              # is learned from the built image, not ahead of time.
+              REPORT="latest (resolved by vendor)"
+              BUILD_ARGS="KIRO_CLI_VERSION=latest
+          KIRO_SHA256_AMD64=
+          KIRO_SHA256_ARM64=" ;;
+            claude)
+              ACP=$(curl -fsSL --retry 3 https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/latest | jq -r .version)
+              CODE=$(curl -fsSL --retry 3 https://registry.npmjs.org/@anthropic-ai/claude-code/latest | jq -r .version)
+              check_ver "$ACP"; check_ver "$CODE"
+              REPORT="claude-agent-acp $ACP + claude-code $CODE"
+              BUILD_ARGS="CLAUDE_AGENT_ACP_VERSION=$ACP
+          CLAUDE_CODE_VERSION=$CODE" ;;
+            codex)
+              ACP=$(curl -fsSL --retry 3 https://registry.npmjs.org/@agentclientprotocol/codex-acp/latest | jq -r .version)
+              CODE=$(curl -fsSL --retry 3 https://registry.npmjs.org/@openai/codex/latest | jq -r .version)
+              check_ver "$ACP"; check_ver "$CODE"
+              REPORT="codex-acp $ACP + codex $CODE"
+              BUILD_ARGS="CODEX_ACP_VERSION=$ACP
+          CODEX_VERSION=$CODE" ;;
+            copilot)
+              V=$(curl -fsSL --retry 3 https://registry.npmjs.org/@github/copilot/latest | jq -r .version)
+              check_ver "$V"; REPORT="copilot $V"
+              BUILD_ARGS="COPILOT_VERSION=$V" ;;
+            gemini)
+              V=$(curl -fsSL --retry 3 https://registry.npmjs.org/@google/gemini-cli/latest | jq -r .version)
+              check_ver "$V"; REPORT="gemini-cli $V"
+              BUILD_ARGS="GEMINI_CLI_VERSION=$V" ;;
+            kimi)
+              V=$(curl -fsSL --retry 3 https://registry.npmjs.org/@moonshot-ai/kimi-code/latest | jq -r .version)
+              check_ver "$V"; REPORT="kimi-code $V"
+              BUILD_ARGS="KIMI_CODE_VERSION=$V" ;;
+            mimocode)
+              V=$(curl -fsSL --retry 3 https://registry.npmjs.org/@mimo-ai/cli/latest | jq -r .version)
+              check_ver "$V"; REPORT="mimo-code $V"
+              BUILD_ARGS="MIMOCODE_VERSION=$V" ;;
+            opencode)
+              V=$(curl -fsSL --retry 3 https://registry.npmjs.org/opencode-ai/latest | jq -r .version)
+              check_ver "$V"; REPORT="opencode $V"
+              BUILD_ARGS="OPENCODE_VERSION=$V" ;;
+            pi)
+              ACP=$(curl -fsSL --retry 3 https://registry.npmjs.org/pi-acp/latest | jq -r .version)
+              CODE=$(curl -fsSL --retry 3 https://registry.npmjs.org/@earendil-works/pi-coding-agent/latest | jq -r .version)
+              check_ver "$ACP"; check_ver "$CODE"
+              REPORT="pi-acp $ACP + pi-coding-agent $CODE"
+              BUILD_ARGS="PI_ACP_VERSION=$ACP
+          PI_CODING_AGENT_VERSION=$CODE" ;;
+            cursor)
+              # The install script embeds the version it would install; there is
+              # no separate version index. Anchored to the download URL shape so
+              # an unrelated mention of the domain cannot match.
+              V=$(curl -fsSL --retry 3 https://cursor.com/install \
+                | grep -oE 'downloads\.cursor\.com/lab/[^/]+/' | head -1 \
+                | sed 's|downloads.cursor.com/lab/||; s|/$||')
+              check_ver "$V"; REPORT="cursor-agent $V"
+              BUILD_ARGS="CURSOR_VERSION=$V" ;;
+            grok)
+              V=$(curl -fsSL --retry 3 https://storage.googleapis.com/grok-build-public-artifacts/cli/stable | tr -d '[:space:]')
+              check_ver "$V"; REPORT="grok $V"
+              BUILD_ARGS="GROK_VERSION=$V
+          GROK_SHA256_AMD64=
+          GROK_SHA256_ARM64=" ;;
+            devin)
+              MANIFEST=$(curl -fsSL --retry 3 https://static.devin.ai/cli/current/manifest.json)
+              V=$(echo "$MANIFEST" | jq -r .version)
+              check_ver "$V"; REPORT="devin $V"
+              # Vendor publishes per-arch sha256; keep the check enabled by
+              # passing the resolved digest for this arch to both args (only the
+              # matching-arch one is consulted by the Dockerfile case).
+              if [ "${{ matrix.platform.arch }}" = "arm64" ]; then
+                SHA=$(echo "$MANIFEST" | jq -r '.platforms["aarch64-unknown-linux"].sha256')
+                BUILD_ARGS="DEVIN_VERSION=$V
+          DEVIN_SHA256_ARM64=$SHA"
+              else
+                SHA=$(echo "$MANIFEST" | jq -r '.platforms["x86_64-unknown-linux"].sha256')
+                BUILD_ARGS="DEVIN_VERSION=$V
+          DEVIN_SHA256_AMD64=$SHA"
+              fi ;;
+            antigravity)
+              V=$(curl -fsSL --retry 3 https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest | jq -r .tag_name)
+              check_ver "$V"; REPORT="antigravity $V"
+              BUILD_ARGS="AGY_VERSION_OVERRIDE=$V
+          AGY_SHA256_AMD64=
+          AGY_SHA256_ARM64=" ;;
+            hermes)
+              # Resolve the release, dereference an annotated tag to its immutable
+              # commit, then pin both the install commit and the installer SHA so
+              # the Dockerfile's SHA check stays enabled.
+              RELEASE=$(github_api https://api.github.com/repos/NousResearch/hermes-agent/releases/latest)
+              TAG=$(echo "$RELEASE" | jq -r .tag_name)
+              REF=$(github_api "https://api.github.com/repos/NousResearch/hermes-agent/git/ref/tags/${TAG}")
+              REF_TYPE=$(echo "$REF" | jq -r .object.type)
+              COMMIT=$(echo "$REF" | jq -r .object.sha)
+              for _ in 1 2 3; do
+                [ "$REF_TYPE" = "tag" ] || break
+                REF=$(github_api "https://api.github.com/repos/NousResearch/hermes-agent/git/tags/${COMMIT}")
+                REF_TYPE=$(echo "$REF" | jq -r .object.type)
+                COMMIT=$(echo "$REF" | jq -r .object.sha)
+              done
+              [ "$REF_TYPE" = "commit" ] || { echo "::error::hermes $TAG did not resolve to a commit"; exit 1; }
+              echo "$COMMIT" | grep -qE '^[0-9a-f]{40}$' || { echo "::error::invalid hermes commit: $COMMIT"; exit 1; }
+              INSTALL_SHA=$(curl -fsSL --retry 3 \
+                "https://raw.githubusercontent.com/NousResearch/hermes-agent/${COMMIT}/scripts/install.sh" \
+                | sha256sum | cut -d' ' -f1)
+              echo "$INSTALL_SHA" | grep -qE '^[0-9a-f]{64}$' || { echo "::error::could not hash hermes installer"; exit 1; }
+              REPORT="hermes $TAG @ $COMMIT"
+              BUILD_ARGS="HERMES_INSTALL_COMMIT=$COMMIT
+          HERMES_INSTALL_SHA256=$INSTALL_SHA" ;;
+            *)
+              echo "::error::no resolver for variant $VARIANT"; exit 1 ;;
+          esac
+
+          echo "Resolved $VARIANT -> $REPORT"
+          echo "report=$REPORT" >> "$GITHUB_OUTPUT"
+          # The BUILD_ARGS literals above are indented for readability; strip any
+          # leading whitespace so each emitted line is a clean KEY=VALUE that
+          # build-push-action's build-args parser accepts. Drop blank lines too.
+          CLEAN_ARGS=$(printf '%s\n' "$BUILD_ARGS" | sed 's/^[[:space:]]*//' | grep -v '^$')
+          # Multi-line output for the build-args block.
+          {
+            echo "build_args<<__BUILD_ARGS_EOF__"
+            echo "$CLEAN_ARGS"
+            echo "__BUILD_ARGS_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.package
+          target: ${{ matrix.variant }}
+          build-contexts: bins=bin
+          platforms: ${{ matrix.platform.os }}
+          build-args: ${{ steps.resolve.outputs.build_args }}
+          # Freshness lane: don't reuse the agent-CLI layer across days, or a
+          # cached layer would defeat the point. The compile stage's binaries
+          # are already built; this only rebuilds the thin CLI layer.
+          no-cache: true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-digests-${{ matrix.variant }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Create the multi-arch manifest and apply the nightly tags per variant.
+  # ---------------------------------------------------------------------------
+  tag:
+    needs: [matrix, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: nightly-digests-${{ matrix.variant }}-*
+          merge-multiple: true
+
+      - name: Validate digest count
+        run: |
+          COUNT=$(ls -1 /tmp/digests/ | wc -l)
+          if [ "$COUNT" -ne 2 ]; then
+            echo "::error::Expected 2 digests (amd64 + arm64) for ${{ matrix.variant }}, got $COUNT"
+            exit 1
+          fi
+          for f in /tmp/digests/*; do
+            name=$(basename "$f")
+            echo "$name" | grep -qE '^[a-f0-9]{64}$' || { echo "::error::invalid digest: $name"; exit 1; }
+          done
+
+      - name: Create manifest and tag
+        env:
+          VARIANT: ${{ matrix.variant }}
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          DATE=$(date -u +%Y%m%d)
+          MOVING="${IMAGE}:nightly-${VARIANT}"
+          IMMUTABLE="${IMAGE}:nightly-${DATE}-${GITHUB_RUN_ID}-${VARIANT}"
+          DIGESTS=$(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+
+          docker buildx imagetools create -t "$MOVING" -t "$IMMUTABLE" ${DIGESTS}
+
+          {
+            echo "### 📦 nightly \`${VARIANT}\`"
+            echo
+            echo '```'
+            echo "$MOVING"
+            echo "$IMMUTABLE"
+            echo '```'
+            echo
+            echo "Drop-in image tracking the vendor's latest CLI. No compatibility guarantee."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -20,7 +20,8 @@ name: Nightly Build
 #   - Release (v*) and pre-beta-* tags and their build path are untouched.
 #
 # native + agentcore are intentionally absent: they carry no coding CLI by
-# definition, so there is nothing to freshen.
+# definition, so there is nothing to freshen. pi is temporarily absent because
+# its existing package target does not ship its configured adapter (#1520).
 
 on:
   schedule:
@@ -71,6 +72,15 @@ jobs:
           else
             VARIANTS="$INPUT_VARIANTS"
           fi
+
+          # Bash field splitting discards a trailing empty field, so reject the
+          # raw delimiter shapes before splitting. Whitespace-only elements are
+          # caught after trimming in the loop below.
+          case "$VARIANTS" in
+            ,*|*,|*,,*)
+              echo "::error::empty variant entry in: $INPUT_VARIANTS"
+              exit 1 ;;
+          esac
 
           # Parse once into a normalized, validated, de-duplicated list. This is
           # the single source the matrix JSON is built from, so empty fields
@@ -203,11 +213,23 @@ jobs:
 
           case "$VARIANT" in
             kiro)
-              # No public version index; the vendor serves a `latest` path that
-              # the existing stable/${VERSION}/ URL template resolves to. Version
-              # is learned from the built image, not ahead of time.
-              REPORT="latest (resolved by vendor)"
+              # Kiro exposes no version index, but its latest objects have strong
+              # ETags and honor If-Match. Resolve both content identifiers once;
+              # Dockerfile.package enforces them during each architecture build.
+              # The tag job additionally requires the installed versions to
+              # match before it creates the multi-arch manifest.
+              kiro_etag() {
+                curl -fsSI --retry 3 --retry-all-errors "$1" \
+                  | sed -n 's/^etag: *//Ip' | tail -1 | tr -d '\r"' | tr '[:upper:]' '[:lower:]'
+              }
+              ETAG_AMD=$(kiro_etag https://prod.download.cli.kiro.dev/stable/latest/kirocli-x86_64-linux.zip)
+              ETAG_ARM=$(kiro_etag https://prod.download.cli.kiro.dev/stable/latest/kirocli-aarch64-linux.zip)
+              echo "$ETAG_AMD" | grep -qE '^[0-9a-f]{32}$' || { echo "::error::invalid Kiro amd64 ETag: $ETAG_AMD"; exit 1; }
+              echo "$ETAG_ARM" | grep -qE '^[0-9a-f]{32}$' || { echo "::error::invalid Kiro arm64 ETag: $ETAG_ARM"; exit 1; }
+              REPORT="latest @ amd64:$ETAG_AMD arm64:$ETAG_ARM"
               BUILD_ARGS="KIRO_CLI_VERSION=latest
+          KIRO_ETAG_AMD64=$ETAG_AMD
+          KIRO_ETAG_ARM64=$ETAG_ARM
           KIRO_SHA256_AMD64=
           KIRO_SHA256_ARM64=" ;;
             claude)
@@ -280,7 +302,8 @@ jobs:
           DEVIN_SHA256_AMD64=$SHA_AMD
           DEVIN_SHA256_ARM64=$SHA_ARM" ;;
             antigravity)
-              V=$(curl -fsSL --retry 3 https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest | jq -r .tag_name)
+              RELEASE=$(github_api https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest)
+              V=$(echo "$RELEASE" | jq -r .tag_name)
               check_ver "$V"; REPORT="antigravity $V"
               BUILD_ARGS="AGY_VERSION_OVERRIDE=$V
           AGY_EFFECTIVE_VERSION=$V
@@ -340,10 +363,12 @@ jobs:
   # ---------------------------------------------------------------------------
   build:
     needs: [matrix, compile, resolve]
+    # A failed vendor resolver must not suppress successful siblings. Override
+    # the default needs-success condition, but still require the shared matrix
+    # and compilation prerequisites. A build child whose own resolve artifact
+    # is absent fails at its exact-name download while other variants continue.
     # Canonical nightly-* tags may only be published from the default branch.
-    # A workflow_dispatch from a feature branch still runs matrix/compile/resolve
-    # (dry validation) but must not push under the canonical namespace.
-    if: github.ref == 'refs/heads/main'
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' && needs.matrix.result == 'success' && needs.compile.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -408,6 +433,30 @@ jobs:
           no-cache: true
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
+      - name: Verify and report installed Kiro version
+        if: matrix.variant == 'kiro'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          ARCH: ${{ matrix.platform.arch }}
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+          docker pull "$IMAGE"
+          VERSION=$(docker run --rm --entrypoint /usr/local/bin/kiro-cli "$IMAGE" --version | tr -d '\r' | tail -1)
+          [ -n "$VERSION" ] || { echo "::error::Kiro returned an empty version"; exit 1; }
+          mkdir -p /tmp/kiro-versions
+          printf '%s\n' "$VERSION" > "/tmp/kiro-versions/${ARCH}"
+          echo "Kiro ${ARCH}: $VERSION"
+
+      - name: Upload installed Kiro version
+        if: matrix.variant == 'kiro'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-kiro-version-${{ matrix.platform.arch }}
+          path: /tmp/kiro-versions/*
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -465,9 +514,17 @@ jobs:
           name: nightly-resolve-${{ matrix.variant }}
           path: /tmp/resolved
 
+      - name: Download installed Kiro versions
+        if: matrix.variant == 'kiro'
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/kiro-versions
+          pattern: nightly-kiro-version-*
+          merge-multiple: true
+
       - name: Validate digest count
         run: |
-          COUNT=$(ls -1 /tmp/digests/ 2>/dev/null | wc -l | tr -d ' ')
+          COUNT=$(find /tmp/digests -maxdepth 1 -type f -print 2>/dev/null | wc -l | tr -d ' ')
           if [ "$COUNT" -ne 2 ]; then
             echo "::error::No complete image for ${{ matrix.variant }} (expected 2 digests amd64+arm64, got $COUNT) — its build leg likely failed. This variant is not published; siblings are unaffected."
             exit 1
@@ -476,6 +533,21 @@ jobs:
             name=$(basename "$f")
             echo "$name" | grep -qE '^[a-f0-9]{64}$' || { echo "::error::invalid digest: $name"; exit 1; }
           done
+
+      - name: Validate installed Kiro versions match
+        if: matrix.variant == 'kiro'
+        run: |
+          set -euo pipefail
+          [ -f /tmp/kiro-versions/amd64 ] || { echo "::error::missing Kiro amd64 version report"; exit 1; }
+          [ -f /tmp/kiro-versions/arm64 ] || { echo "::error::missing Kiro arm64 version report"; exit 1; }
+          AMD=$(cat /tmp/kiro-versions/amd64)
+          ARM=$(cat /tmp/kiro-versions/arm64)
+          [ "$AMD" = "$ARM" ] || {
+            echo "::error::Kiro architecture version mismatch: amd64='$AMD', arm64='$ARM'"
+            exit 1
+          }
+          printf 'kiro %s\n' "$AMD" > /tmp/resolved/report
+          echo "Kiro versions match: $AMD"
 
       - name: Create manifest and tag
         env:
@@ -488,9 +560,12 @@ jobs:
           # Include the run attempt so a re-run (which re-resolves mutable
           # vendor versions) cannot move a tag documented as immutable.
           IMMUTABLE="${IMAGE}:nightly-${DATE}-${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}-${VARIANT}"
-          DIGESTS=$(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
+          DIGESTS=()
+          for f in /tmp/digests/*; do
+            DIGESTS+=("${IMAGE}@sha256:$(basename "$f")")
+          done
 
-          docker buildx imagetools create -t "$MOVING" -t "$IMMUTABLE" ${DIGESTS}
+          docker buildx imagetools create -t "$MOVING" -t "$IMMUTABLE" "${DIGESTS[@]}"
 
           {
             echo "### 📦 nightly \`${VARIANT}\`"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -192,9 +192,9 @@ jobs:
           set -euo pipefail
 
           # BUILD_ARGS accumulates the --build-arg overrides fed to buildx.
-          # For SHA-pinned variants we deliberately pass empty SHAs: the
-          # Dockerfile.package check is skipped when the SHA arg is empty
-          # (release/pre-beta still pass their pinned SHAs and stay verified).
+          # Kiro binds empty-SHA downloads to strong ETags. Grok and Antigravity
+          # have no usable digest and must pass the explicit nightly-only opt-in;
+          # release/pre-beta keep pinned SHAs and fail closed if one is missing.
           BUILD_ARGS=""
 
           github_api() {
@@ -287,7 +287,8 @@ jobs:
               check_ver "$V"; REPORT="grok $V"
               BUILD_ARGS="GROK_VERSION=$V
           GROK_SHA256_AMD64=
-          GROK_SHA256_ARM64=" ;;
+          GROK_SHA256_ARM64=
+          ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=true" ;;
             devin)
               MANIFEST=$(curl -fsSL --retry 3 https://static.devin.ai/cli/current/manifest.json)
               V=$(echo "$MANIFEST" | jq -r .version)
@@ -305,10 +306,10 @@ jobs:
               RELEASE=$(github_api https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest)
               V=$(echo "$RELEASE" | jq -r .tag_name)
               check_ver "$V"; REPORT="antigravity $V"
-              BUILD_ARGS="AGY_VERSION_OVERRIDE=$V
-          AGY_EFFECTIVE_VERSION=$V
+              BUILD_ARGS="AGY_VERSION=$V
           AGY_SHA256_AMD64=
-          AGY_SHA256_ARM64=" ;;
+          AGY_SHA256_ARM64=
+          ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=true" ;;
             hermes)
               # Resolve the release, dereference an annotated tag to its immutable
               # commit, then pin both the install commit and the installer SHA so

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -68,7 +68,7 @@ jobs:
             VARIANTS="$INPUT_VARIANTS"
             for v in $(echo "$VARIANTS" | tr ',' ' '); do
               v=$(echo "$v" | xargs)
-              if ! echo ",$ALL_VARIANTS," | grep -q ",$v,"; then
+              if ! echo ",$ALL_VARIANTS," | grep -qF -- ",$v,"; then
                 echo "::error::Unknown or unsupported nightly variant: $v (allowed: $ALL_VARIANTS)"
                 exit 1
               fi
@@ -138,42 +138,27 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
-  # Package: resolve the vendor's latest CLI version, then build a lightweight
-  # image per variant (no Rust compilation) with the resolved version passed as
-  # a build-arg override.
+  # Resolve each vendor's latest CLI version ONCE per variant (not per arch), so
+  # amd64 and arm64 build the same version even if a vendor publishes mid-run.
+  # Emits a per-variant artifact holding the build-arg overrides + a human
+  # report, consumed by the build and tag jobs.
   # ---------------------------------------------------------------------------
-  build:
-    needs: [matrix, compile]
+  resolve:
+    needs: matrix
     strategy:
       fail-fast: false
       matrix:
         variant: ${{ fromJson(needs.matrix.outputs.variants) }}
-        platform:
-          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
-          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Download pre-built binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: nightly-bins-${{ matrix.platform.arch }}
-          path: bin
-
-      - name: Make binaries executable
-        run: chmod +x bin/*
-
       - name: Resolve the vendor's latest CLI version
-        id: resolve
         env:
-          # Used only for the Hermes cross-repo Contents API request. An
-          # authenticated fetch avoids the shared-runner 429s seen on
-          # raw.githubusercontent.com, while the resolved commit keeps the
-          # installer immutable.
+          # Used for the cross-repo GitHub API requests (hermes, antigravity).
+          # An authenticated fetch avoids the shared-runner 429s seen on
+          # api/raw.githubusercontent.com, while the resolved commit/tag keeps
+          # the installer immutable.
           GH_TOKEN: ${{ github.token }}
           VARIANT: ${{ matrix.variant }}
         run: |
@@ -268,18 +253,15 @@ jobs:
               MANIFEST=$(curl -fsSL --retry 3 https://static.devin.ai/cli/current/manifest.json)
               V=$(echo "$MANIFEST" | jq -r .version)
               check_ver "$V"; REPORT="devin $V"
-              # Vendor publishes per-arch sha256; keep the check enabled by
-              # passing the resolved digest for this arch to both args (only the
-              # matching-arch one is consulted by the Dockerfile case).
-              if [ "${{ matrix.platform.arch }}" = "arm64" ]; then
-                SHA=$(echo "$MANIFEST" | jq -r '.platforms["aarch64-unknown-linux"].sha256')
-                BUILD_ARGS="DEVIN_VERSION=$V
-          DEVIN_SHA256_ARM64=$SHA"
-              else
-                SHA=$(echo "$MANIFEST" | jq -r '.platforms["x86_64-unknown-linux"].sha256')
-                BUILD_ARGS="DEVIN_VERSION=$V
-          DEVIN_SHA256_AMD64=$SHA"
-              fi ;;
+              # Vendor publishes per-arch sha256; resolve BOTH and pass both args
+              # so amd64 and arm64 builds each verify their own binary. The
+              # Dockerfile's case selects the matching-arch one at build time.
+              SHA_AMD=$(echo "$MANIFEST" | jq -r '.platforms["x86_64-unknown-linux"].sha256')
+              SHA_ARM=$(echo "$MANIFEST" | jq -r '.platforms["aarch64-unknown-linux"].sha256')
+              echo "$SHA_AMD$SHA_ARM" | grep -qE '^[0-9a-f]{128}$' || { echo "::error::devin manifest missing per-arch sha256"; exit 1; }
+              BUILD_ARGS="DEVIN_VERSION=$V
+          DEVIN_SHA256_AMD64=$SHA_AMD
+          DEVIN_SHA256_ARM64=$SHA_ARM" ;;
             antigravity)
               V=$(curl -fsSL --retry 3 https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest | jq -r .tag_name)
               check_ver "$V"; REPORT="antigravity $V"
@@ -303,8 +285,12 @@ jobs:
               done
               [ "$REF_TYPE" = "commit" ] || { echo "::error::hermes $TAG did not resolve to a commit"; exit 1; }
               echo "$COMMIT" | grep -qE '^[0-9a-f]{40}$' || { echo "::error::invalid hermes commit: $COMMIT"; exit 1; }
-              INSTALL_SHA=$(curl -fsSL --retry 3 \
-                "https://raw.githubusercontent.com/NousResearch/hermes-agent/${COMMIT}/scripts/install.sh" \
+              # Hash the installer via the authenticated Contents API (raw+json)
+              # for the resolved commit — same reason as the release fetch above:
+              # dodges the shared-runner 429s on raw.githubusercontent.com. The
+              # Dockerfile still fetches+verifies against this SHA at build time.
+              INSTALL_SHA=$(github_api -H 'Accept: application/vnd.github.raw+json' \
+                "https://api.github.com/repos/NousResearch/hermes-agent/contents/scripts/install.sh?ref=${COMMIT}" \
                 | sha256sum | cut -d' ' -f1)
               echo "$INSTALL_SHA" | grep -qE '^[0-9a-f]{64}$' || { echo "::error::could not hash hermes installer"; exit 1; }
               REPORT="hermes $TAG @ $COMMIT"
@@ -315,17 +301,66 @@ jobs:
           esac
 
           echo "Resolved $VARIANT -> $REPORT"
-          echo "report=$REPORT" >> "$GITHUB_OUTPUT"
+          mkdir -p resolved
           # The BUILD_ARGS literals above are indented for readability; strip any
           # leading whitespace so each emitted line is a clean KEY=VALUE that
           # build-push-action's build-args parser accepts. Drop blank lines too.
-          CLEAN_ARGS=$(printf '%s\n' "$BUILD_ARGS" | sed 's/^[[:space:]]*//' | grep -v '^$')
-          # Multi-line output for the build-args block.
+          printf '%s\n' "$BUILD_ARGS" | sed 's/^[[:space:]]*//' | grep -v '^$' > resolved/build_args
+          printf '%s\n' "$REPORT" > resolved/report
+
+      - name: Upload resolved build args
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-resolve-${{ matrix.variant }}
+          path: resolved/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Package: build a lightweight image per variant×arch (no Rust compilation),
+  # feeding the once-resolved build-arg overrides so both arches share a version.
+  # ---------------------------------------------------------------------------
+  build:
+    needs: [matrix, compile, resolve]
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJson(needs.matrix.outputs.variants) }}
+        platform:
+          - { os: linux/amd64, runner: ubuntu-latest, arch: amd64 }
+          - { os: linux/arm64, runner: ubuntu-24.04-arm, arch: arm64 }
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download pre-built binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-bins-${{ matrix.platform.arch }}
+          path: bin
+
+      - name: Make binaries executable
+        run: chmod +x bin/*
+
+      - name: Download resolved build args
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-resolve-${{ matrix.variant }}
+          path: resolved
+
+      - name: Load resolved build args
+        id: resolve
+        run: |
+          set -euo pipefail
           {
             echo "build_args<<__BUILD_ARGS_EOF__"
-            echo "$CLEAN_ARGS"
+            cat resolved/build_args
             echo "__BUILD_ARGS_EOF__"
           } >> "$GITHUB_OUTPUT"
+          echo "Building $(cat resolved/report)"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -370,7 +405,7 @@ jobs:
   # Create the multi-arch manifest and apply the nightly tags per variant.
   # ---------------------------------------------------------------------------
   tag:
-    needs: [matrix, build]
+    needs: [matrix, resolve, build]
     strategy:
       fail-fast: false
       matrix:
@@ -394,6 +429,12 @@ jobs:
           path: /tmp/digests
           pattern: nightly-digests-${{ matrix.variant }}-*
           merge-multiple: true
+
+      - name: Download resolved report
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-resolve-${{ matrix.variant }}
+          path: /tmp/resolved
 
       - name: Validate digest count
         run: |
@@ -427,6 +468,8 @@ jobs:
             echo "$MOVING"
             echo "$IMMUTABLE"
             echo '```'
+            echo
+            echo "CLI: $(cat /tmp/resolved/report 2>/dev/null || echo 'n/a')"
             echo
             echo "Drop-in image tracking the vendor's latest CLI. No compatibility guarantee."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,8 +15,8 @@ name: Nightly Build
 #   - Freshness over cohort atomicity: each variant publishes independently
 #     (fail-fast: false), so one vendor breaking their latest does not hold back
 #     the rest. A failed variant keeps yesterday's tag; the red job is the alert.
-#   - nightly-<variant> is the moving tag; nightly-YYYYMMDD-<run-id>-<variant>
-#     is the immutable rollback point.
+#   - nightly-<variant> is the moving tag; nightly-YYYYMMDD-<run-id>.<attempt>-<variant>
+#     is the immutable rollback point (the attempt suffix keeps re-runs distinct).
 #   - Release (v*) and pre-beta-* tags and their build path are untouched.
 #
 # native + agentcore are intentionally absent: they carry no coding CLI by
@@ -45,7 +45,11 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # Every agent-CLI variant. native + agentcore excluded: no CLI to freshen.
-  ALL_VARIANTS: 'kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,opencode,antigravity,pi'
+  # pi is excluded too: its package/unified target sets
+  # OPENAB_AGENT_COMMAND=openab-agent but does not ship that binary (a
+  # pre-existing bug across all lanes — see follow-up issue), so a nightly-pi
+  # tag would publish a runtime-broken image. Re-add once the pi target is fixed.
+  ALL_VARIANTS: 'kiro,claude,codex,copilot,cursor,devin,gemini,grok,hermes,kimi,mimocode,opencode,antigravity'
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -66,17 +70,30 @@ jobs:
             VARIANTS="$ALL_VARIANTS"
           else
             VARIANTS="$INPUT_VARIANTS"
-            for v in $(echo "$VARIANTS" | tr ',' ' '); do
-              v=$(echo "$v" | xargs)
-              if ! echo ",$ALL_VARIANTS," | grep -qF -- ",$v,"; then
-                echo "::error::Unknown or unsupported nightly variant: $v (allowed: $ALL_VARIANTS)"
-                exit 1
-              fi
-            done
           fi
-          JSON=$(echo "$VARIANTS" | tr ',' '\n' | sed 's/^ *//;s/ *$//' | jq -R . | jq -sc .)
+
+          # Parse once into a normalized, validated, de-duplicated list. This is
+          # the single source the matrix JSON is built from, so empty fields
+          # (kiro,,claude) and duplicates (kiro,kiro) cannot leak through into
+          # empty matrix legs or artifact-name collisions.
+          SELECTED=""
+          IFS=','
+          for raw in $VARIANTS; do
+            v=$(echo "$raw" | xargs)                       # trim surrounding whitespace
+            [ -n "$v" ] || { echo "::error::empty variant entry in: $INPUT_VARIANTS"; exit 1; }
+            echo ",$ALL_VARIANTS," | grep -qF -- ",$v," || {
+              echo "::error::Unknown or unsupported nightly variant: $v (allowed: $ALL_VARIANTS)"; exit 1; }
+            case ",$SELECTED," in
+              *",$v,"*) echo "::error::duplicate variant: $v"; exit 1 ;;
+            esac
+            SELECTED="${SELECTED:+$SELECTED,}$v"
+          done
+          unset IFS
+          [ -n "$SELECTED" ] || { echo "::error::no variants selected"; exit 1; }
+
+          JSON=$(printf '%s' "$SELECTED" | tr ',' '\n' | jq -R . | jq -sc .)
           echo "variants=${JSON}" >> "$GITHUB_OUTPUT"
-          echo "Building: $VARIANTS"
+          echo "Building: $SELECTED"
 
   # ---------------------------------------------------------------------------
   # Compile openab (and openab-agent, agy-acp) once per architecture.
@@ -266,6 +283,7 @@ jobs:
               V=$(curl -fsSL --retry 3 https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest | jq -r .tag_name)
               check_ver "$V"; REPORT="antigravity $V"
               BUILD_ARGS="AGY_VERSION_OVERRIDE=$V
+          AGY_EFFECTIVE_VERSION=$V
           AGY_SHA256_AMD64=
           AGY_SHA256_ARM64=" ;;
             hermes)
@@ -322,6 +340,10 @@ jobs:
   # ---------------------------------------------------------------------------
   build:
     needs: [matrix, compile, resolve]
+    # Canonical nightly-* tags may only be published from the default branch.
+    # A workflow_dispatch from a feature branch still runs matrix/compile/resolve
+    # (dry validation) but must not push under the canonical namespace.
+    if: github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -406,6 +428,13 @@ jobs:
   # ---------------------------------------------------------------------------
   tag:
     needs: [matrix, resolve, build]
+    # Independent publication: run even if a sibling variant's build failed
+    # (fail-fast: false already lets siblings finish, but a skipped tag job
+    # would still withhold the ones that succeeded). Each variant tags only if
+    # its own two digests are present; the digest-count check below fails just
+    # that variant's tag when its build did not produce both arches. Restricted
+    # to the default branch for the same reason as build.
+    if: ${{ always() && !cancelled() && github.ref == 'refs/heads/main' }}
     strategy:
       fail-fast: false
       matrix:
@@ -438,9 +467,9 @@ jobs:
 
       - name: Validate digest count
         run: |
-          COUNT=$(ls -1 /tmp/digests/ | wc -l)
+          COUNT=$(ls -1 /tmp/digests/ 2>/dev/null | wc -l | tr -d ' ')
           if [ "$COUNT" -ne 2 ]; then
-            echo "::error::Expected 2 digests (amd64 + arm64) for ${{ matrix.variant }}, got $COUNT"
+            echo "::error::No complete image for ${{ matrix.variant }} (expected 2 digests amd64+arm64, got $COUNT) — its build leg likely failed. This variant is not published; siblings are unaffected."
             exit 1
           fi
           for f in /tmp/digests/*; do
@@ -456,7 +485,9 @@ jobs:
           IMAGE="${REGISTRY}/${IMAGE_NAME}"
           DATE=$(date -u +%Y%m%d)
           MOVING="${IMAGE}:nightly-${VARIANT}"
-          IMMUTABLE="${IMAGE}:nightly-${DATE}-${GITHUB_RUN_ID}-${VARIANT}"
+          # Include the run attempt so a re-run (which re-resolves mutable
+          # vendor versions) cannot move a tag documented as immutable.
+          IMMUTABLE="${IMAGE}:nightly-${DATE}-${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}-${VARIANT}"
           DIGESTS=$(printf "${IMAGE}@sha256:%s " $(ls /tmp/digests/))
 
           docker buildx imagetools create -t "$MOVING" -t "$IMMUTABLE" ${DIGESTS}

--- a/Dockerfile.hermes
+++ b/Dockerfile.hermes
@@ -33,7 +33,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # HERMES_HOME points to agent user's data dir for OAuth tokens and config
 ARG HERMES_INSTALL_COMMIT=2bd1977d8fad185c9b4be47884f7e87f1add0ce3
 ARG HERMES_INSTALL_SHA256=dbd9d555ed4ac67bd1fc71ba6a39b410cf2af0ebcfd8f4889e086af78c9ddcaa
-RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
+# Shared CI runners can be throttled by raw.githubusercontent.com; retry
+# transient failures while the pinned SHA256 still verifies the response body.
+RUN curl -fsSL --retry 6 --retry-all-errors --retry-delay 10 --retry-max-time 120 \
+      "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
       -o /tmp/install-hermes.sh && \
     echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \
     HERMES_HOME=/home/agent/.hermes bash /tmp/install-hermes.sh && \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -69,7 +69,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
       curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 \
         "$URL" -o /tmp/kirocli.zip; \
     fi && \
-    { [ -z "$SHA256" ] || echo "$SHA256  /tmp/kirocli.zip" | sha256sum -c -; } && \
+    if [ -n "$SHA256" ]; then \
+      echo "$SHA256  /tmp/kirocli.zip" | sha256sum -c -; \
+    elif [ -z "$ETAG" ]; then \
+      echo "Kiro download requires SHA256 or a strong ETag" >&2; exit 1; \
+    fi && \
     unzip /tmp/kirocli.zip -d /tmp && \
     cp /tmp/kirocli/bin/* /usr/local/bin/ && \
     chmod +x /usr/local/bin/kiro-cli* && \
@@ -221,6 +225,9 @@ FROM base-debian AS grok
 ARG GROK_VERSION=0.1.220
 ARG GROK_SHA256_AMD64=98d331d64dfc4fb1dae862475218cccdd195f76839b8361a0678af2fd388364b
 ARG GROK_SHA256_ARM64=3b15efc258f4219d01736acee70c575a8167f970cb4d497a3b0c218440db58ff
+# Explicit opt-in for the nightly TLS-only path. Empty SHA values fail closed
+# for every other caller, including release and pre-beta builds.
+ARG ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=false
 ARG TARGETPLATFORM
 RUN set -eux; \
     case "${TARGETPLATFORM:-linux/amd64}" in \
@@ -230,7 +237,11 @@ RUN set -eux; \
     esac; \
     curl -fsSL "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${GROK_VERSION}-linux-${arch}" \
       -o /tmp/grok && \
-    { [ -z "$sha" ] || echo "${sha}  /tmp/grok" | sha256sum -c -; } && \
+    if [ -n "$sha" ]; then \
+      echo "${sha}  /tmp/grok" | sha256sum -c -; \
+    elif [ "$ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS" != "true" ]; then \
+      echo "Grok download requires SHA256 unless the nightly-only opt-in is true" >&2; exit 1; \
+    fi && \
     install -m 0755 /tmp/grok /usr/local/bin/grok && \
     rm /tmp/grok
 ENV HOME=/home/agent
@@ -332,7 +343,7 @@ RUN set -eux; \
     esac; \
     curl -fsSL "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-${arch}.tar.gz" \
       -o /tmp/devin.tar.gz && \
-    { [ -z "$sha" ] || echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c -; } && \
+    echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \
     tar xzf /tmp/devin.tar.gz -C /tmp && \
     install -m 0755 /tmp/bin/devin /usr/local/bin/devin && \
     rm -rf /tmp/devin* /tmp/bin /tmp/share
@@ -352,20 +363,16 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # Target: antigravity
 # =============================================================================
 FROM base-debian AS antigravity
-ENV AGY_VERSION=1.1.13
-# Nightly builds override the version without touching the pinned ENV above
-# (which the packaged-pin parity check asserts byte-for-byte). When empty, the
-# pinned AGY_VERSION is used; the nightly lane passes the resolved latest.
-ARG AGY_VERSION_OVERRIDE=
-# Effective installed version, surfaced as image metadata so `inspect` reflects
-# what was actually installed (the ENV above stays pinned for parity). Nightly
-# passes the resolved version here; otherwise it mirrors the pinned default.
-ARG AGY_EFFECTIVE_VERSION=1.1.13
-LABEL dev.openab.agy.version="${AGY_EFFECTIVE_VERSION}"
+# One overridable pin drives the download and all persisted image metadata.
+ARG AGY_VERSION=1.1.13
+ENV AGY_VERSION="${AGY_VERSION}"
+LABEL dev.openab.agy.version="${AGY_VERSION}"
 ARG AGY_SHA256_AMD64=edc7c32b5ab4fc2e4da03381fee83ed566dea6b56b56f9329cd13cd77947a1d9
 ARG AGY_SHA256_ARM64=a9fdd2a386770c27dbf784436bd4de70d4d4901c832d5ec6abf27758d5c370f8
+# Explicit opt-in for the nightly TLS-only path. Empty SHA values fail closed
+# for every other caller, including release and pre-beta builds.
+ARG ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS=false
 RUN ARCH=$(dpkg --print-architecture) && \
-    AGY_VERSION="${AGY_VERSION_OVERRIDE:-$AGY_VERSION}" && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz"; sha="${AGY_SHA256_AMD64}" ;; \
       arm64) ASSET="agy_cli_linux_arm64.tar.gz"; sha="${AGY_SHA256_ARM64}" ;; \
@@ -373,7 +380,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
     esac && \
     curl -fsSL "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${ASSET}" \
       -o /tmp/agy.tar.gz && \
-    { [ -z "$sha" ] || echo "${sha}  /tmp/agy.tar.gz" | sha256sum -c -; } && \
+    if [ -n "$sha" ]; then \
+      echo "${sha}  /tmp/agy.tar.gz" | sha256sum -c -; \
+    elif [ "$ALLOW_UNVERIFIED_NIGHTLY_DOWNLOADS" != "true" ]; then \
+      echo "Antigravity download requires SHA256 unless the nightly-only opt-in is true" >&2; exit 1; \
+    fi && \
     tar -xzf /tmp/agy.tar.gz -C /usr/local/bin && \
     rm /tmp/agy.tar.gz && \
     mv /usr/local/bin/antigravity /usr/local/bin/agy && \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -46,17 +46,29 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 # =============================================================================
 FROM base-debian AS kiro
 ARG KIRO_CLI_VERSION=2.13.0
+# Optional immutable content identifiers for the nightly `latest` path. Release
+# and pre-beta builds leave these empty and retain their pinned SHA256 checks.
+ARG KIRO_ETAG_AMD64=
+ARG KIRO_ETAG_ARM64=
 ARG KIRO_SHA256_AMD64=d8c5277358b4a82b2d9a9ed2d52e110862536dc82b9e32c3719fc5f5a9834c94
 ARG KIRO_SHA256_ARM64=95972602568c2065b7d8cc28924730304d40e612c0984ee0144d8ba452000be3
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then \
       URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-aarch64-linux.zip"; \
+      ETAG="$KIRO_ETAG_ARM64"; \
       SHA256="$KIRO_SHA256_ARM64"; \
     else \
       URL="https://prod.download.cli.kiro.dev/stable/${KIRO_CLI_VERSION}/kirocli-x86_64-linux.zip"; \
+      ETAG="$KIRO_ETAG_AMD64"; \
       SHA256="$KIRO_SHA256_AMD64"; \
     fi && \
-    curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 "$URL" -o /tmp/kirocli.zip && \
+    if [ -n "$ETAG" ]; then \
+      curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 \
+        -H "If-Match: \"$ETAG\"" "$URL" -o /tmp/kirocli.zip; \
+    else \
+      curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 \
+        "$URL" -o /tmp/kirocli.zip; \
+    fi && \
     { [ -z "$SHA256" ] || echo "$SHA256  /tmp/kirocli.zip" | sha256sum -c -; } && \
     unzip /tmp/kirocli.zip -d /tmp && \
     cp /tmp/kirocli/bin/* /usr/local/bin/ && \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -266,7 +266,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 ARG HERMES_INSTALL_COMMIT=2bd1977d8fad185c9b4be47884f7e87f1add0ce3
 ARG HERMES_INSTALL_SHA256=dbd9d555ed4ac67bd1fc71ba6a39b410cf2af0ebcfd8f4889e086af78c9ddcaa
-RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
+# Shared CI runners can be throttled by raw.githubusercontent.com; retry
+# transient failures while the pinned SHA256 still verifies the response body.
+RUN curl -fsSL --retry 6 --retry-all-errors --retry-delay 10 --retry-max-time 120 \
+      "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
       -o /tmp/install-hermes.sh && \
     echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \
     HERMES_HOME=/home/agent/.hermes bash /tmp/install-hermes.sh && \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -57,7 +57,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
       SHA256="$KIRO_SHA256_AMD64"; \
     fi && \
     curl --proto '=https' --tlsv1.2 -sSf --retry 3 --retry-delay 5 "$URL" -o /tmp/kirocli.zip && \
-    echo "$SHA256  /tmp/kirocli.zip" | sha256sum -c - && \
+    { [ -z "$SHA256" ] || echo "$SHA256  /tmp/kirocli.zip" | sha256sum -c -; } && \
     unzip /tmp/kirocli.zip -d /tmp && \
     cp /tmp/kirocli/bin/* /usr/local/bin/ && \
     chmod +x /usr/local/bin/kiro-cli* && \
@@ -218,7 +218,7 @@ RUN set -eux; \
     esac; \
     curl -fsSL "https://storage.googleapis.com/grok-build-public-artifacts/cli/grok-${GROK_VERSION}-linux-${arch}" \
       -o /tmp/grok && \
-    echo "${sha}  /tmp/grok" | sha256sum -c - && \
+    { [ -z "$sha" ] || echo "${sha}  /tmp/grok" | sha256sum -c -; } && \
     install -m 0755 /tmp/grok /usr/local/bin/grok && \
     rm /tmp/grok
 ENV HOME=/home/agent
@@ -320,7 +320,7 @@ RUN set -eux; \
     esac; \
     curl -fsSL "https://static.devin.ai/cli/${DEVIN_VERSION}/devin-${DEVIN_VERSION}-${arch}.tar.gz" \
       -o /tmp/devin.tar.gz && \
-    echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c - && \
+    { [ -z "$sha" ] || echo "${sha}  /tmp/devin.tar.gz" | sha256sum -c -; } && \
     tar xzf /tmp/devin.tar.gz -C /tmp && \
     install -m 0755 /tmp/bin/devin /usr/local/bin/devin && \
     rm -rf /tmp/devin* /tmp/bin /tmp/share
@@ -341,9 +341,14 @@ CMD ["openab", "run", "-c", "/etc/openab/config.toml"]
 # =============================================================================
 FROM base-debian AS antigravity
 ENV AGY_VERSION=1.1.13
+# Nightly builds override the version without touching the pinned ENV above
+# (which the packaged-pin parity check asserts byte-for-byte). When empty, the
+# pinned AGY_VERSION is used; the nightly lane passes the resolved latest.
+ARG AGY_VERSION_OVERRIDE=
 ARG AGY_SHA256_AMD64=edc7c32b5ab4fc2e4da03381fee83ed566dea6b56b56f9329cd13cd77947a1d9
 ARG AGY_SHA256_ARM64=a9fdd2a386770c27dbf784436bd4de70d4d4901c832d5ec6abf27758d5c370f8
 RUN ARCH=$(dpkg --print-architecture) && \
+    AGY_VERSION="${AGY_VERSION_OVERRIDE:-$AGY_VERSION}" && \
     case "$ARCH" in \
       amd64) ASSET="agy_cli_linux_x64.tar.gz"; sha="${AGY_SHA256_AMD64}" ;; \
       arm64) ASSET="agy_cli_linux_arm64.tar.gz"; sha="${AGY_SHA256_ARM64}" ;; \
@@ -351,7 +356,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     esac && \
     curl -fsSL "https://github.com/google-antigravity/antigravity-cli/releases/download/${AGY_VERSION}/${ASSET}" \
       -o /tmp/agy.tar.gz && \
-    echo "${sha}  /tmp/agy.tar.gz" | sha256sum -c - && \
+    { [ -z "$sha" ] || echo "${sha}  /tmp/agy.tar.gz" | sha256sum -c -; } && \
     tar -xzf /tmp/agy.tar.gz -C /usr/local/bin && \
     rm /tmp/agy.tar.gz && \
     mv /usr/local/bin/antigravity /usr/local/bin/agy && \

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -345,6 +345,11 @@ ENV AGY_VERSION=1.1.13
 # (which the packaged-pin parity check asserts byte-for-byte). When empty, the
 # pinned AGY_VERSION is used; the nightly lane passes the resolved latest.
 ARG AGY_VERSION_OVERRIDE=
+# Effective installed version, surfaced as image metadata so `inspect` reflects
+# what was actually installed (the ENV above stays pinned for parity). Nightly
+# passes the resolved version here; otherwise it mirrors the pinned default.
+ARG AGY_EFFECTIVE_VERSION=1.1.13
+LABEL dev.openab.agy.version="${AGY_EFFECTIVE_VERSION}"
 ARG AGY_SHA256_AMD64=edc7c32b5ab4fc2e4da03381fee83ed566dea6b56b56f9329cd13cd77947a1d9
 ARG AGY_SHA256_ARM64=a9fdd2a386770c27dbf784436bd4de70d4d4901c832d5ec6abf27758d5c370f8
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfile.unified
+++ b/Dockerfile.unified
@@ -294,7 +294,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 ARG HERMES_INSTALL_COMMIT=2bd1977d8fad185c9b4be47884f7e87f1add0ce3
 ARG HERMES_INSTALL_SHA256=dbd9d555ed4ac67bd1fc71ba6a39b410cf2af0ebcfd8f4889e086af78c9ddcaa
-RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
+# Shared CI runners can be throttled by raw.githubusercontent.com; retry
+# transient failures while the pinned SHA256 still verifies the response body.
+RUN curl -fsSL --retry 6 --retry-all-errors --retry-delay 10 --retry-max-time 120 \
+      "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HERMES_INSTALL_COMMIT}/scripts/install.sh" \
       -o /tmp/install-hermes.sh && \
     echo "${HERMES_INSTALL_SHA256}  /tmp/install-hermes.sh" | sha256sum -c - && \
     HERMES_HOME=/home/agent/.hermes bash /tmp/install-hermes.sh && \


### PR DESCRIPTION
> ⚠️ **This is a drop-in replacement channel with no compatibility guarantee.** Nightly
> images track each vendor's latest coding CLI, which can change or break at any time.
> They are **not releases** and carry no stability or compatibility promise. Pin a real
> `v*` release (or a `pre-beta-*` tag) when you need a stable, reproducible image.

## Summary

Adds a scheduled nightly image channel for `openabdev/openab`, analogous to the nightly
channel in `openab-pty`. Each supported variant packages the current OpenAB binary with the
vendor's latest CLI.

The pinned release and pre-beta lanes cannot already provide this: their CLI versions and,
for binary downloads, SHA256 values are defaults inside `Dockerfile.package`, so rebuilding
those lanes intentionally republishes the same CLI. Nightly resolves fresh vendor metadata
and supplies build-argument overrides without changing those defaults.

## Channel behavior

- Schedule: daily at `06:23 UTC`; manual dispatch may select a strict comma-separated subset.
- Pipeline: select matrix → compile OpenAB once per architecture + resolve each vendor once per
  variant → build each variant/architecture by digest → create per-variant multi-arch manifests.
- Canonical publication is restricted to `main`. A feature-branch dispatch may validate the
  selector, compilation, and resolvers but cannot push images.
- Tags:
  - `nightly-<variant>` — moving tag.
  - `nightly-YYYYMMDD-<run-id>.<attempt>-<variant>` — immutable rollback point; the attempt
    suffix prevents a workflow re-run from moving an existing rollback tag.
- Variants publish independently. A failed resolver/build for one variant does not withhold
  successful siblings; that variant keeps yesterday's moving tag.
- `native` and `agentcore` are excluded because they contain no vendor CLI. `pi` is temporarily
  excluded because its existing package target does not ship its configured adapter (#1520).

## Integrity model

- Release and pre-beta retain their pinned SHA256 checks exactly as before.
- Devin resolves and validates both vendor-published architecture SHA256 values.
- Hermes resolves a release tag to an immutable commit and hashes the installer fetched through
  the authenticated GitHub Contents API.
- Kiro exposes no version index. Nightly resolves a strong ETag for each latest object once,
  validates it, and the Dockerfile sends `If-Match` during each download (a changed object fails
  HTTP 412). Each native image then runs `kiro-cli --version`; the tag job requires amd64 and
  arm64 reports to match before creating a manifest.
- Grok and Antigravity do not publish an ahead-of-time digest usable by this lane; their nightly
  downloads intentionally use empty SHA overrides and rely on TLS. This relaxation is confined
  to `nightly-*` builds.

## Validation

- Exact selector script: rejects leading/interior/trailing/whitespace-only empty entries and
  duplicates; accepts normalized valid subsets and `all`.
- Exact Kiro resolver: emits validated 32-hex ETags for both architectures.
- Live Kiro CDN: matching quoted `If-Match` → HTTP 206; incorrect ETag → HTTP 412.
- Kiro manifest gate: matching installed versions pass; mismatched versions fail closed.
- Exact authenticated Antigravity resolver returns the latest release and expected build args.
- `actionlint` + `shellcheck`: clean.
- `Dockerfile.package` Kiro target: BuildKit `--check` clean after skipping only the unrelated,
  pre-existing `OPENAB_AGENT_AUTH_COMMAND` secret-name heuristic.
- Package-pin parity assertions and `git diff --check`: pass.

## Review Contract

### Goal
Provide a daily and manually dispatchable nightly channel that is a drop-in image replacement
for each supported agent variant, packages the vendor's latest CLI, allows healthy variants to
publish independently, and leaves pinned release/pre-beta behavior unchanged. Nightly explicitly
has no compatibility guarantee.

### Non-goals
- It is not a stable release, SemVer promise, or compatibility/support commitment.
- It does not alter release or `pre-beta-*` tags, pinned versions, or pinned SHA defaults.
- It does not cover `native`, `agentcore`, or the currently broken `pi` package target (#1520).
- It does not provide a runtime smoke test for every vendor CLI; Kiro receives a targeted native
  version check because its vendor offers only a mutable latest URL.
- It does not publish canonical tags from non-main workflow dispatches.

### Accepted Residual Risks
- **Vendor-latest compatibility:** a vendor may publish a behaviorally incompatible CLI. The
  affected variant fails its build or advances its moving tag; recovery is pinning the previous
  attempt-unique rollback tag.
- **Grok/Antigravity nightly integrity:** those vendors do not expose a usable digest in the
  current resolution path. Nightly relies on TLS and empty SHA overrides for these two variants.
  This does not weaken release/pre-beta because their non-empty pinned SHAs remain the defaults.
- **Partial cohorts:** independent publication intentionally permits some variants to advance
  while another remains on yesterday's tag. The failed variant's red resolver/build/tag is the
  alert; successful variants are not withheld.
- **No general runtime gate:** successful packaging does not guarantee a vendor CLI remains ACP
  compatible. This is part of the channel's explicit no-guarantee contract.

### Acceptance Criteria
- A scheduled run from `main` can publish moving and attempt-unique multi-arch tags for every
  selected supported variant; a non-main dispatch cannot publish.
- One failed vendor resolver does not skip other variants' build matrix children. Each child
  proceeds only when its exact resolve artifact exists, and each tag requires its own two valid
  architecture digests.
- Kiro downloads are bound to the once-resolved per-architecture ETags with `If-Match`; both
  installed `kiro-cli --version` reports must match before its manifest is created.
- Manual variant input rejects unknown, duplicate, and every empty-field shape, including
  `,kiro`, `kiro,,claude`, and `kiro,`.
- Antigravity and Hermes GitHub API lookups use the authenticated helper.
- Empty SHA args skip verification only for the explicit nightly paths; non-empty release and
  pre-beta defaults still fail on checksum mismatch, and pin-parity validation remains green.
- Workflow YAML/action expressions and embedded shell pass actionlint/shellcheck; Dockerfile
  syntax, package-pin parity, and whitespace validation pass.

### Follow-ups
- Fix the existing `pi` package target and re-add it to nightly (#1520).
- Add broader per-variant runtime smoke tests if the nightly channel needs stronger operational
  guarantees than its current build gate.
- Replace Grok/Antigravity TLS-only nightly downloads with vendor-published digests if suitable
  metadata becomes available.
- Add user-facing image-channel documentation after the channel's first successful production run.
