### PR TITLE
docs: update model selection compatibility

### DIFF
--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -75,3 +75,28 @@ agents:
 
 - **No streaming**: `agy -p` returns the full response at once; the adapter sends it as a single `agent_message_chunk` notification.
 - **Cancel is a no-op**: `agy -p` runs to completion; `session/cancel` acknowledges but cannot interrupt.
+
+## Model Selection
+
+The Discord `/models` dropdown is supported. `agy-acp` returns model
+`configOptions` when a session is created or loaded. It fetches the available
+models from `agy models` and caches a successful result. If the live fetch fails,
+the adapter uses the cache and then falls back to this static list when no cache
+is available:
+
+- Gemini 3.5 Flash (Medium)
+- Gemini 3.5 Flash (High)
+- Gemini 3.5 Flash (Low)
+- Gemini 3.1 Pro (Low)
+- Gemini 3.1 Pro (High)
+
+When a user selects a model with `/models`, OpenAB sends
+`session/set_config_option`. `agy-acp` stores the selected model for that session
+and adds `--model <model_id>` to subsequent `agy` invocations.
+
+To select a default model for every new session, set `default_config_options`:
+
+```toml
+[pool]
+default_config_options = { model = "Gemini 3.5 Flash (Medium)" }
+```

--- a/docs/devin.md
+++ b/docs/devin.md
@@ -105,7 +105,9 @@ default_config_options = { model = "swe-1-6" }
 
 Available model values include: `adaptive`, `swe-1-6`, `swe-1-6-fast`, `claude-opus-4-8-medium`,
 `glm-5-2`, `gpt-5-5-medium`, `kimi-k2-7`, and many more. The full list is reported by the
-agent at session creation and visible via the Discord `/model` slash command.
+agent as ACP `configOptions` at session creation, making it available in the Discord `/models`
+dropdown once a session is active. This behavior is based on ACP client evidence; a live OpenAB
+session capture is still pending.
 
 > **Note:** The `--model` flag and `DEVIN_MODEL` env var are **ignored** in ACP mode.
 > Use `default_config_options` instead.

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -2,6 +2,13 @@
 
 Gemini CLI supports ACP natively via the `--acp` flag — no adapter needed.
 
+> **Migration notice:** Since June 18, 2026, Gemini CLI no longer serves Google AI
+> Pro, Google AI Ultra, or free-tier individual accounts. Google recommends
+> migrating those users to Antigravity CLI. Enterprise users with Gemini Code
+> Assist licenses and API-key authentication remain supported. See Google's
+> [transition announcement](https://github.com/google-gemini/gemini-cli/discussions/27274)
+> and [June 18 update](https://github.com/google-gemini/gemini-cli/discussions/28017).
+
 ## Docker Image
 
 ```bash

--- a/docs/gemini.md
+++ b/docs/gemini.md
@@ -65,7 +65,12 @@ env = { GEMINI_API_KEY = "${GEMINI_API_KEY}" }
 
 ## Authentication
 
-Gemini supports Google OAuth or an API key:
+Gemini CLI authentication depends on the account type:
 
-- **API key**: Set `GEMINI_API_KEY` environment variable
-- **OAuth**: Run Google OAuth flow inside the pod
+- **API key**: Set the `GEMINI_API_KEY` environment variable.
+- **Enterprise or Google Cloud OAuth**: Run the Google OAuth flow inside the pod
+  using an organizational account with supported Gemini Code Assist or Google
+  Cloud access.
+- **Individual OAuth**: Google AI Pro, Google AI Ultra, and free-tier individual
+  accounts are no longer served by Gemini CLI. Migrate these users to
+  Antigravity CLI.

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -114,15 +114,19 @@ The bot will reply in a thread. After that, just type in the thread — no @ment
 
 openab supports `/models`, `/agents`, and `/cancel` on **Discord**, but **not on Slack**. If you previously configured these commands in your Slack app's **Slash Commands** page, you can safely delete them — the Slack adapter ignores both `slash_commands` and `interactive` envelope types.
 
-The root cause is a combination of three Slack-specific platform constraints, none of which is fixable from openab's side:
+The root cause is a combination of two Slack-specific platform constraints, neither of which is fixable from openab's side:
 
 1. **Slack blocks third-party slash commands inside threads.** Invoking `/models` from a thread's reply composer returns the Slack error `"/models is not supported in threads. Sorry!"`. This is enforced by the Slack client itself, not by any app setting — enabling Interactivity, Socket Mode, or reinstalling the app does not bypass it. Slack's built-in commands (`/remind`, `/shrug`, etc.) get special treatment that custom apps cannot.
 
 2. **Channel-level slash command payloads have no thread context.** If the user types `/models` in the channel's main composer instead of a thread, Slack delivers the command but the payload carries no `thread_ts`. Since openab keys each ACP session by thread (`slack:<thread_ts>` or `slack:<trigger_ts>`), the command cannot be routed to the right session. Sessions are never keyed by `channel_id` alone, so there's no workaround on the adapter side.
 
-3. **Most ACP agents don't expose a model-switch surface.** Even when routing succeeded, `/models` reads the session's `configOptions` from the ACP `initialize` response. Only `kiro-cli` emits these in the expected format (via its `models`/`modes` fallback). `claude-code`, `codex`, `gemini`, `cursor-agent`, and `opencode` do not, so the menu would be empty for those backends — the user would see `"⚠️ No model options available"` with no recourse.
+Backend model-selection support also varies; see the current
+[slash-command compatibility table](slash-commands.md#models-and-agents). This
+does not change Slack support: the two routing constraints above prevent the
+menu from reaching the correct session even when a backend emits model
+`configOptions`.
 
-On Discord, none of these apply: slash commands work in thread-channels, the channel ID *is* the thread key, and users typically stay within a single agent per deployment anyway.
+On Discord, neither constraint applies: slash commands work in thread-channels, the channel ID *is* the thread key, and users typically stay within a single agent per deployment anyway.
 
 ### If you need to switch models or agents with a Slack deployment
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -40,7 +40,7 @@ When the user picks an option, OpenAB sends `session/set_config_option` to the A
 | kiro-cli | ✅ Returns available models via `models` fallback | ✅ Returns modes (`kiro_default`, `kiro_planner`) via `modes` fallback |
 | claude-code | ❌ No `configOptions` emitted | ❌ |
 | codex | ❌ | ❌ |
-| gemini (legacy) | ❌ No `configOptions` emitted; individual-account access ended June 18, 2026, while Enterprise and API-key access remain supported | ❌ |
+| gemini | ❌ No `configOptions` emitted; see [Gemini CLI account migration guidance](gemini.md) | ❌ |
 | antigravity | ✅ Returns available models via `configOptions`; `agy-acp` fetches them from `agy models`, with cache and static fallback | ❌ |
 | opencode | ✅ Emits model `configOptions` at session creation in OpenCode 1.17.9 (source-confirmed; live OpenAB session capture pending) | ❌ |
 | devin | ✅ Emits model `configOptions` at session creation (ACP client evidence; live OpenAB session capture pending) | ❌ |

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -40,7 +40,9 @@ When the user picks an option, OpenAB sends `session/set_config_option` to the A
 | kiro-cli | ✅ Returns available models via `models` fallback | ✅ Returns modes (`kiro_default`, `kiro_planner`) via `modes` fallback |
 | claude-code | ❌ No `configOptions` emitted | ❌ |
 | codex | ❌ | ❌ |
-| gemini | ❌ | ❌ |
+| antigravity | ✅ Returns available models via `configOptions`; `agy-acp` fetches them from `agy models`, with cache and static fallback | ❌ |
+| opencode | ✅ Emits model `configOptions` at session creation in OpenCode 1.17.9 (source-confirmed; live OpenAB session capture pending) | ❌ |
+| devin | ✅ Emits model `configOptions` at session creation (ACP client evidence; live OpenAB session capture pending) | ❌ |
 | cursor-agent | ❌ (tracking: #493) | ❌ |
 | copilot | ❌ (tracking: #496) | ❌ |
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -40,6 +40,7 @@ When the user picks an option, OpenAB sends `session/set_config_option` to the A
 | kiro-cli | ✅ Returns available models via `models` fallback | ✅ Returns modes (`kiro_default`, `kiro_planner`) via `modes` fallback |
 | claude-code | ❌ No `configOptions` emitted | ❌ |
 | codex | ❌ | ❌ |
+| gemini (legacy) | ❌ No `configOptions` emitted; individual-account access ended June 18, 2026, while Enterprise and API-key access remain supported | ❌ |
 | antigravity | ✅ Returns available models via `configOptions`; `agy-acp` fetches them from `agy models`, with cache and static fallback | ❌ |
 | opencode | ✅ Emits model `configOptions` at session creation in OpenCode 1.17.9 (source-confirmed; live OpenAB session capture pending) | ❌ |
 | devin | ✅ Emits model `configOptions` at session creation (ACP client evidence; live OpenAB session capture pending) | ❌ |


### PR DESCRIPTION
## What problem does this solve?

The `/models` compatibility table omits supported backends, does not distinguish Gemini CLI from Antigravity, and does not match current ACP model-selection behavior. The Antigravity guide also lacks model-selection instructions, the Devin guide refers to a non-existent `/model` Discord command, and the Slack guide contains a stale OpenCode capability statement.

Discord Discussion URL: https://discord.com/channels/1491295327620169908/1491365157010542652/1544999250000089118

## Review Contract

### Goal

Correct and complete the `/models` compatibility table for Gemini, Antigravity, OpenCode, and Devin; document Antigravity model selection; correct Devin's slash-command reference; centralize Gemini account-migration guidance; and reconcile the Slack guide with current OpenCode behavior.

### Non-goals

- No runtime, Helm, or CI changes.
- No live-session verification of Devin or OpenCode model dropdowns.
- No changes to backend model-selection implementations.
- No removal or runtime deprecation of the Gemini backend.

### Accepted Residual Risks

- The Devin entry is based on external ACP client evidence rather than a live OpenAB session capture.
- The OpenCode entry is based on the pinned v1.17.9 upstream source rather than a live OpenAB session capture.
- Gemini account availability is vendor-controlled and may change; `docs/gemini.md` is the canonical migration source linked from the compatibility table.

### Acceptance Criteria

- [x] `slash-commands.md` includes distinct Gemini, Antigravity, OpenCode, and Devin rows.
- [x] The Gemini row describes model-selection capability and links to the canonical account-migration guidance.
- [x] OpenCode is documented conservatively from pinned v1.17.9 source evidence.
- [x] `antigravity.md` explains `/models`, live model fetching, cache/fallback behavior, and `default_config_options`.
- [x] `devin.md` references `/models` and states the live-verification caveat.
- [x] `slack.md` links to the central compatibility table instead of duplicating backend claims.
- [x] Only documentation files are changed.

### Follow-ups

- Capture live OpenAB sessions for Devin and OpenCode to confirm the source-level behavior end to end.
- Revisit OpenCode `/agents` if OpenAB maps ACP's `mode` category to its `agent` category in the future.

## At a Glance

N/A - docs-only.

## Prior Art & Industry Research

Not applicable - this is a documentation-only correction of existing ACP behavior and vendor account guidance.

**OpenClaw:** Not applicable - no architectural or runtime change.

**Hermes Agent:** Not applicable - no architectural or runtime change.

**Other references (optional):** OpenCode v1.17.9 ACP `service.ts` and `config-option.ts`; OpenAB's `agy-acp` adapter; Gemini CLI maintainer transition announcements.

## Proposed Solution

- Update the support table with distinct Gemini and Antigravity rows plus source-backed OpenCode and cautiously worded Devin entries.
- Keep Gemini account availability and migration details in `docs/gemini.md`, linked from the quick-reference table.
- Add an Antigravity model-selection section describing the full selection flow and fallback list.
- Correct Devin's `/model` reference to `/models` and document the evidence boundary.
- Replace the stale Slack backend inventory with a link to the central compatibility table.

## Why this approach?

It keeps the change docs-only, preserves supported backend identities, and aligns the documentation with the versions and adapter code currently shipped by OpenAB. Explicit caveats distinguish source verification from end-to-end live verification, while links avoid duplicating vendor-policy details across documents.

## Alternatives Considered

- Mark OpenCode unsupported: rejected because pinned OpenCode v1.17.9 emits model `configOptions` and handles model configuration changes.
- Wait for live captures before updating any docs: rejected because Antigravity is verified locally and the remaining source evidence can be documented accurately with caveats.
- Mark the entire Gemini backend as legacy: rejected because Enterprise/Google Cloud and API-key access remain supported and OpenAB still ships the backend.

## Validation

- [x] All four Markdown links introduced by the final diff were validated: two Gemini maintainer discussions and two internal documentation links.
- [x] Tables, headings, lists, and code fences were manually inspected for GitHub rendering.
- [x] `git diff --check` passes.
- [x] Manual testing - compared each statement with `agy-acp` source, OpenAB config-option parsing, pinned OpenCode v1.17.9 upstream ACP source, the existing Devin guide, and Gemini CLI maintainer announcements.
